### PR TITLE
feat: Sleeper transactions, NFL state, and player data

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ function pair per table.
 - `src/ffb/nfl_data.py` — nflverse data via `nfl_data_py`: weekly stats, schedules, rosters, snap
   counts, injuries, seasonal data, depth charts, player bios, Next Gen Stats, FTN charting data,
   and a cross-platform player ID crosswalk.
+- `src/ffb/sleeper.py` — Sleeper's public league API (no auth required): league settings, rosters,
+  users, and weekly matchups (including starting lineups). Set `LEAGUE_ID` in the module before
+  running.
 
 ## Environment
 

--- a/src/ffb/sleeper.py
+++ b/src/ffb/sleeper.py
@@ -1,6 +1,7 @@
 """Fetch and load Sleeper league data into the DuckDB warehouse."""
 
 import json
+import time
 from pathlib import Path
 
 import duckdb
@@ -12,7 +13,7 @@ WAREHOUSE_PATH = Path("data/warehouse.duckdb")
 BASE_URL = "https://api.sleeper.app/v1"
 
 # TODO: set this to your league's ID (the numeric ID in the league's Sleeper URL).
-LEAGUE_ID = "REPLACE_WITH_YOUR_LEAGUE_ID"
+LEAGUE_ID = "1390836961870090240"
 
 # Regular season + playoffs; trim if your league's schedule is shorter.
 WEEKS = list(range(1, 19))
@@ -39,7 +40,10 @@ def _load_json_to_table(raw_path: Path, table_name: str) -> None:
 
     WAREHOUSE_PATH.parent.mkdir(parents=True, exist_ok=True)
     con = duckdb.connect(str(WAREHOUSE_PATH))
-    con.execute(f"CREATE OR REPLACE TABLE {table_name} AS SELECT * FROM df")
+    if df.empty and len(df.columns) == 0:
+        con.execute(f"DROP TABLE IF EXISTS {table_name}")
+    else:
+        con.execute(f"CREATE OR REPLACE TABLE {table_name} AS SELECT * FROM df")
     con.close()
 
     print(f"Loaded {raw_path} into {WAREHOUSE_PATH} (table: {table_name})")
@@ -90,8 +94,69 @@ def load_matchups(raw_path: Path) -> None:
     _load_json_to_table(raw_path, "sleeper_matchups")
 
 
+def fetch_transactions(league_id: str, weeks: list[int]) -> Path:
+    """Fetch weekly transactions (waivers, free agent moves, trades) and save raw to JSON."""
+    rows = []
+    for week in weeks:
+        week_rows = _get(f"/league/{league_id}/transactions/{week}")
+        for row in week_rows:
+            row["week"] = week
+        rows.extend(week_rows)
+    return _save_raw_json(rows, f"transactions_{league_id}")
+
+
+def load_transactions(raw_path: Path) -> None:
+    _load_json_to_table(raw_path, "sleeper_transactions")
+
+
+def fetch_nfl_state() -> Path:
+    """Fetch the current NFL season/week state and save raw to JSON."""
+    data = _get("/state/nfl")
+    return _save_raw_json([data], "state_nfl")
+
+
+def load_nfl_state(raw_path: Path) -> None:
+    _load_json_to_table(raw_path, "sleeper_nfl_state")
+
+
+PLAYERS_MAX_AGE_SECONDS = 24 * 60 * 60
+
+
+def fetch_players(sport: str = "nfl") -> Path:
+    """Fetch the full player dictionary and save raw to JSON.
+
+    Sleeper asks that this endpoint be called at most once per day, so if the
+    raw file already exists and is less than a day old, the cached copy is
+    reused instead of hitting the network again.
+    """
+    raw_path = RAW_DIR / f"players_{sport}.json"
+    if raw_path.exists():
+        age_seconds = time.time() - raw_path.stat().st_mtime
+        if age_seconds < PLAYERS_MAX_AGE_SECONDS:
+            print(f"Skipped fetch: {raw_path} is {age_seconds / 3600:.1f}h old (< 24h)")
+            return raw_path
+
+    data = _get(f"/players/{sport}")
+    return _save_raw_json(data, f"players_{sport}")
+
+
+def load_players(raw_path: Path) -> None:
+    data = json.loads(raw_path.read_text())
+    df = pd.json_normalize(list(data.values()))
+
+    WAREHOUSE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    con = duckdb.connect(str(WAREHOUSE_PATH))
+    con.execute("CREATE OR REPLACE TABLE sleeper_players AS SELECT * FROM df")
+    con.close()
+
+    print(f"Loaded {raw_path} into {WAREHOUSE_PATH} (table: sleeper_players)")
+
+
 if __name__ == "__main__":
     load_league(fetch_league(LEAGUE_ID))
     load_rosters(fetch_rosters(LEAGUE_ID))
     load_users(fetch_users(LEAGUE_ID))
     load_matchups(fetch_matchups(LEAGUE_ID, WEEKS))
+    load_transactions(fetch_transactions(LEAGUE_ID, WEEKS))
+    load_nfl_state(fetch_nfl_state())
+    load_players(fetch_players())

--- a/src/ffb/sleeper.py
+++ b/src/ffb/sleeper.py
@@ -1,0 +1,97 @@
+"""Fetch and load Sleeper league data into the DuckDB warehouse."""
+
+import json
+from pathlib import Path
+
+import duckdb
+import pandas as pd
+import requests
+
+RAW_DIR = Path("data/raw/sleeper")
+WAREHOUSE_PATH = Path("data/warehouse.duckdb")
+BASE_URL = "https://api.sleeper.app/v1"
+
+# TODO: set this to your league's ID (the numeric ID in the league's Sleeper URL).
+LEAGUE_ID = "REPLACE_WITH_YOUR_LEAGUE_ID"
+
+# Regular season + playoffs; trim if your league's schedule is shorter.
+WEEKS = list(range(1, 19))
+
+
+def _get(path: str):
+    response = requests.get(f"{BASE_URL}{path}")
+    response.raise_for_status()
+    return response.json()
+
+
+def _save_raw_json(data, filename_stem: str) -> Path:
+    RAW_DIR.mkdir(parents=True, exist_ok=True)
+    raw_path = RAW_DIR / f"{filename_stem}.json"
+    raw_path.write_text(json.dumps(data))
+    print(f"Saved {raw_path}")
+    return raw_path
+
+
+def _load_json_to_table(raw_path: Path, table_name: str) -> None:
+    """Load a raw JSON file into a DuckDB table (idempotent)."""
+    data = json.loads(raw_path.read_text())
+    df = pd.json_normalize(data)
+
+    WAREHOUSE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    con = duckdb.connect(str(WAREHOUSE_PATH))
+    con.execute(f"CREATE OR REPLACE TABLE {table_name} AS SELECT * FROM df")
+    con.close()
+
+    print(f"Loaded {raw_path} into {WAREHOUSE_PATH} (table: {table_name})")
+
+
+def fetch_league(league_id: str) -> Path:
+    """Fetch league settings/metadata and save raw to JSON."""
+    data = _get(f"/league/{league_id}")
+    return _save_raw_json([data], f"league_{league_id}")
+
+
+def load_league(raw_path: Path) -> None:
+    _load_json_to_table(raw_path, "sleeper_league")
+
+
+def fetch_rosters(league_id: str) -> Path:
+    """Fetch team rosters (owned players, roster settings) and save raw to JSON."""
+    data = _get(f"/league/{league_id}/rosters")
+    return _save_raw_json(data, f"rosters_{league_id}")
+
+
+def load_rosters(raw_path: Path) -> None:
+    _load_json_to_table(raw_path, "sleeper_rosters")
+
+
+def fetch_users(league_id: str) -> Path:
+    """Fetch league members (owners) and save raw to JSON."""
+    data = _get(f"/league/{league_id}/users")
+    return _save_raw_json(data, f"users_{league_id}")
+
+
+def load_users(raw_path: Path) -> None:
+    _load_json_to_table(raw_path, "sleeper_users")
+
+
+def fetch_matchups(league_id: str, weeks: list[int]) -> Path:
+    """Fetch weekly matchups (starters, points, roster_id) and save raw to JSON."""
+    rows = []
+    for week in weeks:
+        week_rows = _get(f"/league/{league_id}/matchups/{week}")
+        for row in week_rows:
+            row["week"] = week
+        rows.extend(week_rows)
+    return _save_raw_json(rows, f"matchups_{league_id}")
+
+
+def load_matchups(raw_path: Path) -> None:
+    _load_json_to_table(raw_path, "sleeper_matchups")
+
+
+if __name__ == "__main__":
+    load_league(fetch_league(LEAGUE_ID))
+    load_rosters(fetch_rosters(LEAGUE_ID))
+    load_users(fetch_users(LEAGUE_ID))
+    load_matchups(fetch_matchups(LEAGUE_ID, WEEKS))


### PR DESCRIPTION
## Summary
- Set the real Sleeper `LEAGUE_ID` (previously a placeholder)
- Add `fetch_transactions`/`load_transactions` (waivers, free agent moves, trades per week)
- Add `fetch_nfl_state`/`load_nfl_state` (current season/week)
- Add `fetch_players`/`load_players` (full player dictionary), capped to one network call per 24h per Sleeper's rate-limit guidance
- Fix `_load_json_to_table` crashing when a raw payload is empty (e.g. off-season matchups/transactions return `[]`)

## Test plan
- [x] Ran `python -m src.ffb.sleeper` end to end with the real league ID
- [x] Verified row counts: `sleeper_league` 1, `sleeper_rosters` 12, `sleeper_users` 8, `sleeper_players` 12218
- [x] Confirmed off-season `sleeper_matchups`/`sleeper_transactions` are dropped instead of erroring
- [x] Confirmed `sleeper_nfl_state` reflects preseason week 1, 2026
- [x] Ran `fetch_players()` twice in a row and confirmed the second call is skipped (cache < 24h)