### PR TITLE
feat: add consensus engine for median/floor/ceiling projections

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,15 +35,22 @@ function pair per table.
   extracts the `ecrData` JSON embedded in FantasyPros' rankings pages, since they don't offer a
   free public API. Set `current_week` in the module before running in-season.
 - `src/ffb/fftoday.py` — FFToday's own season-long fantasy point projections (standard/half-PPR/
-  PPR) by position. No auth required; parses the plain HTML projections table, since FFToday
-  doesn't offer an API. Rate-limits aggressive scraping, so requests are spaced out.
+  PPR) by position, including DST. No auth required; parses the plain HTML projections table,
+  since FFToday doesn't offer an API. Rate-limits aggressive scraping, so requests are spaced out.
 - `src/ffb/cbs.py` — CBS Sports' own season-long fantasy point projections (standard/PPR) by
-  position. No auth required; parses the plain HTML projections table, since CBS doesn't offer a
-  free API.
-- `src/ffb/consensus.py` — builds `consensus_projections`: a median/floor (20th percentile)/
-  ceiling (80th percentile) PPR projection per player, aggregated across every independent
-  projection source above (ESPN, Sleeper/RotoWire, FFToday, CBS) via the nflverse player ID
-  crosswalk. Pure SQL over already-loaded tables — no fetch step, no network.
+  position, including DST. No auth required; parses the plain HTML projections table, since CBS
+  doesn't offer a free API.
+- `src/ffb/teams.py` — shared NFL team-abbreviation normalizer, not a data source itself. Each
+  projection site represents team defenses differently (a full name, a bare nickname, or a
+  non-canonical abbreviation like "LAR"); this maps any of those to the abbreviation nflverse
+  uses elsewhere in this warehouse (e.g. "LA" for the Rams), so DST rows can be joined by team.
+- `src/ffb/consensus.py` — builds two tables: `consensus_projections` (skill positions QB/RB/
+  WR/TE/K, joined via the nflverse player ID crosswalk onto `gsis_id`) and
+  `consensus_dst_projections` (team defenses, joined by normalized team abbreviation instead,
+  since defenses aren't in the player crosswalk). Each is a median/floor (20th percentile)/
+  ceiling (80th percentile) PPR projection per player or team, aggregated across every
+  independent projection source above (ESPN, Sleeper/RotoWire, FFToday, CBS). Pure SQL over
+  already-loaded tables — no fetch step, no network.
 
 ## Environment
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ function pair per table.
   rankings (standard/half-PPR/PPR) and in-season weekly rankings by position. No auth required;
   extracts the `ecrData` JSON embedded in FantasyPros' rankings pages, since they don't offer a
   free public API. Set `current_week` in the module before running in-season.
+- `src/ffb/fftoday.py` — FFToday's own season-long fantasy point projections (standard/half-PPR/
+  PPR) by position. No auth required; parses the plain HTML projections table, since FFToday
+  doesn't offer an API. Rate-limits aggressive scraping, so requests are spaced out.
+- `src/ffb/cbs.py` — CBS Sports' own season-long fantasy point projections (standard/PPR) by
+  position. No auth required; parses the plain HTML projections table, since CBS doesn't offer a
+  free API.
+- `src/ffb/consensus.py` — builds `consensus_projections`: a median/floor (20th percentile)/
+  ceiling (80th percentile) PPR projection per player, aggregated across every independent
+  projection source above (ESPN, Sleeper/RotoWire, FFToday, CBS) via the nflverse player ID
+  crosswalk. Pure SQL over already-loaded tables — no fetch step, no network.
 
 ## Environment
 

--- a/scripts/build_warehouse.sh
+++ b/scripts/build_warehouse.sh
@@ -12,3 +12,9 @@ python -m src.ffb.nfl_data
 python -m src.ffb.sleeper
 python -m src.ffb.espn
 python -m src.ffb.fantasypros
+python -m src.ffb.fftoday
+python -m src.ffb.cbs
+
+# Depends on every source above already being loaded (joins their projections through the
+# nflverse `ids` crosswalk from nfl_data.py).
+python -m src.ffb.consensus

--- a/src/ffb/cbs.py
+++ b/src/ffb/cbs.py
@@ -14,18 +14,19 @@ import pandas as pd
 import requests
 from bs4 import BeautifulSoup
 
+from src.ffb.teams import normalize_team
+
 RAW_DIR = Path("data/raw/cbs")
 WAREHOUSE_PATH = Path("data/warehouse.duckdb")
 BASE_URL = "https://www.cbssports.com/fantasy/football/stats"
 HEADERS = {"User-Agent": "Mozilla/5.0"}
 
-# CBS's positions and URL scoring-format slugs. There's no half-PPR variant (that slug 404s);
-# DST is fetched for completeness even though it's excluded from the cross-source join later
-# (no entry in the nflverse player ID crosswalk, since it's a team, not a player).
+# CBS's positions and URL scoring-format slugs. There's no half-PPR variant (that slug 404s).
 POSITIONS = ["QB", "RB", "WR", "TE", "K", "DST"]
 SCORING_FORMATS = {"standard": "nonppr", "ppr": "ppr"}
 
 _CBS_ID_RE = re.compile(r"/nfl/players/(\d+)/")
+_TEAM_ABBR_RE = re.compile(r"/nfl/teams/([A-Z]+)/")
 
 
 def fetch_season_projections(position: str, scoring: str, season: int) -> Path:
@@ -46,12 +47,6 @@ def _parse_table(html: str) -> pd.DataFrame:
     records = []
     for row in soup.find_all("tr", class_="TableBase-bodyTr"):
         name_cell = row.find("td")
-        long_name = name_cell.find("span", class_="CellPlayerName--long")
-        anchor = long_name.find("a") if long_name else name_cell.find("a")
-        if not anchor:
-            continue
-        match = _CBS_ID_RE.search(anchor.get("href", ""))
-        team_span = name_cell.find("span", class_="CellPlayerName-team")
 
         number_cells = row.find_all("td", class_=lambda c: c and "TableBase-bodyTd--number" in c)
         if len(number_cells) < 2:
@@ -62,15 +57,41 @@ def _parse_table(html: str) -> pd.DataFrame:
         except ValueError:
             continue
 
-        records.append(
-            {
-                "cbs_id": int(match.group(1)) if match else None,
-                "player_name": anchor.get_text(strip=True),
-                "team": team_span.get_text(strip=True) if team_span else None,
-                "projected_points": fpts,
-                "fppg": fppg,
-            }
-        )
+        long_name = name_cell.find("span", class_="CellPlayerName--long")
+        if long_name:
+            # Individual player row.
+            anchor = long_name.find("a")
+            if not anchor:
+                continue
+            match = _CBS_ID_RE.search(anchor.get("href", ""))
+            team_span = name_cell.find("span", class_="CellPlayerName-team")
+            records.append(
+                {
+                    "cbs_id": int(match.group(1)) if match else None,
+                    "player_name": anchor.get_text(strip=True),
+                    "team": team_span.get_text(strip=True) if team_span else None,
+                    "projected_points": fpts,
+                    "fppg": fppg,
+                }
+            )
+        else:
+            # Team defense row: a team logo/name lockup instead of a player name. The logo's
+            # own <a> (matched first by a bare href search) has no text, so target the visible
+            # team-name span specifically.
+            team_span = name_cell.find("span", class_="TeamName")
+            anchor = team_span.find("a") if team_span else None
+            match = _TEAM_ABBR_RE.search(anchor.get("href", "")) if anchor else None
+            if not match:
+                continue
+            records.append(
+                {
+                    "cbs_id": None,
+                    "player_name": anchor.get_text(strip=True),
+                    "team": normalize_team(match.group(1)),
+                    "projected_points": fpts,
+                    "fppg": fppg,
+                }
+            )
     return pd.DataFrame(records)
 
 

--- a/src/ffb/cbs.py
+++ b/src/ffb/cbs.py
@@ -1,0 +1,108 @@
+"""Fetch and load CBS Sports' own season-long fantasy point projections into the DuckDB
+warehouse.
+
+CBS doesn't offer an API; each position/scoring-format's projections page is a single
+unauthenticated HTML table, which we parse directly with BeautifulSoup (the same
+partial-extraction approach used elsewhere in this project for sites without a real API).
+"""
+
+import re
+from pathlib import Path
+
+import duckdb
+import pandas as pd
+import requests
+from bs4 import BeautifulSoup
+
+RAW_DIR = Path("data/raw/cbs")
+WAREHOUSE_PATH = Path("data/warehouse.duckdb")
+BASE_URL = "https://www.cbssports.com/fantasy/football/stats"
+HEADERS = {"User-Agent": "Mozilla/5.0"}
+
+# CBS's positions and URL scoring-format slugs. There's no half-PPR variant (that slug 404s);
+# DST is fetched for completeness even though it's excluded from the cross-source join later
+# (no entry in the nflverse player ID crosswalk, since it's a team, not a player).
+POSITIONS = ["QB", "RB", "WR", "TE", "K", "DST"]
+SCORING_FORMATS = {"standard": "nonppr", "ppr": "ppr"}
+
+_CBS_ID_RE = re.compile(r"/nfl/players/(\d+)/")
+
+
+def fetch_season_projections(position: str, scoring: str, season: int) -> Path:
+    """Fetch one position/scoring format's season-long projections and save raw HTML."""
+    url = f"{BASE_URL}/{position}/{season}/season/projections/{SCORING_FORMATS[scoring]}/"
+    response = requests.get(url, headers=HEADERS)
+    response.raise_for_status()
+    RAW_DIR.mkdir(parents=True, exist_ok=True)
+    raw_path = RAW_DIR / f"proj_{position.lower()}_{scoring}_{season}.html"
+    raw_path.write_text(response.text)
+    print(f"Saved {raw_path}")
+    return raw_path
+
+
+def _parse_table(html: str) -> pd.DataFrame:
+    soup = BeautifulSoup(html, "html.parser")
+
+    records = []
+    for row in soup.find_all("tr", class_="TableBase-bodyTr"):
+        name_cell = row.find("td")
+        long_name = name_cell.find("span", class_="CellPlayerName--long")
+        anchor = long_name.find("a") if long_name else name_cell.find("a")
+        if not anchor:
+            continue
+        match = _CBS_ID_RE.search(anchor.get("href", ""))
+        team_span = name_cell.find("span", class_="CellPlayerName-team")
+
+        number_cells = row.find_all("td", class_=lambda c: c and "TableBase-bodyTd--number" in c)
+        if len(number_cells) < 2:
+            continue
+        try:
+            fpts = float(number_cells[-2].get_text(strip=True).replace(",", ""))
+            fppg = float(number_cells[-1].get_text(strip=True).replace(",", ""))
+        except ValueError:
+            continue
+
+        records.append(
+            {
+                "cbs_id": int(match.group(1)) if match else None,
+                "player_name": anchor.get_text(strip=True),
+                "team": team_span.get_text(strip=True) if team_span else None,
+                "projected_points": fpts,
+                "fppg": fppg,
+            }
+        )
+    return pd.DataFrame(records)
+
+
+def load_season_projections(fetched: list[tuple[str, str, int, Path]]) -> None:
+    """Parse raw HTML files (from fetch_season_projections) into one unified table.
+
+    `fetched` is a list of (position, scoring, season, raw_path) tuples, so metadata comes from
+    the fetch call directly rather than being re-derived from filenames.
+    """
+    dfs = []
+    for position, scoring, season, raw_path in fetched:
+        df = _parse_table(raw_path.read_text())
+        df["position"] = position
+        df["scoring"] = scoring
+        df["season"] = season
+        dfs.append(df)
+
+    combined = pd.concat(dfs, ignore_index=True)
+    WAREHOUSE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    con = duckdb.connect(str(WAREHOUSE_PATH))
+    con.execute("CREATE OR REPLACE TABLE cbs_projections AS SELECT * FROM combined")
+    con.close()
+
+    print(f"Loaded {len(combined)} rows into {WAREHOUSE_PATH} (table: cbs_projections)")
+
+
+if __name__ == "__main__":
+    season = 2026
+
+    fetched = [
+        (position, scoring, season, fetch_season_projections(position, scoring, season))
+        for position in POSITIONS
+        for scoring in SCORING_FORMATS
+    ]
+    load_season_projections(fetched)

--- a/src/ffb/consensus.py
+++ b/src/ffb/consensus.py
@@ -1,0 +1,89 @@
+"""Build the consensus (median/floor/ceiling) projection table from every projection source.
+
+Pure warehouse-to-warehouse SQL — no fetch step, no network, just a transform over tables that
+the other source modules (espn, sleeper, fftoday, cbs) have already loaded, joined through the
+nflverse `ids` player crosswalk (loaded by nfl_data.py) onto a common `gsis_id`.
+
+DST is excluded: team defenses have no entry in the player-level `ids` crosswalk.
+"""
+
+from pathlib import Path
+
+import duckdb
+
+WAREHOUSE_PATH = Path("data/warehouse.duckdb")
+
+# Skill positions covered by every source below (DST is excluded — no entry in the player-level
+# `ids` crosswalk, since it's a team, not a player).
+_SKILL_POSITIONS = ("QB", "RB", "WR", "TE", "K")
+
+# Every join also matches on position, since the `ids` crosswalk has a handful of duplicate
+# external IDs among long-retired/free-agent players (verified harmless against current data —
+# none of them appear in any of the active-player projection sources below — but matching on
+# position too costs nothing and rules it out structurally rather than by luck). `ids` labels
+# kickers "PK" where every source here uses "K", so the crosswalk is normalized to "K" first.
+_BUILD_SQL = f"""
+CREATE OR REPLACE TABLE consensus_projections AS
+WITH ids_normalized AS (
+    SELECT gsis_id, name, espn_id, sleeper_id, cbs_id, merge_name,
+           CASE WHEN position = 'PK' THEN 'K' ELSE position END AS position
+    FROM ids
+),
+source_projections AS (
+    SELECT ids.gsis_id, ids.name AS player_name, ids.position, 'espn' AS source,
+           e.projected_points
+    FROM espn_projections e
+    JOIN ids_normalized ids ON ids.espn_id = e.espn_id AND ids.position = e.position
+
+    UNION ALL
+
+    SELECT ids.gsis_id, ids.name, ids.position, 'sleeper', SUM(s.pts_ppr)
+    FROM sleeper_projections s
+    JOIN ids_normalized ids
+        ON TRY_CAST(s.sleeper_id AS DOUBLE) = ids.sleeper_id AND ids.position = s.position
+    GROUP BY ids.gsis_id, ids.name, ids.position
+
+    UNION ALL
+
+    SELECT ids.gsis_id, ids.name, ids.position, 'cbs', c.projected_points
+    FROM cbs_projections c
+    JOIN ids_normalized ids ON ids.cbs_id = c.cbs_id AND ids.position = c.position
+    WHERE c.scoring = 'ppr'
+
+    UNION ALL
+
+    SELECT ids.gsis_id, ids.name, ids.position, 'fftoday', f.projected_points
+    FROM fftoday_projections f
+    JOIN ids_normalized ids ON ids.merge_name = f.merge_name AND ids.position = f.position
+    WHERE f.scoring = 'ppr'
+)
+SELECT
+    gsis_id,
+    ANY_VALUE(player_name) AS player_name,
+    ANY_VALUE(position) AS position,
+    COUNT(*) AS num_sources,
+    MIN(projected_points) AS min_points,
+    MAX(projected_points) AS max_points,
+    PERCENTILE_CONT(0.2) WITHIN GROUP (ORDER BY projected_points) AS floor_p20,
+    PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY projected_points) AS median_p50,
+    PERCENTILE_CONT(0.8) WITHIN GROUP (ORDER BY projected_points) AS ceiling_p80,
+    STDDEV(projected_points) AS stddev_points
+FROM source_projections
+WHERE gsis_id IS NOT NULL
+    AND projected_points IS NOT NULL
+    AND position IN {_SKILL_POSITIONS}
+GROUP BY gsis_id
+"""
+
+
+def build_consensus_projections() -> None:
+    con = duckdb.connect(str(WAREHOUSE_PATH))
+    con.execute(_BUILD_SQL)
+    (count,) = con.execute("SELECT COUNT(*) FROM consensus_projections").fetchone()
+    con.close()
+
+    print(f"Built {count} rows into {WAREHOUSE_PATH} (table: consensus_projections)")
+
+
+if __name__ == "__main__":
+    build_consensus_projections()

--- a/src/ffb/consensus.py
+++ b/src/ffb/consensus.py
@@ -1,21 +1,34 @@
-"""Build the consensus (median/floor/ceiling) projection table from every projection source.
+"""Build the consensus (median/floor/ceiling) projection tables from every projection source.
 
 Pure warehouse-to-warehouse SQL — no fetch step, no network, just a transform over tables that
-the other source modules (espn, sleeper, fftoday, cbs) have already loaded, joined through the
-nflverse `ids` player crosswalk (loaded by nfl_data.py) onto a common `gsis_id`.
+the other source modules (espn, sleeper, fftoday, cbs) have already loaded.
 
-DST is excluded: team defenses have no entry in the player-level `ids` crosswalk.
+Two output tables, because team defenses need a different join key than individual players:
+- consensus_projections: skill positions (QB/RB/WR/TE/K), joined through the nflverse `ids`
+  player crosswalk (loaded by nfl_data.py) onto a common `gsis_id`.
+- consensus_dst_projections: team defenses, joined on a normalized team abbreviation (see
+  teams.py) instead, since `ids` is player-level and has no team-defense entries.
 """
 
 from pathlib import Path
 
 import duckdb
 
+from src.ffb.teams import normalize_team
+
 WAREHOUSE_PATH = Path("data/warehouse.duckdb")
 
-# Skill positions covered by every source below (DST is excluded — no entry in the player-level
-# `ids` crosswalk, since it's a team, not a player).
 _SKILL_POSITIONS = ("QB", "RB", "WR", "TE", "K")
+
+_PERCENTILE_AGGREGATES = """
+    COUNT(*) AS num_sources,
+    MIN(projected_points) AS min_points,
+    MAX(projected_points) AS max_points,
+    PERCENTILE_CONT(0.2) WITHIN GROUP (ORDER BY projected_points) AS floor_p20,
+    PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY projected_points) AS median_p50,
+    PERCENTILE_CONT(0.8) WITHIN GROUP (ORDER BY projected_points) AS ceiling_p80,
+    STDDEV(projected_points) AS stddev_points
+"""
 
 # Every join also matches on position, since the `ids` crosswalk has a handful of duplicate
 # external IDs among long-retired/free-agent players (verified harmless against current data —
@@ -61,13 +74,7 @@ SELECT
     gsis_id,
     ANY_VALUE(player_name) AS player_name,
     ANY_VALUE(position) AS position,
-    COUNT(*) AS num_sources,
-    MIN(projected_points) AS min_points,
-    MAX(projected_points) AS max_points,
-    PERCENTILE_CONT(0.2) WITHIN GROUP (ORDER BY projected_points) AS floor_p20,
-    PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY projected_points) AS median_p50,
-    PERCENTILE_CONT(0.8) WITHIN GROUP (ORDER BY projected_points) AS ceiling_p80,
-    STDDEV(projected_points) AS stddev_points
+    {_PERCENTILE_AGGREGATES}
 FROM source_projections
 WHERE gsis_id IS NOT NULL
     AND projected_points IS NOT NULL
@@ -75,14 +82,57 @@ WHERE gsis_id IS NOT NULL
 GROUP BY gsis_id
 """
 
+# `team` values are normalized (via the normalize_team Python UDF registered below) before this
+# runs, since each source represents defenses differently — a full name, a bare nickname, or a
+# non-canonical abbreviation (e.g. "LAR" instead of this warehouse's "LA" for the Rams).
+_BUILD_DST_SQL = f"""
+CREATE OR REPLACE TABLE consensus_dst_projections AS
+WITH source_projections AS (
+    -- espn_projections.team is already normalized at load time (see espn.py:load_projections).
+    SELECT team, 'espn' AS source, projected_points
+    FROM espn_projections
+    WHERE position = 'DST'
+
+    UNION ALL
+
+    SELECT normalize_team(team), 'sleeper', SUM(pts_ppr)
+    FROM sleeper_projections
+    WHERE position = 'DEF'
+    GROUP BY team
+
+    UNION ALL
+
+    SELECT team, 'cbs', projected_points
+    FROM cbs_projections
+    WHERE position = 'DST' AND scoring = 'ppr'
+
+    UNION ALL
+
+    SELECT team, 'fftoday', projected_points
+    FROM fftoday_projections
+    WHERE position = 'DST' AND scoring = 'ppr'
+)
+SELECT
+    team,
+    {_PERCENTILE_AGGREGATES}
+FROM source_projections
+WHERE team IS NOT NULL AND projected_points IS NOT NULL
+GROUP BY team
+"""
+
 
 def build_consensus_projections() -> None:
     con = duckdb.connect(str(WAREHOUSE_PATH))
+    con.create_function("normalize_team", normalize_team, ["VARCHAR"], "VARCHAR")
+
     con.execute(_BUILD_SQL)
+    con.execute(_BUILD_DST_SQL)
     (count,) = con.execute("SELECT COUNT(*) FROM consensus_projections").fetchone()
+    (dst_count,) = con.execute("SELECT COUNT(*) FROM consensus_dst_projections").fetchone()
     con.close()
 
     print(f"Built {count} rows into {WAREHOUSE_PATH} (table: consensus_projections)")
+    print(f"Built {dst_count} rows into {WAREHOUSE_PATH} (table: consensus_dst_projections)")
 
 
 if __name__ == "__main__":

--- a/src/ffb/espn.py
+++ b/src/ffb/espn.py
@@ -9,6 +9,8 @@ import pandas as pd
 import requests
 from dotenv import load_dotenv
 
+from src.ffb.teams import normalize_team
+
 load_dotenv()
 
 RAW_DIR = Path("data/raw/espn")
@@ -163,12 +165,17 @@ def load_projections(raw_path: Path, season: int) -> None:
                 and stat.get("scoringPeriodId") == 0
                 and stat.get("seasonId") == season
             ):
+                position = POSITION_IDS.get(player.get("defaultPositionId"))
+                full_name = player.get("fullName")
                 rows.append(
                     {
                         "espn_id": player.get("id"),
-                        "player_name": player.get("fullName"),
-                        "position": POSITION_IDS.get(player.get("defaultPositionId")),
-                        "team": player.get("proTeamId"),
+                        "player_name": full_name,
+                        "position": position,
+                        # DST rows carry no useful proTeamId; derive the team abbreviation
+                        # from the name (e.g. "Texans D/ST") instead, for the team-based join
+                        # DST needs (no player ID crosswalk covers team defenses).
+                        "team": normalize_team(full_name) if position == "DST" else None,
                         "season": season,
                         "projected_points": stat.get("appliedTotal"),
                     }

--- a/src/ffb/espn.py
+++ b/src/ffb/espn.py
@@ -140,6 +140,50 @@ def load_player_ownership(raw_path: Path) -> None:
     _load_json_to_table(raw_path, "espn_player_ownership")
 
 
+# ESPN's numeric defaultPositionId, mapped to the position strings used elsewhere in this
+# warehouse (e.g. the nflverse `ids` crosswalk).
+POSITION_IDS = {1: "QB", 2: "RB", 3: "WR", 4: "TE", 5: "K", 16: "DST"}
+
+
+def load_projections(raw_path: Path, season: int) -> None:
+    """Parse ESPN's own season-total point projection out of the player pool raw file.
+
+    Reuses the raw file already saved by fetch_player_ownership (no new network call) — each
+    player's `stats` list mixes actuals and projections across seasons/weeks, so we pick out
+    the season-total projection row (statSourceId=1, scoringPeriodId=0, seasonId=season).
+    """
+    players = json.loads(raw_path.read_text())
+
+    rows = []
+    for row in players:
+        player = row.get("player", {})
+        for stat in player.get("stats", []):
+            if (
+                stat.get("statSourceId") == 1
+                and stat.get("scoringPeriodId") == 0
+                and stat.get("seasonId") == season
+            ):
+                rows.append(
+                    {
+                        "espn_id": player.get("id"),
+                        "player_name": player.get("fullName"),
+                        "position": POSITION_IDS.get(player.get("defaultPositionId")),
+                        "team": player.get("proTeamId"),
+                        "season": season,
+                        "projected_points": stat.get("appliedTotal"),
+                    }
+                )
+                break
+
+    df = pd.DataFrame(rows)
+    WAREHOUSE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    con = duckdb.connect(str(WAREHOUSE_PATH))
+    con.execute("CREATE OR REPLACE TABLE espn_projections AS SELECT * FROM df")
+    con.close()
+
+    print(f"Loaded {len(df)} rows into {WAREHOUSE_PATH} (table: espn_projections)")
+
+
 def fetch_transactions(league_id: str, season: int) -> Path:
     """Fetch waiver claims, trades, and adds/drops and save raw to JSON."""
     data = _get(_league_url(league_id, season), params={"view": "mTransactions2"})
@@ -166,6 +210,8 @@ if __name__ == "__main__":
     load_rosters(fetch_rosters(LEAGUE_ID, SEASON))
     load_matchups(fetch_matchups(LEAGUE_ID, SEASON))
     load_players(fetch_players(SEASON))
-    load_player_ownership(fetch_player_ownership(LEAGUE_ID, SEASON))
+    ownership_raw_path = fetch_player_ownership(LEAGUE_ID, SEASON)
+    load_player_ownership(ownership_raw_path)
+    load_projections(ownership_raw_path, SEASON)
     load_transactions(fetch_transactions(LEAGUE_ID, SEASON))
     load_boxscores(fetch_boxscores(LEAGUE_ID, SEASON))

--- a/src/ffb/fftoday.py
+++ b/src/ffb/fftoday.py
@@ -1,0 +1,138 @@
+"""Fetch and load FFToday's own season-long fantasy point projections into the DuckDB warehouse.
+
+FFToday doesn't offer an API; each position's projections page is a single unauthenticated HTML
+table, which we parse directly with BeautifulSoup (the same partial-extraction approach used
+elsewhere in this project for sites without a real API).
+"""
+
+import re
+import time
+from pathlib import Path
+
+import duckdb
+import pandas as pd
+import requests
+from bs4 import BeautifulSoup
+
+RAW_DIR = Path("data/raw/fftoday")
+WAREHOUSE_PATH = Path("data/warehouse.duckdb")
+BASE_URL = "https://www.fftoday.com/rankings/playerproj.php"
+HEADERS = {"User-Agent": "Mozilla/5.0"}
+
+# FFToday starts returning 403s after a burst of rapid requests; a short delay between page
+# fetches keeps a full run (5 positions x 3 scoring formats) under that threshold.
+REQUEST_DELAY_SECONDS = 2
+
+# FFToday's PosID param. DST is excluded: it has no entry in the nflverse player ID crosswalk
+# (the `ids` table) used to join projections across sources, since it's a team, not a player.
+POSITIONS = {"QB": 10, "RB": 20, "WR": 30, "TE": 40, "K": 80}
+
+# FFToday's LeagueID param selects a named scoring preset — confirmed against the page's own
+# <select name="LeagueID"> options, not guessed from URL patterns.
+SCORING_FORMATS = {"standard": "1", "half_ppr": "193033", "ppr": "107644"}
+
+_SUFFIXES_RE = re.compile(r"\s+(jr\.?|sr\.?|ii|iii|iv|v)$", re.I)
+_PUNCTUATION_RE = re.compile(r"[.'’]")
+
+
+def _merge_name(name: str) -> str:
+    """Normalize a player name to match the nflverse `ids.merge_name` crosswalk column."""
+    name = _PUNCTUATION_RE.sub("", name)
+    name = _SUFFIXES_RE.sub("", name)
+    return re.sub(r"\s+", " ", name).strip().lower()
+
+
+def fetch_season_projections(position: str, scoring: str, season: int) -> Path:
+    """Fetch one position/scoring format's season-long projections and save raw HTML."""
+    time.sleep(REQUEST_DELAY_SECONDS)
+    response = requests.get(
+        BASE_URL,
+        params={
+            "Season": season,
+            "PosID": POSITIONS[position],
+            "LeagueID": SCORING_FORMATS[scoring],
+        },
+        headers=HEADERS,
+    )
+    response.raise_for_status()
+    RAW_DIR.mkdir(parents=True, exist_ok=True)
+    raw_path = RAW_DIR / f"proj_{position.lower()}_{scoring}_{season}.html"
+    raw_path.write_text(response.text)
+    print(f"Saved {raw_path}")
+    return raw_path
+
+
+def _find_projections_table(soup: BeautifulSoup) -> tuple[list, list]:
+    """Find the (leaf) table whose header row ends in 'FPts', and split header from data rows.
+
+    FFToday nests the real data table inside layout tables, so a naive first-table-found search
+    picks up an outer wrapper whose flattened text coincidentally contains 'FPts' too.
+    """
+    for table in soup.find_all("table"):
+        if table.find("table"):
+            continue
+        rows = table.find_all("tr")
+        for i, row in enumerate(rows):
+            cells = [c.get_text(strip=True) for c in row.find_all(["td", "th"])]
+            if cells and cells[-1] == "FPts":
+                return rows[i + 1 :], cells
+    raise ValueError("Could not find a projections table with an 'FPts' column")
+
+
+def _parse_table(html: str) -> pd.DataFrame:
+    soup = BeautifulSoup(html, "html.parser")
+    data_rows, _header = _find_projections_table(soup)
+
+    records = []
+    for row in data_rows:
+        cells = [c.get_text(strip=True) for c in row.find_all("td")]
+        if len(cells) < 3:
+            continue
+        player_name = cells[1]
+        try:
+            projected_points = float(cells[-1].replace(",", ""))
+        except ValueError:
+            continue
+        records.append(
+            {
+                "merge_name": _merge_name(player_name),
+                "player_name": player_name,
+                "team": cells[2],
+                "projected_points": projected_points,
+            }
+        )
+    return pd.DataFrame(records)
+
+
+def load_season_projections(fetched: list[tuple[str, str, int, Path]]) -> None:
+    """Parse raw HTML files (from fetch_season_projections) into one unified table.
+
+    `fetched` is a list of (position, scoring, season, raw_path) tuples, so metadata comes from
+    the fetch call directly rather than being re-derived from filenames.
+    """
+    dfs = []
+    for position, scoring, season, raw_path in fetched:
+        df = _parse_table(raw_path.read_text())
+        df["position"] = position
+        df["scoring"] = scoring
+        df["season"] = season
+        dfs.append(df)
+
+    combined = pd.concat(dfs, ignore_index=True)
+    WAREHOUSE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    con = duckdb.connect(str(WAREHOUSE_PATH))
+    con.execute("CREATE OR REPLACE TABLE fftoday_projections AS SELECT * FROM combined")
+    con.close()
+
+    print(f"Loaded {len(combined)} rows into {WAREHOUSE_PATH} (table: fftoday_projections)")
+
+
+if __name__ == "__main__":
+    season = 2026
+
+    fetched = [
+        (position, scoring, season, fetch_season_projections(position, scoring, season))
+        for position in POSITIONS
+        for scoring in SCORING_FORMATS
+    ]
+    load_season_projections(fetched)

--- a/src/ffb/fftoday.py
+++ b/src/ffb/fftoday.py
@@ -14,18 +14,19 @@ import pandas as pd
 import requests
 from bs4 import BeautifulSoup
 
+from src.ffb.teams import normalize_team
+
 RAW_DIR = Path("data/raw/fftoday")
 WAREHOUSE_PATH = Path("data/warehouse.duckdb")
 BASE_URL = "https://www.fftoday.com/rankings/playerproj.php"
 HEADERS = {"User-Agent": "Mozilla/5.0"}
 
 # FFToday starts returning 403s after a burst of rapid requests; a short delay between page
-# fetches keeps a full run (5 positions x 3 scoring formats) under that threshold.
+# fetches keeps a full run (6 positions x 3 scoring formats) under that threshold.
 REQUEST_DELAY_SECONDS = 2
 
-# FFToday's PosID param. DST is excluded: it has no entry in the nflverse player ID crosswalk
-# (the `ids` table) used to join projections across sources, since it's a team, not a player.
-POSITIONS = {"QB": 10, "RB": 20, "WR": 30, "TE": 40, "K": 80}
+# FFToday's PosID param.
+POSITIONS = {"QB": 10, "RB": 20, "WR": 30, "TE": 40, "K": 80, "DST": 99}
 
 # FFToday's LeagueID param selects a named scoring preset — confirmed against the page's own
 # <select name="LeagueID"> options, not guessed from URL patterns.
@@ -79,7 +80,7 @@ def _find_projections_table(soup: BeautifulSoup) -> tuple[list, list]:
     raise ValueError("Could not find a projections table with an 'FPts' column")
 
 
-def _parse_table(html: str) -> pd.DataFrame:
+def _parse_table(html: str, position: str) -> pd.DataFrame:
     soup = BeautifulSoup(html, "html.parser")
     data_rows, _header = _find_projections_table(soup)
 
@@ -88,19 +89,34 @@ def _parse_table(html: str) -> pd.DataFrame:
         cells = [c.get_text(strip=True) for c in row.find_all("td")]
         if len(cells) < 3:
             continue
-        player_name = cells[1]
         try:
             projected_points = float(cells[-1].replace(",", ""))
         except ValueError:
             continue
-        records.append(
-            {
-                "merge_name": _merge_name(player_name),
-                "player_name": player_name,
-                "team": cells[2],
-                "projected_points": projected_points,
-            }
-        )
+
+        if position == "DST":
+            # DST rows have a full team name ("Houston Texans") in place of a player name, and
+            # no separate team column — there's no player crosswalk for team defenses, so this
+            # joins by team abbreviation instead in consensus.py.
+            team_name = cells[1]
+            records.append(
+                {
+                    "merge_name": None,
+                    "player_name": team_name,
+                    "team": normalize_team(team_name),
+                    "projected_points": projected_points,
+                }
+            )
+        else:
+            player_name = cells[1]
+            records.append(
+                {
+                    "merge_name": _merge_name(player_name),
+                    "player_name": player_name,
+                    "team": cells[2],
+                    "projected_points": projected_points,
+                }
+            )
     return pd.DataFrame(records)
 
 
@@ -112,7 +128,7 @@ def load_season_projections(fetched: list[tuple[str, str, int, Path]]) -> None:
     """
     dfs = []
     for position, scoring, season, raw_path in fetched:
-        df = _parse_table(raw_path.read_text())
+        df = _parse_table(raw_path.read_text(), position)
         df["position"] = position
         df["scoring"] = scoring
         df["season"] = season

--- a/src/ffb/sleeper.py
+++ b/src/ffb/sleeper.py
@@ -11,9 +11,12 @@ import requests
 RAW_DIR = Path("data/raw/sleeper")
 WAREHOUSE_PATH = Path("data/warehouse.duckdb")
 BASE_URL = "https://api.sleeper.app/v1"
+PROJECTIONS_BASE_URL = "https://api.sleeper.app"
 
 # TODO: set this to your league's ID (the numeric ID in the league's Sleeper URL).
 LEAGUE_ID = "1390836961870090240"
+
+SEASON = 2026
 
 # Regular season + playoffs; trim if your league's schedule is shorter.
 WEEKS = list(range(1, 19))
@@ -152,6 +155,52 @@ def load_players(raw_path: Path) -> None:
     print(f"Loaded {raw_path} into {WAREHOUSE_PATH} (table: sleeper_players)")
 
 
+def fetch_projections(season: int, weeks: list[int]) -> Path:
+    """Fetch weekly player projections (public, not league-scoped) and save raw to JSON.
+
+    This is a different, unauthenticated Sleeper API surface (no /v1 prefix, no league ID) —
+    it's the feed Sleeper's own app uses to show projected points, sourced from RotoWire.
+    """
+    rows = []
+    for week in weeks:
+        response = requests.get(
+            f"{PROJECTIONS_BASE_URL}/projections/nfl/{season}/{week}",
+            params={"season_type": "regular"},
+        )
+        response.raise_for_status()
+        week_rows = response.json()
+        for row in week_rows:
+            row["week"] = week
+        rows.extend(week_rows)
+    return _save_raw_json(rows, f"projections_{season}")
+
+
+def load_projections(raw_path: Path) -> None:
+    data = json.loads(raw_path.read_text())
+    rows = [
+        {
+            "sleeper_id": row.get("player_id"),
+            "player_name": (row.get("player") or {}).get("first_name", "")
+            + " "
+            + (row.get("player") or {}).get("last_name", ""),
+            "position": (row.get("player") or {}).get("position"),
+            "team": row.get("team"),
+            "season": row.get("season"),
+            "week": row.get("week"),
+            "pts_ppr": (row.get("stats") or {}).get("pts_ppr"),
+        }
+        for row in data
+    ]
+    df = pd.DataFrame(rows)
+
+    WAREHOUSE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    con = duckdb.connect(str(WAREHOUSE_PATH))
+    con.execute("CREATE OR REPLACE TABLE sleeper_projections AS SELECT * FROM df")
+    con.close()
+
+    print(f"Loaded {len(df)} rows into {WAREHOUSE_PATH} (table: sleeper_projections)")
+
+
 if __name__ == "__main__":
     load_league(fetch_league(LEAGUE_ID))
     load_rosters(fetch_rosters(LEAGUE_ID))
@@ -160,3 +209,4 @@ if __name__ == "__main__":
     load_transactions(fetch_transactions(LEAGUE_ID, WEEKS))
     load_nfl_state(fetch_nfl_state())
     load_players(fetch_players())
+    load_projections(fetch_projections(SEASON, WEEKS))

--- a/src/ffb/teams.py
+++ b/src/ffb/teams.py
@@ -1,0 +1,33 @@
+"""Canonical NFL team abbreviations, matching the convention nfl_data_py uses elsewhere in this
+warehouse (e.g. the `rosters` table) — "LA" (not "LAR") for the Rams, "JAX" (not "JAC") for the
+Jaguars. Projection sources represent team defenses inconsistently (full team names, bare
+nicknames, or a divergent abbreviation), so `normalize_team` maps any of those down to the
+canonical abbreviation, for joining DST rows across sources by team instead of a player ID.
+"""
+
+NICKNAME_TO_ABBR = {
+    "Cardinals": "ARI", "Falcons": "ATL", "Ravens": "BAL", "Bills": "BUF",
+    "Panthers": "CAR", "Bears": "CHI", "Bengals": "CIN", "Browns": "CLE",
+    "Cowboys": "DAL", "Broncos": "DEN", "Lions": "DET", "Packers": "GB",
+    "Texans": "HOU", "Colts": "IND", "Jaguars": "JAX", "Chiefs": "KC",
+    "Chargers": "LAC", "Rams": "LA", "Raiders": "LV", "Dolphins": "MIA",
+    "Vikings": "MIN", "Patriots": "NE", "Saints": "NO", "Giants": "NYG",
+    "Jets": "NYJ", "Eagles": "PHI", "Steelers": "PIT", "Seahawks": "SEA",
+    "49ers": "SF", "Buccaneers": "TB", "Titans": "TEN", "Commanders": "WAS",
+}  # fmt: skip
+
+ABBR_ALIASES = {
+    "LAR": "LA", "JAC": "JAX", "WSH": "WAS", "GNB": "GB", "NOR": "NO",
+    "SFO": "SF", "TAM": "TB", "NWE": "NE", "KAN": "KC", "LVR": "LV",
+}  # fmt: skip
+
+
+def normalize_team(value: str) -> str:
+    """Normalize a team name, nickname, or abbreviation to the canonical abbreviation."""
+    value = value.strip()
+    if value.upper() in ABBR_ALIASES:
+        return ABBR_ALIASES[value.upper()]
+    if value.upper() in NICKNAME_TO_ABBR.values():
+        return value.upper()
+    nickname = value.replace("D/ST", "").strip().split()[-1]
+    return NICKNAME_TO_ABBR.get(nickname, value.upper())


### PR DESCRIPTION
## Summary

Adds a FantasyPros-style consensus engine: aggregates four independent season-long PPR
projection sources (ESPN, Sleeper/RotoWire, FFToday, CBS Sports) and computes a per-player
median, 20th-percentile floor, and 80th-percentile ceiling.

- `espn.py` — parses ESPN's own blended projection out of the already-archived
  player-ownership payload (no new fetch)
- `sleeper.py` — new fetch/load for Sleeper's public (RotoWire-sourced) projections API
- `fftoday.py`, `cbs.py` (new) — scrape each site's own staff projections
- `teams.py` (new) — shared NFL team-abbreviation normalizer, since each site represents
  team defenses differently (full name, nickname, or a non-canonical abbreviation like "LAR")
- `consensus.py` (new) — the SQL: joins sources through the nflverse player ID crosswalk onto
  `gsis_id` for skill positions, and by normalized team abbreviation for DST, then computes
  `PERCENTILE_CONT(0.2/0.5/0.8)` into `consensus_projections` / `consensus_dst_projections`

## Validation

Cross-checked the resulting rankings against FantasyPros' independent rank-based ECR
consensus (rank correlation per position, skill positions + DST):

| Position | Spearman corr | Mean rank diff |
|---|---|---|
| QB | 0.93 | 5.0 |
| RB | 0.93 | 9.7 |
| WR | 0.93 | 11.8 |
| TE | 0.88 | 7.4 |
| K | 0.79 | 5.2 |
| DST | 0.91 | 3.1 |

Agreement is strongest at the top of each position (where every source has data) and weakens
toward the bottom of the player pool (where FFToday/CBS's tables cap out and only Sleeper
still projects a player) — expected given thinner source coverage there, not a data bug.

## Known limitations (not fixed here)

- FFToday (~50/position) and CBS (~100/position) cap their projection tables server-side, no
  pagination found — deep bench players (~1/3 of the output) only get 1-2 source coverage.
- Sleeper has no season-total endpoint; its contribution is a sum of 18 weekly projections.
- Weekly (in-season) consensus isn't built yet — this is season-long only.

## Test plan

- [x] Ran every fetch/load module end to end; spot-checked known players/teams across sources
  for plausible, consistent point totals
- [x] Verified `floor_p20 <= median_p50 <= ceiling_p80` holds for all rows in both output tables
- [x] Verified idempotency (re-running loads from already-saved raw files reproduces identical
  row counts)
- [x] Cross-validated against FantasyPros' independent ECR rank consensus (table above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)