### PR TITLE
fix: don't blend a stale in-house projection into a current consensus

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,11 @@ network access of their own.
   since defenses aren't in the player crosswalk). Each is a median/floor (20th percentile)/
   ceiling (80th percentile) PPR projection per player or team, aggregated across every
   independent projection source above (ESPN, Sleeper/RotoWire, FFToday, CBS) plus the in-house
-  model below. Pure SQL over already-loaded tables — no fetch step, no network.
+  model below. The in-house model's contribution is scoped to the season the other four sources
+  actually represent (derived from their own data), not its own most-recent `target_season` —
+  nflverse-fed `inhouse_projections` can lag the external sites' current-season projections, so a
+  stale in-house number drops out of the blend instead of silently mixing with four current ones.
+  Pure SQL over already-loaded tables — no fetch step, no network.
 - `src/gold/offensive_line.py` — builds `offensive_line_grades`: a per-team-per-season 0-100
   offensive line grade from PFR's advanced pass/rush stats, combining pass-block (QB pressure
   rate allowed, weighted by pass attempts) and run-block (RB/FB yards before contact per rush

--- a/src/gold/consensus.py
+++ b/src/gold/consensus.py
@@ -11,6 +11,14 @@ Two output tables, because team defenses need a different join key than individu
   the same nflverse GSIS ID space), so it's unioned in directly with no crosswalk join.
 - consensus_dst_projections: team defenses, joined on a normalized team abbreviation (see
   teams.py) instead, since `ids` is player-level and has no team-defense entries.
+
+inhouse_projections can lag behind the other four sources: its prior-year feature data comes from
+nflverse, which publishes noticeably slower than the external sites' own current-season
+projections, so its latest `target_season` isn't guaranteed to be the season the other four
+sources actually represent. consensus_projections' inhouse arm is scoped to that season (derived
+from the external sources themselves), not inhouse's own `MAX(target_season)` — otherwise a stale
+inhouse projection would get silently blended in alongside four current ones under the same
+player, dragging the consensus toward last season's number with no signal that anything was off.
 """
 
 from pathlib import Path
@@ -45,6 +53,20 @@ WITH ids_normalized AS (
            CASE WHEN position = 'PK' THEN 'K' ELSE position END AS position
     FROM ids
 ),
+-- The season the other four sources actually represent (sleeper_projections.season is text,
+-- everyone else's is already numeric) — see module docstring for why inhouse_projections is
+-- matched against this instead of its own MAX(target_season).
+current_season AS (
+    SELECT MAX(season) AS season FROM (
+        SELECT MAX(season) AS season FROM espn_projections
+        UNION ALL
+        SELECT MAX(TRY_CAST(season AS BIGINT)) AS season FROM sleeper_projections
+        UNION ALL
+        SELECT MAX(season) AS season FROM cbs_projections
+        UNION ALL
+        SELECT MAX(season) AS season FROM fftoday_projections
+    )
+),
 source_projections AS (
     SELECT ids.gsis_id, ids.name AS player_name, ids.position, 'espn' AS source,
            e.projected_points
@@ -77,11 +99,12 @@ source_projections AS (
 
     -- No ids crosswalk join here (see module docstring) and no position-matching safety net
     -- either — that guards against ids' duplicate-external-ID problem, which doesn't apply since
-    -- this source never goes through ids at all. Scoped to the live target_season, i.e. the one
-    -- cohort inhouse_projections.py actually predicts (rather than backtests).
+    -- this source never goes through ids at all. Scoped to current_season, not inhouse's own
+    -- MAX(target_season) — if inhouse hasn't caught up to the season the other sources represent,
+    -- it drops out of the blend entirely rather than contributing a stale number.
     SELECT player_id, player_name, position, 'inhouse', projected_points
     FROM inhouse_projections
-    WHERE target_season = (SELECT MAX(target_season) FROM inhouse_projections)
+    WHERE target_season = (SELECT season FROM current_season)
 )
 SELECT
     gsis_id,


### PR DESCRIPTION
## Summary
- `consensus_projections`' in-house arm was scoped to `inhouse_projections`' own `MAX(target_season)`, with no check against what season the other four sources (ESPN/Sleeper/CBS/FFToday) actually represent.
- Those sites publish current-season projections well before nflverse publishes the prior season's weekly stats that `inhouse_projections` needs as input, so in-house can silently lag a full year behind — and when it does, its stale number was still getting unioned in under the same `gsis_id`, dragging the blended floor/median/ceiling toward last season's value with no signal anything was off.
- Found while validating a new `breakout_candidates` model on a sibling branch: the four external sources already carry `season=2026` projections, but `inhouse_projections` is still stuck on `target_season=2025` (nflverse hasn't published 2025 weekly stats yet).
- Fix: derive `current_season` from the other four sources themselves and require `inhouse_projections.target_season` to match before including it. If it doesn't match, in-house drops out of that build's blend entirely rather than contributing a number from a different season.

## Verification
- [x] Confirmed on real warehouse data: Gibbs/Bijan/Chase all had `num_sources=5` with the in-house value sitting at or near the blended floor before this fix.
- [x] After the fix, `num_sources` drops to 4 for those rows and the floor rises to reflect only current-season sources (e.g. Bijan's range went from 290.8–398.8 to 353.0–398.8).
- [x] Ran `python -m src.gold.consensus` end-to-end with no errors; row count dropped from 770 → 640 (players whose *only* source was the now-excluded stale in-house row disappear entirely, which is correct — no consensus can be formed from zero current-season sources).

🤖 Generated with [Claude Code](https://claude.com/claude-code)