### PR TITLE
feat: fetch FantasyPros consensus draft and weekly rankings

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ function pair per table.
   leagues require `ESPN_S2` and `SWID` cookies from a logged-in browser session, set via a
   gitignored `.env` file (see `.env.example`). Set `LEAGUE_ID` and `SEASON` in the module before
   running.
+- `src/ffb/fantasypros.py` — FantasyPros consensus expert rankings (ECR): preseason overall draft
+  rankings (standard/half-PPR/PPR) and in-season weekly rankings by position. No auth required;
+  extracts the `ecrData` JSON embedded in FantasyPros' rankings pages, since they don't offer a
+  free public API. Set `current_week` in the module before running in-season.
 
 ## Environment
 

--- a/src/ffb/fantasypros.py
+++ b/src/ffb/fantasypros.py
@@ -1,0 +1,94 @@
+"""Fetch and load FantasyPros consensus expert rankings (ECR) into the DuckDB warehouse.
+
+FantasyPros doesn't offer a free public API, but its rankings pages embed the full ranking
+dataset as a `var ecrData = {...}` JSON blob in the page HTML. We extract that JSON and save it
+as the raw archive, same as the partial-extraction approach used in espn.py (e.g. saving just
+`data["teams"]` rather than the full API envelope).
+"""
+
+import json
+import re
+from pathlib import Path
+
+import duckdb
+import pandas as pd
+import requests
+
+RAW_DIR = Path("data/raw/fantasypros")
+WAREHOUSE_PATH = Path("data/warehouse.duckdb")
+BASE_URL = "https://www.fantasypros.com/nfl/rankings"
+HEADERS = {"User-Agent": "Mozilla/5.0"}
+
+# Preseason draft rankings, one per scoring format.
+DRAFT_SCORING_FORMATS = {
+    "standard": "consensus-cheatsheets",
+    "half-ppr": "half-point-ppr-cheatsheets",
+    "ppr": "ppr-cheatsheets",
+}
+
+# In-season weekly rankings, one per position.
+WEEKLY_POSITIONS = ["qb", "rb", "wr", "te", "flex", "k", "dst"]
+
+_ECR_DATA_RE = re.compile(r"var ecrData = (\{.*?\});", re.S)
+
+
+def _get_players(url: str, params: dict | None = None) -> list[dict]:
+    """Fetch a FantasyPros rankings page and extract its embedded player list."""
+    response = requests.get(url, params=params, headers=HEADERS)
+    response.raise_for_status()
+    match = _ECR_DATA_RE.search(response.text)
+    if not match:
+        raise ValueError(f"Could not find ecrData on {response.url}")
+    return json.loads(match.group(1))["players"]
+
+
+def _save_raw_json(players: list[dict], filename_stem: str) -> Path:
+    RAW_DIR.mkdir(parents=True, exist_ok=True)
+    raw_path = RAW_DIR / f"{filename_stem}.json"
+    raw_path.write_text(json.dumps(players))
+    print(f"Saved {len(players)} rows to {raw_path}")
+    return raw_path
+
+
+def _load_json_to_table(raw_path: Path, table_name: str) -> None:
+    """Load a raw JSON file into a DuckDB table (idempotent)."""
+    players = json.loads(raw_path.read_text())
+    df = pd.json_normalize(players)
+
+    WAREHOUSE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    con = duckdb.connect(str(WAREHOUSE_PATH))
+    con.execute(f"CREATE OR REPLACE TABLE {table_name} AS SELECT * FROM df")
+    con.close()
+
+    print(f"Loaded {raw_path} into {WAREHOUSE_PATH} (table: {table_name})")
+
+
+def fetch_draft_rankings(scoring: str) -> Path:
+    """Fetch preseason overall consensus rankings for a scoring format and save raw to JSON."""
+    slug = DRAFT_SCORING_FORMATS[scoring]
+    players = _get_players(f"{BASE_URL}/{slug}.php")
+    return _save_raw_json(players, f"draft_{scoring}")
+
+
+def load_draft_rankings(raw_path: Path, scoring: str) -> None:
+    _load_json_to_table(raw_path, f"fantasypros_draft_rankings_{scoring.replace('-', '_')}")
+
+
+def fetch_weekly_rankings(position: str, week: int) -> Path:
+    """Fetch weekly consensus rankings for a position/week and save raw to JSON."""
+    players = _get_players(f"{BASE_URL}/{position}.php", params={"week": week})
+    return _save_raw_json(players, f"weekly_{position}_{week}")
+
+
+def load_weekly_rankings(raw_path: Path, position: str) -> None:
+    _load_json_to_table(raw_path, f"fantasypros_weekly_rankings_{position}")
+
+
+if __name__ == "__main__":
+    current_week = 1
+
+    for scoring_format in DRAFT_SCORING_FORMATS:
+        load_draft_rankings(fetch_draft_rankings(scoring_format), scoring_format)
+
+    for position in WEEKLY_POSITIONS:
+        load_weekly_rankings(fetch_weekly_rankings(position, current_week), position)


### PR DESCRIPTION
## Summary
- Adds `src/ffb/fantasypros.py`: fetches FantasyPros consensus expert rankings (ECR) by extracting the embedded `ecrData` JSON from rankings pages (no public API available)
- Preseason draft rankings for standard/half-PPR/PPR scoring, plus in-season weekly rankings by position (QB/RB/WR/TE/FLEX/K/DST)
- Follows the established `fetch_*`/`load_*` pattern, raw JSON archived to `data/raw/fantasypros/`, loaded into DuckDB tables in `data/warehouse.duckdb`

## Test plan
- [x] Built `.venv` (Python 3.11) and installed pinned deps
- [x] Ran `python -m src.ffb.fantasypros` end to end against the live site
- [x] Verified all 10 tables loaded with expected row counts (e.g. 490 rows for PPR draft rankings)
- [x] Spot-checked sample rows (player name/team/position/rank) for sanity

🤖 Generated with [Claude Code](https://claude.com/claude-code)