### PR TITLE
feat: add in-house PPG projection as a fifth consensus source

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ network access of their own.
   `consensus_dst_projections` (team defenses, joined by normalized team abbreviation instead,
   since defenses aren't in the player crosswalk). Each is a median/floor (20th percentile)/
   ceiling (80th percentile) PPR projection per player or team, aggregated across every
-  independent projection source above (ESPN, Sleeper/RotoWire, FFToday, CBS). Pure SQL over
-  already-loaded tables — no fetch step, no network.
+  independent projection source above (ESPN, Sleeper/RotoWire, FFToday, CBS) plus the in-house
+  model below. Pure SQL over already-loaded tables — no fetch step, no network.
 - `src/gold/offensive_line.py` — builds `offensive_line_grades`: a per-team-per-season 0-100
   offensive line grade from PFR's advanced pass/rush stats, combining pass-block (QB pressure
   rate allowed, weighted by pass attempts) and run-block (RB/FB yards before contact per rush
@@ -69,9 +69,18 @@ network access of their own.
   per-target-season PPR points-per-game baseline (QB/RB/WR/TE) from nflverse weekly stats, looking
   back up to 4 seasons and weighting more recent seasons more heavily (1.0/0.9/0.8/0.7). A season
   only counts toward the baseline if the player played at least 6 games in it, so an
-  injury-shortened or backup-role cameo doesn't distort the per-game rate. A feature-engineering
-  building block, not a projection itself — meant to feed a future in-house predictive model. Pure
-  SQL over already-loaded tables — no fetch step, no network.
+  injury-shortened or backup-role cameo doesn't distort the per-game rate. Also outputs
+  `weighted_games_per_season`, the same recency-weighted average applied to games played instead —
+  a durability signal. A feature-engineering building block, not a projection itself. Pure SQL
+  over already-loaded tables — no fetch step, no network.
+- `src/gold/inhouse_projections.py` — builds `inhouse_projections`: a home-grown PPG projection
+  from a gradient-boosted model (scikit-learn's `HistGradientBoostingRegressor`), trained on a
+  shift-based setup — `player_weighted_baselines` plus prior-season `offensive_line_grades`/
+  `skill_position_grades` as features, actual next-season PPG as the label — then converted to a
+  season-total point projection via the `weighted_games_per_season` durability signal. The only
+  `src/gold` module that isn't pure SQL (Python/pandas/scikit-learn over already-loaded tables
+  instead), and the only one with a genuine train/holdout split, printing out-of-sample MAE/R2 on
+  each run. Feeds into `consensus.py` as a fifth projection source.
 
 ## Environment
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,8 @@ duckdb==1.5.5
 fastparquet==2026.5.0
 fsspec==2026.7.0
 idna==3.18
+joblib==1.5.3
+narwhals==2.24.0
 nfl_data_py==0.3.3
 numpy==1.26.4
 packaging==26.3
@@ -16,7 +18,10 @@ python-dateutil==2.9.0.post0
 python-dotenv==1.1.1
 pytz==2026.3.post1
 requests==2.34.2
+scikit-learn==1.9.0
+scipy==1.17.1
 six==1.17.0
 soupsieve==2.9.1
+threadpoolctl==3.6.0
 typing_extensions==4.16.0
 urllib3==2.7.0

--- a/scripts/build_warehouse.sh
+++ b/scripts/build_warehouse.sh
@@ -15,6 +15,12 @@ python -m src.silver.fantasypros
 python -m src.silver.fftoday
 python -m src.silver.cbs
 
-# Depends on every source above already being loaded (joins their projections through the
-# nflverse `ids` crosswalk from nfl_data.py).
+# Gold layer, in dependency order: the team-context grades and player baseline are pure
+# transforms of nfl_data.py's tables; inhouse_projections depends on all three of those; consensus
+# depends on every source above (external sites joined through the nflverse `ids` crosswalk,
+# inhouse_projections joined directly since it's already keyed on that same ID space).
+python -m src.gold.offensive_line
+python -m src.gold.skill_position_grades
+python -m src.gold.player_baselines
+python -m src.gold.inhouse_projections
 python -m src.gold.consensus

--- a/src/gold/consensus.py
+++ b/src/gold/consensus.py
@@ -1,11 +1,14 @@
 """Build the consensus (median/floor/ceiling) projection tables from every projection source.
 
 Pure warehouse-to-warehouse SQL — no fetch step, no network, just a transform over tables that
-the other source modules (espn, sleeper, fftoday, cbs) have already loaded.
+the other source modules (espn, sleeper, fftoday, cbs) and the in-house model
+(inhouse_projections.py) have already loaded/built.
 
 Two output tables, because team defenses need a different join key than individual players:
 - consensus_projections: skill positions (QB/RB/WR/TE/K), joined through the nflverse `ids`
-  player crosswalk (loaded by nfl_data.py) onto a common `gsis_id`.
+  player crosswalk (loaded by nfl_data.py) onto a common `gsis_id`. inhouse_projections is the one
+  exception — it's already keyed on that same `gsis_id` (it's built from weekly_stats, which uses
+  the same nflverse GSIS ID space), so it's unioned in directly with no crosswalk join.
 - consensus_dst_projections: team defenses, joined on a normalized team abbreviation (see
   teams.py) instead, since `ids` is player-level and has no team-defense entries.
 """
@@ -69,6 +72,16 @@ source_projections AS (
     FROM fftoday_projections f
     JOIN ids_normalized ids ON ids.merge_name = f.merge_name AND ids.position = f.position
     WHERE f.scoring = 'ppr'
+
+    UNION ALL
+
+    -- No ids crosswalk join here (see module docstring) and no position-matching safety net
+    -- either — that guards against ids' duplicate-external-ID problem, which doesn't apply since
+    -- this source never goes through ids at all. Scoped to the live target_season, i.e. the one
+    -- cohort inhouse_projections.py actually predicts (rather than backtests).
+    SELECT player_id, player_name, position, 'inhouse', projected_points
+    FROM inhouse_projections
+    WHERE target_season = (SELECT MAX(target_season) FROM inhouse_projections)
 )
 SELECT
     gsis_id,

--- a/src/gold/inhouse_projections.py
+++ b/src/gold/inhouse_projections.py
@@ -1,0 +1,186 @@
+"""Build an in-house PPG projection: a shift-based model trained on this warehouse's own data.
+
+Unlike the other `src/gold` modules, this one isn't pure SQL — it's Python/pandas/scikit-learn
+over the warehouse (still no fetch step, no network). It's the "home-grown predictive model" idea
+from project notes: prior-year weighted baseline + team context -> next-year PPG, meant to become
+a fifth voice in `consensus.py`'s aggregation alongside the external sites.
+
+Features, all as of `target_season - 1` (the most recent season actually played — team context for
+the season being predicted doesn't exist yet, so this stays a strictly prior-year-only setup):
+- `player_weighted_baselines.weighted_ppg_ppr` / `weighted_games_per_season` / `seasons_used` —
+  the player's own recency-weighted history and durability.
+- `offensive_line_grades.ol_grade` and `skill_position_grades.grade` (own position) for the
+  player's most-played team that season — a LEFT JOIN, since QB never matches
+  `skill_position_grades` (it only grades WR/TE/RB); HistGradientBoostingRegressor takes the
+  resulting NaN natively, no imputation needed.
+
+Label: actual PPG in `target_season`, only for players who played >= the same games-played floor
+`player_baselines.py` uses (imported, not redefined) — an actual season cut short by injury is as
+untrustworthy a training target as a short season is a baseline input.
+
+Only two cohorts ever get a *stored* prediction, both produced without seeing their own label:
+- the earliest labeled `target_season` has no prior labeled season to train on, so no honest
+  out-of-sample prediction is possible for it — it's used only as training data, not stored.
+- the next labeled `target_season` is held out as a genuine backtest: trained on the earliest
+  season only, predicted out-of-sample, with MAE/R2 printed.
+- the live (unlabeled) `target_season` — the one that actually feeds `consensus.py` — is predicted
+  by a model refit on *all* labeled seasons combined, since there's no reason to hold data back
+  from the projection that actually matters once the honest backtest above has already run.
+
+`projected_points` (season-total, matching the units every other source in `consensus.py` uses) is
+`predicted_ppg_ppr * expected_games`, where `expected_games` is the same
+`weighted_games_per_season` durability signal used as a model input — decoupling "how good per
+game" (learned) from "how many games will they play" (a recency-weighted historical rate).
+"""
+
+from pathlib import Path
+
+import duckdb
+import pandas as pd
+from sklearn.ensemble import HistGradientBoostingRegressor
+from sklearn.metrics import mean_absolute_error, r2_score
+
+from src.gold.player_baselines import _MIN_GAMES_PLAYED, _SKILL_POSITIONS
+from src.silver.teams import normalize_team
+
+WAREHOUSE_PATH = Path("data/warehouse.duckdb")
+
+_BASE_FEATURES = [
+    "weighted_ppg_ppr", "weighted_games_per_season", "seasons_used", "ol_grade", "skill_grade",
+]
+_FEATURE_COLUMNS = _BASE_FEATURES + [f"position_{p}" for p in _SKILL_POSITIONS]
+
+# Conservative for a dataset this small (a few hundred rows per cohort): shallow trees, a decent
+# per-leaf sample floor, and a gentle learning rate all guard against overfitting what little data
+# there is.
+_MODEL_PARAMS = dict(max_depth=3, min_samples_leaf=15, learning_rate=0.1, random_state=0)
+
+# player_team resolves each player's most-played team in a season (mirrors the
+# team_by_player_season pattern in skill_position_grades.py, over weekly_stats instead of
+# ngs_data), so team context can be joined in as of target_season - 1.
+_FEATURE_SQL = f"""
+WITH team_by_player_season AS (
+    SELECT
+        season, player_id, normalize_team(recent_team) AS team,
+        ROW_NUMBER() OVER (
+            PARTITION BY season, player_id ORDER BY COUNT(*) DESC
+        ) AS rn
+    FROM weekly_stats
+    WHERE season_type = 'REG' AND recent_team IS NOT NULL
+    GROUP BY season, player_id, normalize_team(recent_team)
+),
+player_team AS (
+    SELECT season, player_id, team FROM team_by_player_season WHERE rn = 1
+),
+actual_outcomes AS (
+    SELECT
+        player_id,
+        season AS target_season,
+        SUM(fantasy_points_ppr) / COUNT(*) AS actual_ppg_ppr
+    FROM weekly_stats
+    WHERE season_type = 'REG'
+        AND fantasy_points_ppr IS NOT NULL
+        AND position IN {_SKILL_POSITIONS}
+    GROUP BY player_id, season
+    HAVING COUNT(*) >= {_MIN_GAMES_PLAYED}
+)
+SELECT
+    b.target_season,
+    b.player_id,
+    b.player_name,
+    b.position,
+    b.seasons_used,
+    b.weighted_ppg_ppr,
+    b.weighted_games_per_season,
+    pt.team,
+    ol.ol_grade,
+    sk.grade AS skill_grade,
+    o.actual_ppg_ppr
+FROM player_weighted_baselines b
+LEFT JOIN player_team pt ON pt.player_id = b.player_id AND pt.season = b.target_season - 1
+LEFT JOIN offensive_line_grades ol ON ol.team = pt.team AND ol.season = b.target_season - 1
+LEFT JOIN skill_position_grades sk
+    ON sk.team = pt.team AND sk.season = b.target_season - 1 AND sk.position = b.position
+LEFT JOIN actual_outcomes o ON o.player_id = b.player_id AND o.target_season = b.target_season
+"""
+
+
+def _add_position_dummies(df: pd.DataFrame) -> pd.DataFrame:
+    dummies = pd.get_dummies(df["position"])
+    for position in _SKILL_POSITIONS:
+        if position not in dummies.columns:
+            dummies[position] = 0
+    dummies = dummies[list(_SKILL_POSITIONS)].add_prefix("position_").astype(int)
+    return pd.concat([df, dummies], axis=1)
+
+
+def _fit(train: pd.DataFrame) -> HistGradientBoostingRegressor:
+    model = HistGradientBoostingRegressor(**_MODEL_PARAMS)
+    model.fit(train[_FEATURE_COLUMNS], train["actual_ppg_ppr"])
+    return model
+
+
+def build_inhouse_projections() -> None:
+    con = duckdb.connect(str(WAREHOUSE_PATH))
+    con.create_function("normalize_team", normalize_team, ["VARCHAR"], "VARCHAR")
+    df = con.execute(_FEATURE_SQL).df()
+    con.close()
+
+    df = _add_position_dummies(df)
+    labeled = df[df["actual_ppg_ppr"].notna()].sort_values("target_season")
+    labeled_seasons = sorted(labeled["target_season"].unique())
+    live_season = df["target_season"].max()
+
+    output_frames = []
+
+    if len(labeled_seasons) >= 2:
+        train_season, holdout_season = labeled_seasons[0], labeled_seasons[1]
+        train = labeled[labeled["target_season"] == train_season]
+        holdout = labeled[labeled["target_season"] == holdout_season].copy()
+
+        holdout_model = _fit(train)
+        holdout["predicted_ppg_ppr"] = holdout_model.predict(holdout[_FEATURE_COLUMNS])
+        mae = mean_absolute_error(holdout["actual_ppg_ppr"], holdout["predicted_ppg_ppr"])
+        r2 = r2_score(holdout["actual_ppg_ppr"], holdout["predicted_ppg_ppr"])
+        print(
+            f"Holdout eval: trained on target_season={train_season} (n={len(train)}), "
+            f"evaluated out-of-sample on target_season={holdout_season} (n={len(holdout)}) "
+            f"-> MAE={mae:.2f} R2={r2:.2f}"
+        )
+        output_frames.append(holdout)
+    else:
+        print("Fewer than 2 labeled seasons available — skipping holdout evaluation.")
+
+    # Restrict live output to players who actually played in target_season - 1: without that,
+    # a player with no data more recent than 2+ years back (e.g. a retiree like Tom Brady, whose
+    # last game was 2022) still gets extrapolated forward from their old numbers, with nothing in
+    # the feature set signaling they're no longer active. Training/holdout are untouched — a
+    # missing prior-year team there is just a smaller feature signal, not a "don't show this"
+    # judgment call the way it is for the live cohort actually feeding consensus.py.
+    live = df[(df["target_season"] == live_season) & df["team"].notna()].copy()
+    if not labeled.empty:
+        final_model = _fit(labeled)
+        live["predicted_ppg_ppr"] = final_model.predict(live[_FEATURE_COLUMNS])
+    else:
+        live["predicted_ppg_ppr"] = float("nan")
+        print("No labeled seasons available yet — live cohort predictions left null.")
+    output_frames.append(live)
+
+    result = pd.concat(output_frames, ignore_index=True)
+    result["expected_games"] = result["weighted_games_per_season"]
+    result["projected_points"] = result["predicted_ppg_ppr"] * result["expected_games"]
+    result = result[[
+        "player_id", "player_name", "position", "target_season",
+        "predicted_ppg_ppr", "expected_games", "projected_points",
+    ]]
+
+    con = duckdb.connect(str(WAREHOUSE_PATH))
+    con.execute("CREATE OR REPLACE TABLE inhouse_projections AS SELECT * FROM result")
+    (count,) = con.execute("SELECT COUNT(*) FROM inhouse_projections").fetchone()
+    con.close()
+
+    print(f"Built {count} rows into {WAREHOUSE_PATH} (table: inhouse_projections)")
+
+
+if __name__ == "__main__":
+    build_inhouse_projections()

--- a/src/gold/player_baselines.py
+++ b/src/gold/player_baselines.py
@@ -12,6 +12,11 @@ plenty of one-game cameo rows (a Week 18 call-up, a player who tore an ACL in We
 those set a full-weight per-game rate would badly distort the baseline rather than just add noise
 to it.
 
+Alongside the PPG baseline, also outputs a `weighted_games_per_season` durability signal — the
+same recency-weighted average, but of games played rather than points per game — since a player's
+expected next-season games played is itself a useful feature (workload correlates with role) and
+the multiplier needed to turn a PPG prediction into a season-total point projection.
+
 This is a feature-engineering building block, not a projection itself — it's meant to feed a
 future in-house predictive model (prior-year weighted baseline + team context -> next-year PPG).
 """
@@ -92,7 +97,8 @@ SELECT
     m.position,
     COUNT(*) AS seasons_used,
     SUM(h.games_played) AS games_used,
-    SUM(h.ppg_ppr * h.recency_weight) / SUM(h.recency_weight) AS weighted_ppg_ppr
+    SUM(h.ppg_ppr * h.recency_weight) / SUM(h.recency_weight) AS weighted_ppg_ppr,
+    SUM(h.games_played * h.recency_weight) / SUM(h.recency_weight) AS weighted_games_per_season
 FROM history h
 JOIN most_recent_season m
     ON m.target_season = h.target_season AND m.player_id = h.player_id AND m.rn = 1


### PR DESCRIPTION
## Summary
- Adds `src/gold/inhouse_projections.py`: a shift-based `HistGradientBoostingRegressor` model (prior-year `player_weighted_baselines` + prior-season `offensive_line_grades`/`skill_position_grades` as features → next-season PPG), converted to a season-total projection via a recency-weighted games-per-season durability multiplier
- Wires the result into `consensus.py` as a fifth projection source alongside ESPN/Sleeper/CBS/FFToday — no crosswalk join needed, since it's already keyed on the same nflverse GSIS ID space
- `player_baselines.py`: adds `weighted_games_per_season` (same recency weighting as the PPG baseline, applied to games played), used both as a model feature and as the PPG → season-total multiplier
- Restricts the live cohort to players who actually played last season, so a retiree with no recent games (e.g. Tom Brady, whose last game was 2022) doesn't get extrapolated forward from stale history
- Fixes `scripts/build_warehouse.sh`, which previously only ran `consensus` — `offensive_line`, `skill_position_grades`, and `player_baselines` were silently skipped on a from-scratch rebuild. Now runs all four gold modules in dependency order.
- New dependency: `scikit-learn` (+ its transitive deps), pinned in `requirements.txt`

## Test plan
- [x] `python -m src.gold.player_baselines` — `weighted_games_per_season` values look sane (e.g. McCaffrey/Kupp reduced for injury history, iron-man WRs near 16-17)
- [x] `python -m src.gold.inhouse_projections` — holdout eval (trained on 2022, evaluated out-of-sample on 2023): MAE=3.00, R2=0.46; live 2024 cohort top-15 by projected points reads like a real draft board (Tyreek Hill, Lamb, Adams, Allen, Mahomes, Puka Nacua, ...)
- [x] Confirmed the retiree fix: Tom Brady no longer appears in the live 2024 output
- [x] `python -m src.gold.consensus` — `consensus_projections.num_sources` now reaches 5 for well-covered players (e.g. Josh Allen, Jahmyr Gibbs, Bijan Robinson)
- [x] Ran the full gold-layer chain fresh in the new `build_warehouse.sh` order (offensive_line → skill_position_grades → player_baselines → inhouse_projections → consensus) with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)