### PR TITLE
feat: add offensive line strength grade

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ network access of their own.
 
 - `src/silver/nfl_data.py` — nflverse data via `nfl_data_py`: weekly stats, schedules, rosters,
   snap counts, injuries, seasonal data, depth charts, player bios, Next Gen Stats, FTN charting
-  data, and a cross-platform player ID crosswalk.
+  data, PFR advanced pass/rush stats, and a cross-platform player ID crosswalk.
 - `src/silver/sleeper.py` — Sleeper's public league API (no auth required): league settings,
   rosters, users, weekly matchups (including starting lineups), transactions, current NFL state,
   and the full player dictionary. Set `LEAGUE_ID` in the module before running.
@@ -56,6 +56,10 @@ network access of their own.
   ceiling (80th percentile) PPR projection per player or team, aggregated across every
   independent projection source above (ESPN, Sleeper/RotoWire, FFToday, CBS). Pure SQL over
   already-loaded tables — no fetch step, no network.
+- `src/gold/offensive_line.py` — builds `offensive_line_grades`: a per-team-per-season 0-100
+  offensive line grade from PFR's advanced pass/rush stats, combining pass-block (QB pressure
+  rate allowed, weighted by pass attempts) and run-block (RB/FB yards before contact per rush
+  attempt) into one score. Pure SQL over already-loaded tables — no fetch step, no network.
 
 ## Environment
 

--- a/src/gold/offensive_line.py
+++ b/src/gold/offensive_line.py
@@ -1,0 +1,88 @@
+"""Build a per-team-per-season offensive line strength grade.
+
+Pure warehouse-to-warehouse SQL — no fetch step, no network. Built from PFR's advanced pass/rush
+stats (loaded by nfl_data.py's fetch_pfr_advstats/load_pfr_advstats), which nflverse already
+parses and publishes as clean parquet, rather than scraping Pro-Football-Reference HTML directly.
+
+Two independent signals, since pass protection and run blocking are different jobs for an O-line:
+- Pass block: how often a team's QBs get pressured, weighted by their pass attempts (a raw
+  per-QB rate would let a 10-attempt backup's outlier game swing the team grade as much as a
+  full-season starter).
+- Run block: yards before contact per rush attempt for the team's RBs/FBs — QB scrambles and WR
+  jet sweeps are excluded, since those happen behind a different blocking look and would add
+  noise rather than signal about the O-line itself.
+
+Both are converted to a 0-100 percentile grade within their season (since raw pressure/YBC rates
+drift year to year with rule and play-calling changes), then averaged into one overall grade.
+"""
+
+from pathlib import Path
+
+import duckdb
+
+from src.silver.teams import normalize_team
+
+WAREHOUSE_PATH = Path("data/warehouse.duckdb")
+
+# PFR reports a player's season as a single "2TM"/"3TM" row when they changed teams, instead of
+# splitting it per team — that row can't be attributed to one team's O-line, so it's dropped.
+_BUILD_SQL = """
+CREATE OR REPLACE TABLE offensive_line_grades AS
+WITH pass_block AS (
+    SELECT
+        season,
+        normalize_team(team) AS team,
+        SUM(times_pressured) / SUM(pass_attempts) AS pressure_rate_allowed
+    FROM pfr_advstats_pass
+    WHERE team NOT IN ('2TM', '3TM') AND pass_attempts > 0
+    GROUP BY season, normalize_team(team)
+),
+run_block AS (
+    SELECT
+        season,
+        normalize_team(tm) AS team,
+        SUM(ybc) / SUM(att) AS run_block_ybc_per_att
+    FROM pfr_advstats_rush
+    WHERE tm NOT IN ('2TM', '3TM') AND pos IN ('RB', 'FB') AND att > 0
+    GROUP BY season, normalize_team(tm)
+),
+combined AS (
+    SELECT
+        COALESCE(p.season, r.season) AS season,
+        COALESCE(p.team, r.team) AS team,
+        p.pressure_rate_allowed,
+        r.run_block_ybc_per_att
+    FROM pass_block p
+    FULL OUTER JOIN run_block r ON p.season = r.season AND p.team = r.team
+)
+SELECT
+    season,
+    team,
+    pressure_rate_allowed,
+    run_block_ybc_per_att,
+    -- Lower pressure rate is better, so the percentile is inverted; higher YBC/att is better, so
+    -- it isn't.
+    100 * (1 - PERCENT_RANK() OVER (PARTITION BY season ORDER BY pressure_rate_allowed)) AS pass_block_grade,
+    100 * PERCENT_RANK() OVER (PARTITION BY season ORDER BY run_block_ybc_per_att) AS run_block_grade,
+    (
+        100 * (1 - PERCENT_RANK() OVER (PARTITION BY season ORDER BY pressure_rate_allowed))
+        + 100 * PERCENT_RANK() OVER (PARTITION BY season ORDER BY run_block_ybc_per_att)
+    ) / 2 AS ol_grade
+FROM combined
+ORDER BY season, ol_grade DESC
+"""
+
+
+def build_offensive_line_grades() -> None:
+    con = duckdb.connect(str(WAREHOUSE_PATH))
+    con.create_function("normalize_team", normalize_team, ["VARCHAR"], "VARCHAR")
+
+    con.execute(_BUILD_SQL)
+    (count,) = con.execute("SELECT COUNT(*) FROM offensive_line_grades").fetchone()
+    con.close()
+
+    print(f"Built {count} rows into {WAREHOUSE_PATH} (table: offensive_line_grades)")
+
+
+if __name__ == "__main__":
+    build_offensive_line_grades()

--- a/src/silver/nfl_data.py
+++ b/src/silver/nfl_data.py
@@ -149,6 +149,19 @@ def load_ftn_data(raw_path: Path) -> None:
     _load_parquet_to_table(raw_path, "ftn_data")
 
 
+def fetch_pfr_advstats(stat_type: str, seasons: list[int]) -> Path:
+    """Fetch PFR advanced season-level stats (pass/rush/rec/def) and save raw to parquet.
+
+    Not available before 2018 (nfl_data_py raises if any requested season predates that).
+    """
+    df = nfl.import_seasonal_pfr(stat_type, seasons)
+    return _save_raw(df, f"pfr_advstats_{stat_type}_{_seasons_label(seasons)}")
+
+
+def load_pfr_advstats(raw_path: Path, stat_type: str) -> None:
+    _load_parquet_to_table(raw_path, f"pfr_advstats_{stat_type}")
+
+
 def fetch_ids() -> Path:
     """Fetch the cross-platform player ID crosswalk and save raw to parquet."""
     df = nfl.import_ids()
@@ -173,3 +186,6 @@ if __name__ == "__main__":
     load_players(fetch_players())
     load_ngs_data(fetch_ngs_data(seasons))
     load_ftn_data(fetch_ftn_data(seasons))
+
+    for stat_type in ["pass", "rush"]:
+        load_pfr_advstats(fetch_pfr_advstats(stat_type, seasons), stat_type)


### PR DESCRIPTION
## Summary
- Adds PFR advanced pass/rush stats as a new nflverse silver source (`src/silver/nfl_data.py`), sourced from nflverse's own published parquet rather than scraped HTML.
- Adds `src/gold/offensive_line.py`, building a per-team-per-season `offensive_line_grades` table: a 0-100 grade combining pass-block (QB pressure rate allowed, weighted by pass attempts) and run-block (RB/FB yards before contact per rush attempt), each percentile-ranked within season.

## Test plan
- [x] Ran `python -m src.gold.offensive_line`; produced 96 rows (32 teams × 3 seasons, 2021-2023) with no nulls from the join.
- [x] Sanity-checked 2023 output against real-world reporting: Dolphins/Ravens/Rams grade highest, Giants/Panthers grade lowest — consistent with those teams' well-documented O-line performance that year.

🤖 Generated with [Claude Code](https://claude.com/claude-code)