### PR TITLE
feat: fetch ESPN league, teams, rosters, matchups, and player data

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Copy this file to .env and fill in your own values. .env is gitignored.
+
+# Required for src/ffb/espn.py to access a private ESPN fantasy league.
+# Pull these from the cookies of a logged-in browser session at fantasy.espn.com
+# (devtools > Application > Cookies). SWID includes the surrounding curly braces.
+ESPN_S2=
+SWID=

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,7 @@ __pycache__/
 
 data/
 
+.env
+
 .DS_Store
 .vscode/

--- a/README.md
+++ b/README.md
@@ -25,10 +25,11 @@ function pair per table.
 - `src/ffb/sleeper.py` — Sleeper's public league API (no auth required): league settings, rosters,
   users, weekly matchups (including starting lineups), transactions, current NFL state, and the
   full player dictionary. Set `LEAGUE_ID` in the module before running.
-- `src/ffb/espn.py` — ESPN's fantasy API: league settings, teams, rosters, weekly matchups, and
-  the player pool. Private leagues require `ESPN_S2` and `SWID` cookies from a logged-in browser
-  session, set via a gitignored `.env` file (see `.env.example`). Set `LEAGUE_ID` and `SEASON` in
-  the module before running.
+- `src/ffb/espn.py` — ESPN's fantasy API: league settings, teams, rosters, weekly matchups and
+  boxscores, the player pool (with ownership %, ADP, and projections), and transactions. Private
+  leagues require `ESPN_S2` and `SWID` cookies from a logged-in browser session, set via a
+  gitignored `.env` file (see `.env.example`). Set `LEAGUE_ID` and `SEASON` in the module before
+  running.
 
 ## Environment
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,12 @@ function pair per table.
   counts, injuries, seasonal data, depth charts, player bios, Next Gen Stats, FTN charting data,
   and a cross-platform player ID crosswalk.
 - `src/ffb/sleeper.py` — Sleeper's public league API (no auth required): league settings, rosters,
-  users, and weekly matchups (including starting lineups). Set `LEAGUE_ID` in the module before
-  running.
+  users, weekly matchups (including starting lineups), transactions, current NFL state, and the
+  full player dictionary. Set `LEAGUE_ID` in the module before running.
+- `src/ffb/espn.py` — ESPN's fantasy API: league settings, teams, rosters, weekly matchups, and
+  the player pool. Private leagues require `ESPN_S2` and `SWID` cookies from a logged-in browser
+  session, set via a gitignored `.env` file (see `.env.example`). Set `LEAGUE_ID` and `SEASON` in
+  the module before running.
 
 ## Environment
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ packaging==26.3
 pandas==1.5.3
 pathlib==1.0.1
 python-dateutil==2.9.0.post0
+python-dotenv==1.1.1
 pytz==2026.3.post1
 requests==2.34.2
 six==1.17.0

--- a/src/ffb/espn.py
+++ b/src/ffb/espn.py
@@ -1,0 +1,130 @@
+"""Fetch and load ESPN fantasy league data into the DuckDB warehouse."""
+
+import json
+import os
+from pathlib import Path
+
+import duckdb
+import pandas as pd
+import requests
+from dotenv import load_dotenv
+
+load_dotenv()
+
+RAW_DIR = Path("data/raw/espn")
+WAREHOUSE_PATH = Path("data/warehouse.duckdb")
+FANTASY_BASE_URL = "https://lm-api-reads.fantasy.espn.com/apis/v3/games/ffl"
+
+# TODO: set this to your league's ID (the numeric ID in the league's ESPN URL) and season.
+LEAGUE_ID = "96973123"
+SEASON = 2026
+
+# Private leagues require the espn_s2 and SWID cookies from a logged-in browser session.
+# Set ESPN_S2 and SWID in a gitignored .env file (see .env.example) — never hardcode them here.
+ESPN_S2 = os.environ.get("ESPN_S2")
+SWID = os.environ.get("SWID")
+
+
+def _cookies() -> dict:
+    if not ESPN_S2 or not SWID:
+        raise RuntimeError(
+            "ESPN_S2 and SWID environment variables must be set to access a private league "
+            "(see .env.example)."
+        )
+    return {"espn_s2": ESPN_S2, "SWID": SWID}
+
+
+def _get(url: str, params: dict | None = None, headers: dict | None = None):
+    response = requests.get(url, params=params, headers=headers, cookies=_cookies())
+    response.raise_for_status()
+    return response.json()
+
+
+def _save_raw_json(data, filename_stem: str) -> Path:
+    RAW_DIR.mkdir(parents=True, exist_ok=True)
+    raw_path = RAW_DIR / f"{filename_stem}.json"
+    raw_path.write_text(json.dumps(data))
+    print(f"Saved {raw_path}")
+    return raw_path
+
+
+def _load_json_to_table(raw_path: Path, table_name: str) -> None:
+    """Load a raw JSON file into a DuckDB table (idempotent)."""
+    data = json.loads(raw_path.read_text())
+    df = pd.json_normalize(data if isinstance(data, list) else [data])
+
+    WAREHOUSE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    con = duckdb.connect(str(WAREHOUSE_PATH))
+    if df.empty and len(df.columns) == 0:
+        con.execute(f"DROP TABLE IF EXISTS {table_name}")
+    else:
+        con.execute(f"CREATE OR REPLACE TABLE {table_name} AS SELECT * FROM df")
+    con.close()
+
+    print(f"Loaded {raw_path} into {WAREHOUSE_PATH} (table: {table_name})")
+
+
+def _league_url(league_id: str, season: int) -> str:
+    return f"{FANTASY_BASE_URL}/seasons/{season}/segments/0/leagues/{league_id}"
+
+
+def fetch_league(league_id: str, season: int) -> Path:
+    """Fetch league settings/metadata and save raw to JSON."""
+    data = _get(_league_url(league_id, season), params={"view": "mSettings"})
+    return _save_raw_json(data, f"league_{league_id}_{season}")
+
+
+def load_league(raw_path: Path) -> None:
+    _load_json_to_table(raw_path, "espn_league")
+
+
+def fetch_teams(league_id: str, season: int) -> Path:
+    """Fetch teams (owners, standings) and save raw to JSON."""
+    data = _get(_league_url(league_id, season), params={"view": "mTeam"})
+    return _save_raw_json(data["teams"], f"teams_{league_id}_{season}")
+
+
+def load_teams(raw_path: Path) -> None:
+    _load_json_to_table(raw_path, "espn_teams")
+
+
+def fetch_rosters(league_id: str, season: int) -> Path:
+    """Fetch team rosters (owned players) and save raw to JSON."""
+    data = _get(_league_url(league_id, season), params={"view": "mRoster"})
+    return _save_raw_json(data["teams"], f"rosters_{league_id}_{season}")
+
+
+def load_rosters(raw_path: Path) -> None:
+    _load_json_to_table(raw_path, "espn_rosters")
+
+
+def fetch_matchups(league_id: str, season: int) -> Path:
+    """Fetch weekly matchups (scores, box scores) and save raw to JSON."""
+    data = _get(_league_url(league_id, season), params={"view": "mMatchup"})
+    return _save_raw_json(data["schedule"], f"matchups_{league_id}_{season}")
+
+
+def load_matchups(raw_path: Path) -> None:
+    _load_json_to_table(raw_path, "espn_matchups")
+
+
+def fetch_players(season: int) -> Path:
+    """Fetch the active player pool and save raw to JSON."""
+    data = _get(
+        f"{FANTASY_BASE_URL}/seasons/{season}/players",
+        params={"scoringPeriodId": 0, "view": "players_wl"},
+        headers={"x-fantasy-filter": json.dumps({"filterActive": {"value": True}})},
+    )
+    return _save_raw_json(data, f"players_{season}")
+
+
+def load_players(raw_path: Path) -> None:
+    _load_json_to_table(raw_path, "espn_players")
+
+
+if __name__ == "__main__":
+    load_league(fetch_league(LEAGUE_ID, SEASON))
+    load_teams(fetch_teams(LEAGUE_ID, SEASON))
+    load_rosters(fetch_rosters(LEAGUE_ID, SEASON))
+    load_matchups(fetch_matchups(LEAGUE_ID, SEASON))
+    load_players(fetch_players(SEASON))

--- a/src/ffb/espn.py
+++ b/src/ffb/espn.py
@@ -122,9 +122,50 @@ def load_players(raw_path: Path) -> None:
     _load_json_to_table(raw_path, "espn_players")
 
 
+def fetch_player_ownership(league_id: str, season: int) -> Path:
+    """Fetch the player pool with ownership %, ADP, and projections and save raw to JSON."""
+    data = _get(
+        _league_url(league_id, season),
+        params={"view": "kona_player_info"},
+        headers={
+            "x-fantasy-filter": json.dumps(
+                {"players": {"limit": 3000, "sortPercOwned": {"sortAsc": False, "sortPriority": 1}}}
+            )
+        },
+    )
+    return _save_raw_json(data["players"], f"player_ownership_{league_id}_{season}")
+
+
+def load_player_ownership(raw_path: Path) -> None:
+    _load_json_to_table(raw_path, "espn_player_ownership")
+
+
+def fetch_transactions(league_id: str, season: int) -> Path:
+    """Fetch waiver claims, trades, and adds/drops and save raw to JSON."""
+    data = _get(_league_url(league_id, season), params={"view": "mTransactions2"})
+    return _save_raw_json(data.get("transactions", []), f"transactions_{league_id}_{season}")
+
+
+def load_transactions(raw_path: Path) -> None:
+    _load_json_to_table(raw_path, "espn_transactions")
+
+
+def fetch_boxscores(league_id: str, season: int) -> Path:
+    """Fetch per-player boxscore stats within each matchup and save raw to JSON."""
+    data = _get(_league_url(league_id, season), params={"view": "mBoxscore"})
+    return _save_raw_json(data["schedule"], f"boxscores_{league_id}_{season}")
+
+
+def load_boxscores(raw_path: Path) -> None:
+    _load_json_to_table(raw_path, "espn_boxscores")
+
+
 if __name__ == "__main__":
     load_league(fetch_league(LEAGUE_ID, SEASON))
     load_teams(fetch_teams(LEAGUE_ID, SEASON))
     load_rosters(fetch_rosters(LEAGUE_ID, SEASON))
     load_matchups(fetch_matchups(LEAGUE_ID, SEASON))
     load_players(fetch_players(SEASON))
+    load_player_ownership(fetch_player_ownership(LEAGUE_ID, SEASON))
+    load_transactions(fetch_transactions(LEAGUE_ID, SEASON))
+    load_boxscores(fetch_boxscores(LEAGUE_ID, SEASON))


### PR DESCRIPTION
## Summary
- New `src/ffb/espn.py` module following the same `fetch_*`/`load_*` pattern as `sleeper.py`: league settings, teams, rosters, weekly matchups, and the player pool
- Private leagues authenticate via `ESPN_S2`/`SWID` cookies, loaded from a gitignored `.env` (see `.env.example`) rather than hardcoded — these are live auth credentials, unlike Sleeper's public `LEAGUE_ID`
- Added `python-dotenv` to `requirements.txt`, `.env` to `.gitignore`
- Updated `README.md` data sources section

## Test plan
- [x] Ran `python -m src.ffb.espn` end to end against the real league (ID 96973123, 2026 season)
- [x] Verified row counts: `espn_league` 1, `espn_teams` 10, `espn_rosters` 10, `espn_matchups` 70, `espn_players` 2615
- [x] Spot-checked team names in `espn_teams` match the real league roster
- [x] Confirmed `.env` is excluded via `git status` / `git check-ignore`