### PR TITLE
feat: points-over-replacement, boom/bust, and ADP-blind breakout candidates

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,15 @@ network access of their own.
   `src/gold` module that isn't pure SQL (Python/pandas/scikit-learn over already-loaded tables
   instead), and the only one with a genuine train/holdout split, printing out-of-sample MAE/R2 on
   each run. Feeds into `consensus.py` as a fifth projection source.
+- `src/gold/points_over_replacement.py` — builds `points_over_replacement`: each skill-position
+  player's season-total fantasy points, recomputed from nflverse weekly stats under each league's
+  own `league_settings` scoring coefficients (not nflverse's canned PPR formula), minus that
+  league-season-position's replacement level. Replacement level is a combined-flex-pool
+  Value-Based-Drafting calculation: dedicated starters (`team_count x slots`) are filled first per
+  position, then whatever's left over from RB/WR/TE is pooled, ranked by points, and FLEX slots are
+  filled from that pool regardless of position — so a position that wins more flex spots in a given
+  season automatically gets a deeper replacement level, with no hardcoded split. Pure SQL/Python
+  over already-loaded tables — no fetch step, no network.
 
 ## Environment
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,15 @@ network access of their own.
   filled from that pool regardless of position — so a position that wins more flex spots in a given
   season automatically gets a deeper replacement level, with no hardcoded split. Pure SQL/Python
   over already-loaded tables — no fetch step, no network.
+- `src/gold/boom_bust.py` — builds `boom_bust`: classifies each skill-position player-season into
+  a preseason-ADP-relative outcome bucket (Boomed/Returned on ADP/Fine/Busted/Got Injured/No
+  Preseason ADP), by converting both `points_over_replacement` and `adp_consensus`'s
+  `consensus_adp` into percentiles within the same season-position pool of ADP-tracked players, so
+  the comparison is scoring-format- and league-size-independent rather than a fixed PPG number or
+  ADP-spot count. Boom/Bust/Fine/Returned split at symmetric +/-20-percentile-point bands around
+  "met expectation"; fewer than 12 games played overrides those bands as Got Injured, but only for
+  players who had preseason draft capital to begin with. Pure SQL over already-loaded tables — no
+  fetch step, no network.
 
 ## Environment
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,16 @@ network access of their own.
   `weighted_games_per_season`, the same recency-weighted average applied to games played instead —
   a durability signal. A feature-engineering building block, not a projection itself. Pure SQL
   over already-loaded tables — no fetch step, no network.
+- `src/gold/league_settings.py` — builds `league_settings`: one row per league (Sleeper, ESPN)
+  normalizing each platform's scoring rules (points per reception/yard/TD/turnover, etc.) and
+  starting-roster construction (team count and QB/RB/WR/TE/FLEX/superflex/bench/IR slot counts)
+  into a shared schema. Sleeper's settings arrive as flat columns; ESPN's arrive as a nested array
+  of `{statId, points}` items and a slot-id-keyed lineup dict, both keyed by undocumented numeric
+  IDs (mapped here using the cwendt94/espn-api project's reference tables, spot-checked against
+  this league's actual raw settings). Exists so scoring-sensitive models (e.g. league-winning-RB
+  thresholds, points-over-replacement) can run one formula per league and get a league-appropriate
+  number back instead of a constant tuned to one scoring format. Pure SQL/Python over already-
+  loaded tables — no fetch step, no network.
 - `src/gold/inhouse_projections.py` — builds `inhouse_projections`: a home-grown PPG projection
   from a gradient-boosted model (scikit-learn's `HistGradientBoostingRegressor`), trained on a
   shift-based setup — `player_weighted_baselines` plus prior-season `offensive_line_grades`/

--- a/README.md
+++ b/README.md
@@ -138,6 +138,16 @@ network access of their own.
   "met expectation"; fewer than 12 games played overrides those bands as Got Injured, but only for
   players who had preseason draft capital to begin with. Pure SQL over already-loaded tables — no
   fetch step, no network.
+- `src/gold/breakout_candidates.py` — builds `breakout_candidates`: ranks `inhouse_projections`'
+  already-ADP-blind prediction into a position-relative percentile per target season and lines it
+  up against `adp_consensus`'s preseason percentile, so a player the model likes that the real-world
+  draft market doesn't (or hasn't seen at all — `consensus_adp` stays NULL rather than being
+  coerced to a default) shows up directly as a high `predicted_delta`. League-agnostic by design —
+  ranks `inhouse_projections`' raw PPG-based projection as-is rather than retraining against either
+  league's own scoring the way `points_over_replacement`/`boom_bust` do. No bucketing and no
+  games-played check the way `boom_bust` has, since both describe an *actual* outcome that, for the
+  live target season, hasn't happened yet — `predicted_delta` is left as a continuous score to
+  sort/filter directly. Pure SQL over already-loaded tables — no fetch step, no network.
 
 ## Environment
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,10 @@ network access of their own.
   season-total point projection via the `weighted_games_per_season` durability signal. The only
   `src/gold` module that isn't pure SQL (Python/pandas/scikit-learn over already-loaded tables
   instead), and the only one with a genuine train/holdout split, printing out-of-sample MAE/R2 on
-  each run. Feeds into `consensus.py` as a fifth projection source.
+  each run, alongside out-of-sample permutation feature importance — which preseason signals
+  (recency-weighted history, durability, OL/skill-position grades) actually move the prediction,
+  not just which ones are in the feature list. Feeds into `consensus.py` as a fifth projection
+  source.
 - `src/gold/points_over_replacement.py` — builds `points_over_replacement`: each skill-position
   player's season-total fantasy points, recomputed from nflverse weekly stats under each league's
   own `league_settings` scoring coefficients (not nflverse's canned PPR formula), minus that

--- a/README.md
+++ b/README.md
@@ -35,7 +35,20 @@ network access of their own.
 - `src/silver/fantasypros.py` — FantasyPros consensus expert rankings (ECR): preseason overall
   draft rankings (standard/half-PPR/PPR) and in-season weekly rankings by position. No auth
   required; extracts the `ecrData` JSON embedded in FantasyPros' rankings pages, since they don't
-  offer a free public API. Set `current_week` in the module before running in-season.
+  offer a free public API. Set `current_week` in the module before running in-season. Also loads
+  `fantasypros_adp`: historical average draft position by season, from CSVs manually downloaded
+  from FantasyPros' ADP page (a client-rendered app with no embeddable data, unlike the rankings
+  pages) and dropped into `data/raw/fantasypros/` — the one silver table in this warehouse with a
+  human "fetch" step instead of a network call. `team`/`bye` reflect the player's team as of
+  whenever the CSV was downloaded, not their actual historical team that season, and are sparse
+  for older seasons (FantasyPros' own archive quality); the ADP rank/value itself is genuine
+  historical data.
+- `src/silver/fantasyfootballcalculator.py` — FantasyFootballCalculator's historical ADP by
+  scoring format (standard/half-PPR/PPR) and season, back to 2015, via FFC's free public JSON API.
+  No auth required. FFC's `teams` query parameter is cosmetic — verified it returns identical
+  underlying ADP values regardless of team count — so this is one pooled dataset per format/season,
+  not genuinely split by league size. A second, independent ADP source alongside
+  `fantasypros_adp`, so no single source's platform-specific bias dominates.
 - `src/silver/fftoday.py` — FFToday's own season-long fantasy point projections (standard/half-PPR/
   PPR) by position, including DST. No auth required; parses the plain HTML projections table,
   since FFToday doesn't offer an API. Rate-limits aggressive scraping, so requests are spaced out.
@@ -46,6 +59,10 @@ network access of their own.
   projection site represents team defenses differently (a full name, a bare nickname, or a
   non-canonical abbreviation like "LAR"); this maps any of those to the abbreviation nflverse
   uses elsewhere in this warehouse (e.g. "LA" for the Rams), so DST rows can be joined by team.
+- `src/silver/players.py` — shared player-name normalizer, not a data source itself. Reproduces
+  nflverse's own `merge_name` convention (lowercase, strip punctuation/suffixes) closely enough to
+  join FantasyPros'/FFC's free-text ADP names onto the `ids` crosswalk's `merge_name`, for sources
+  that carry no platform ID the crosswalk already knows.
 
 ## Proprietary models (`src/gold/`)
 
@@ -56,6 +73,15 @@ network access of their own.
   ceiling (80th percentile) PPR projection per player or team, aggregated across every
   independent projection source above (ESPN, Sleeper/RotoWire, FFToday, CBS) plus the in-house
   model below. Pure SQL over already-loaded tables — no fetch step, no network.
+- `src/gold/adp_consensus.py` — builds `adp_consensus`: a consensus average draft position per
+  player-season (QB/RB/WR/TE), blending `fantasypros_adp` and `ffc_adp` (FantasyFootballCalculator,
+  PPR format) onto a shared `gsis_id` via the `merge_name` normalization in `players.py`, since
+  neither ADP source carries a platform ID the nflverse crosswalk already knows the way ESPN/
+  Sleeper/CBS projections do in `consensus.py`. Each site counts as one vote regardless of how many
+  scoring formats it offers — FFC's standard/half-PPR numbers are kept as their own columns for
+  reference but excluded from the blend, so one site's multiple formats can't outvote the other
+  site's single blended number. Pure SQL/Python over already-loaded tables — no fetch step, no
+  network.
 - `src/gold/offensive_line.py` — builds `offensive_line_grades`: a per-team-per-season 0-100
   offensive line grade from PFR's advanced pass/rush stats, combining pass-block (QB pressure
   rate allowed, weighted by pass attempts) and run-block (RB/FB yards before contact per rush

--- a/src/gold/adp_consensus.py
+++ b/src/gold/adp_consensus.py
@@ -1,0 +1,91 @@
+"""Build a consensus ADP table blending FantasyPros' and FantasyFootballCalculator's historical
+average draft position onto one shared `gsis_id`.
+
+Pure warehouse-to-warehouse SQL/Python — no fetch step, no network. Built from `fantasypros_adp`
+and `ffc_adp` (already loaded by fantasypros.py's load_adp_manual / fantasyfootballcalculator.py),
+resolved onto the nflverse player crosswalk (`ids`, loaded by nfl_data.py) via the `merge_name`
+normalization in players.py, since neither ADP source carries a platform ID `ids` already knows
+the way ESPN/Sleeper/CBS projections do in consensus.py.
+
+Scoped to skill positions (QB/RB/WR/TE) only — team defenses aren't in the player crosswalk at
+all (see consensus.py's DST split), and aren't relevant to the RB-focused work this table exists
+for.
+
+Each source counts as one vote regardless of how many scoring formats it offers: FantasyPros
+contributes its single blended (format-unlabeled) ADP, and FFC contributes its PPR-format ADP
+specifically (the most complete FFC format across all seasons — half-PPR has no data before
+2018). FFC's standard/half-PPR numbers are still exposed as their own columns for reference, but
+excluded from `consensus_adp` so a single site's multiple formats can't outvote the other site's
+one blended number.
+"""
+
+from pathlib import Path
+
+import duckdb
+
+from src.silver.players import merge_name
+
+WAREHOUSE_PATH = Path("data/warehouse.duckdb")
+
+_SKILL_POSITIONS = ("QB", "RB", "WR", "TE")
+
+_BUILD_SQL = f"""
+CREATE OR REPLACE TABLE adp_consensus AS
+WITH ids_normalized AS (
+    SELECT gsis_id, name, merge_name,
+           CASE WHEN position = 'PK' THEN 'K' ELSE position END AS position
+    FROM ids
+),
+fp_resolved AS (
+    SELECT ids.gsis_id, ids.name, ids.position, fp.season, fp.adp AS fantasypros_adp
+    FROM fantasypros_adp fp
+    JOIN ids_normalized ids
+        ON ids.merge_name = to_merge_name(fp.name) AND ids.position = fp.position
+    WHERE fp.position IN {_SKILL_POSITIONS}
+),
+ffc_resolved AS (
+    SELECT
+        ids.gsis_id, ids.name, ids.position, f.season,
+        MAX(CASE WHEN f.scoring_format = 'standard' THEN f.adp END) AS ffc_adp_standard,
+        MAX(CASE WHEN f.scoring_format = 'half-ppr' THEN f.adp END) AS ffc_adp_half_ppr,
+        MAX(CASE WHEN f.scoring_format = 'ppr' THEN f.adp END) AS ffc_adp_ppr
+    FROM ffc_adp f
+    JOIN ids_normalized ids
+        ON ids.merge_name = to_merge_name(f.name) AND ids.position = f.position
+    WHERE f.position IN {_SKILL_POSITIONS}
+    GROUP BY ids.gsis_id, ids.name, ids.position, f.season
+)
+SELECT
+    COALESCE(fp.gsis_id, ffc.gsis_id) AS gsis_id,
+    COALESCE(fp.name, ffc.name) AS player_name,
+    COALESCE(fp.position, ffc.position) AS position,
+    COALESCE(fp.season, ffc.season) AS season,
+    fp.fantasypros_adp,
+    ffc.ffc_adp_standard,
+    ffc.ffc_adp_half_ppr,
+    ffc.ffc_adp_ppr,
+    CASE
+        WHEN fp.fantasypros_adp IS NOT NULL AND ffc.ffc_adp_ppr IS NOT NULL
+            THEN (fp.fantasypros_adp + ffc.ffc_adp_ppr) / 2
+        ELSE COALESCE(fp.fantasypros_adp, ffc.ffc_adp_ppr)
+    END AS consensus_adp,
+    (CASE WHEN fp.fantasypros_adp IS NOT NULL THEN 1 ELSE 0 END)
+        + (CASE WHEN ffc.ffc_adp_ppr IS NOT NULL THEN 1 ELSE 0 END) AS num_sources
+FROM fp_resolved fp
+FULL OUTER JOIN ffc_resolved ffc ON fp.gsis_id = ffc.gsis_id AND fp.season = ffc.season
+"""
+
+
+def build_adp_consensus() -> None:
+    con = duckdb.connect(str(WAREHOUSE_PATH))
+    con.create_function("to_merge_name", merge_name, ["VARCHAR"], "VARCHAR")
+
+    con.execute(_BUILD_SQL)
+    (count,) = con.execute("SELECT COUNT(*) FROM adp_consensus").fetchone()
+    con.close()
+
+    print(f"Built {count} rows into {WAREHOUSE_PATH} (table: adp_consensus)")
+
+
+if __name__ == "__main__":
+    build_adp_consensus()

--- a/src/gold/boom_bust.py
+++ b/src/gold/boom_bust.py
@@ -1,0 +1,117 @@
+"""Classify each player-season into a preseason-ADP-relative outcome bucket.
+
+Pure warehouse-to-warehouse SQL — no fetch step, no network. Built from `points_over_replacement`
+(already built by points_over_replacement.py) and `adp_consensus` (already built by
+adp_consensus.py).
+
+Step 3 of the "league-winning RB" idea: turns each player's replacement-level outcome and their
+preseason draft capital into percentiles within their season's position pool, so both are
+comparable across leagues (different team counts) and scoring formats without a hardcoded PPG or
+ADP-spot-count constant. `points_over_replacement` is ranked within (league_key, season, position)
+since replacement level is league-specific; `adp_consensus`'s `consensus_adp` is ranked within
+(season, position) only, since ADP reflects the real-world draft market rather than either
+league's scoring rules.
+
+Both percentiles are computed over the *same* reference population: players with a preseason
+`consensus_adp` that season/position. `points_over_replacement` on its own is much deeper than the
+ADP-tracked pool (e.g. 135 RBs recorded a stat somewhere in the 2024 season vs. 93 that any ADP
+source tracked as draftable) — ranking the actual-outcome side against that full, scrub-padded
+pool while ranking the preseason side against the narrower ADP pool would systematically inflate
+everyone's percentile_delta upward (more players below you in a bigger pool isn't the same as
+actually outperforming your draft slot). Players with no preseason ADP are bucketed separately
+below rather than assigned a percentile at all.
+
+Outcome buckets mirror the five archetypes from the source idea, made format-agnostic by using
+percentile movement instead of a fixed PPG number or ADP-spot count:
+- No Preseason ADP: no `consensus_adp` that season, so there's no preseason expectation to compare
+  against (mostly waiver-wire adds no source tracked as draftable) — checked first, ahead of the
+  games-played bar below, since "Got Injured" is only a meaningful label for someone who was
+  actually expected to contribute; most sub-12-game players in this table are just replacement-
+  level scrubs who were never fantasy-relevant, not fallen stars.
+- Got Injured: had preseason ADP but played fewer than 12 games (this project's own bar for a
+  "full" season, reused from the source idea rather than inventing a new number) — overrides the
+  percentile-movement buckets below, since a shortened season explains the outcome rather than
+  reflecting a skill/value read.
+- Boomed / Returned on ADP / Fine / Busted: a symmetric +/-20-percentile-point band around "met
+  expectation" (delta 0), translating the source idea's "beat/lost by 10 ADP spots" into a
+  scoring-format- and league-size-independent unit. "Fine" (mild underperformance) and "Returned on
+  ADP" (met or modestly beat expectation) split at delta 0, mirroring the source idea's own
+  asymmetric shape ("lost 1-9 spots" vs. meeting-or-beating ADP).
+"""
+
+from pathlib import Path
+
+import duckdb
+
+WAREHOUSE_PATH = Path("data/warehouse.duckdb")
+
+# Percentile-points of preseason-vs-actual movement that counts as a genuine boom/bust rather than
+# year-to-year noise.
+_BOOM_BUST_THRESHOLD = 0.20
+
+# Reused from the source idea's own qualifier for a "full" season: fewer games than this is
+# "Got Injured" regardless of percentile movement.
+_MIN_GAMES_FOR_OUTCOME = 12
+
+_BUILD_SQL = f"""
+CREATE OR REPLACE TABLE boom_bust AS
+WITH preseason AS (
+    SELECT
+        gsis_id, season, position, consensus_adp,
+        PERCENT_RANK() OVER (
+            PARTITION BY season, position ORDER BY consensus_adp DESC
+        ) AS preseason_percentile
+    FROM adp_consensus
+    WHERE consensus_adp IS NOT NULL
+),
+tracked AS (
+    SELECT
+        por.league_key, por.season, por.player_id, por.player_name, por.position,
+        por.games_played, por.points_over_replacement,
+        pre.consensus_adp, pre.preseason_percentile,
+        PERCENT_RANK() OVER (
+            PARTITION BY por.league_key, por.season, por.position
+            ORDER BY por.points_over_replacement ASC
+        ) AS actual_percentile
+    FROM points_over_replacement por
+    JOIN preseason pre
+        ON pre.gsis_id = por.player_id AND pre.season = por.season AND pre.position = por.position
+),
+untracked AS (
+    SELECT
+        por.league_key, por.season, por.player_id, por.player_name, por.position,
+        por.games_played, por.points_over_replacement,
+        CAST(NULL AS DOUBLE) AS consensus_adp, CAST(NULL AS DOUBLE) AS preseason_percentile,
+        CAST(NULL AS DOUBLE) AS actual_percentile
+    FROM points_over_replacement por
+    WHERE NOT EXISTS (
+        SELECT 1 FROM preseason pre
+        WHERE pre.gsis_id = por.player_id AND pre.season = por.season AND pre.position = por.position
+    )
+)
+SELECT
+    *,
+    actual_percentile - preseason_percentile AS percentile_delta,
+    CASE
+        WHEN preseason_percentile IS NULL THEN 'No Preseason ADP'
+        WHEN games_played < {_MIN_GAMES_FOR_OUTCOME} THEN 'Got Injured'
+        WHEN actual_percentile - preseason_percentile >= {_BOOM_BUST_THRESHOLD} THEN 'Boomed'
+        WHEN actual_percentile - preseason_percentile <= -{_BOOM_BUST_THRESHOLD} THEN 'Busted'
+        WHEN actual_percentile - preseason_percentile < 0 THEN 'Fine'
+        ELSE 'Returned on ADP'
+    END AS outcome_bucket
+FROM (SELECT * FROM tracked UNION ALL SELECT * FROM untracked)
+"""
+
+
+def build_boom_bust() -> None:
+    con = duckdb.connect(str(WAREHOUSE_PATH))
+    con.execute(_BUILD_SQL)
+    (count,) = con.execute("SELECT COUNT(*) FROM boom_bust").fetchone()
+    con.close()
+
+    print(f"Built {count} rows into {WAREHOUSE_PATH} (table: boom_bust)")
+
+
+if __name__ == "__main__":
+    build_boom_bust()

--- a/src/gold/breakout_candidates.py
+++ b/src/gold/breakout_candidates.py
@@ -1,0 +1,73 @@
+"""Compare in-house predicted value against preseason ADP to surface ADP-blind breakout candidates.
+
+Pure warehouse-to-warehouse SQL — no fetch step, no network. Built from `inhouse_projections`
+(already built by inhouse_projections.py) and `adp_consensus` (already built by adp_consensus.py).
+
+`inhouse_projections` already predicts every player's next-season value with zero ADP as an
+input — this table's only job is to rank that prediction into a position-relative percentile and
+line it up against where the real-world draft market expects the same player to go, so a player
+the model likes but ADP doesn't know about (or ranks low) is directly visible as
+`predicted_delta`, rather than the model's opinion only ever being checked against itself.
+
+League-agnostic by design: ranks `inhouse_projections`' existing PPG-based `projected_points`
+as-is rather than retraining against either league's own scoring (the way
+`points_over_replacement`/`boom_bust` do) — "will this player be good" is a talent/production
+question that doesn't hinge on half-PPR-vs-full-PPR scoring nuance, so one number per player-season
+rather than one per league.
+
+Unlike `boom_bust.py`, there's no bucketing into Boom/Bust labels and no games-played/injury check —
+both describe an *actual* outcome that, for `inhouse_projections`' live target_season, hasn't
+happened yet. `predicted_delta` is deliberately left as a continuous score (and left NULL for
+players with no preseason ADP at all) for the caller to sort/filter — a high `predicted_delta`
+paired with a NULL or deep `consensus_adp` is exactly the "ADP hasn't caught up to this player"
+signal being asked for.
+"""
+
+from pathlib import Path
+
+import duckdb
+
+WAREHOUSE_PATH = Path("data/warehouse.duckdb")
+
+_BUILD_SQL = """
+CREATE OR REPLACE TABLE breakout_candidates AS
+WITH preseason AS (
+    SELECT
+        gsis_id, season, position, consensus_adp,
+        PERCENT_RANK() OVER (
+            PARTITION BY season, position ORDER BY consensus_adp DESC
+        ) AS preseason_percentile
+    FROM adp_consensus
+    WHERE consensus_adp IS NOT NULL
+),
+predicted AS (
+    SELECT
+        player_id, player_name, position, target_season, projected_points,
+        PERCENT_RANK() OVER (
+            PARTITION BY target_season, position ORDER BY projected_points ASC
+        ) AS predicted_percentile
+    FROM inhouse_projections
+    WHERE projected_points IS NOT NULL
+)
+SELECT
+    p.target_season, p.player_id, p.player_name, p.position, p.projected_points,
+    p.predicted_percentile,
+    pre.consensus_adp, pre.preseason_percentile,
+    p.predicted_percentile - pre.preseason_percentile AS predicted_delta
+FROM predicted p
+LEFT JOIN preseason pre
+    ON pre.gsis_id = p.player_id AND pre.season = p.target_season AND pre.position = p.position
+"""
+
+
+def build_breakout_candidates() -> None:
+    con = duckdb.connect(str(WAREHOUSE_PATH))
+    con.execute(_BUILD_SQL)
+    (count,) = con.execute("SELECT COUNT(*) FROM breakout_candidates").fetchone()
+    con.close()
+
+    print(f"Built {count} rows into {WAREHOUSE_PATH} (table: breakout_candidates)")
+
+
+if __name__ == "__main__":
+    build_breakout_candidates()

--- a/src/gold/inhouse_projections.py
+++ b/src/gold/inhouse_projections.py
@@ -38,6 +38,7 @@ from pathlib import Path
 import duckdb
 import pandas as pd
 from sklearn.ensemble import HistGradientBoostingRegressor
+from sklearn.inspection import permutation_importance
 from sklearn.metrics import mean_absolute_error, r2_score
 
 from src.gold.player_baselines import _MIN_GAMES_PLAYED, _SKILL_POSITIONS
@@ -156,6 +157,21 @@ def build_inhouse_projections() -> None:
             f"evaluated out-of-sample on target_season={holdout_season} (n={len(holdout)}) "
             f"-> MAE={mae:.2f} R2={r2:.2f}"
         )
+
+        # Out-of-sample (on the holdout, not train) so a feature the model overfit to doesn't look
+        # important just because it memorized train-set noise. Answers "do the team-context signals
+        # (ol_grade/skill_grade) actually carry weight" rather than assuming they do because they're
+        # in the feature list.
+        importances = permutation_importance(
+            holdout_model, holdout[_FEATURE_COLUMNS], holdout["actual_ppg_ppr"],
+            n_repeats=20, random_state=0,
+        )
+        ranked_importances = sorted(
+            zip(_FEATURE_COLUMNS, importances.importances_mean), key=lambda x: -x[1]
+        )
+        importance_str = ", ".join(f"{name}={score:.3f}" for name, score in ranked_importances)
+        print(f"Permutation feature importance (mean R2 drop when shuffled): {importance_str}")
+
         output_frames.append(holdout)
     else:
         print("Fewer than 2 trainable labeled seasons available — skipping holdout evaluation.")

--- a/src/gold/inhouse_projections.py
+++ b/src/gold/inhouse_projections.py
@@ -55,6 +55,14 @@ _FEATURE_COLUMNS = _BASE_FEATURES + [f"position_{p}" for p in _SKILL_POSITIONS]
 # there is.
 _MODEL_PARAMS = dict(max_depth=3, min_samples_leaf=15, learning_rate=0.1, random_state=0)
 
+# offensive_line_grades needs target_season - 1 >= 2018 (PFR advanced stats' own floor) before it
+# has any non-null values at all. Picking an earlier target_season as the single-season holdout
+# training slice would hand it a feature column that's 100% missing rather than just sparse, which
+# breaks HistGradientBoostingRegressor's binning outright. The final live-season model further
+# down still trains on every labeled season combined (pre-2019 ones included), since per-row (not
+# per-column) missingness there is exactly what skill_grade already looks like for every QB row.
+_MIN_TRAIN_SEASON_WITH_TEAM_CONTEXT = 2019
+
 # player_team resolves each player's most-played team in a season (mirrors the
 # team_by_player_season pattern in skill_position_grades.py, over weekly_stats instead of
 # ngs_data), so team context can be joined in as of target_season - 1.
@@ -129,12 +137,13 @@ def build_inhouse_projections() -> None:
     df = _add_position_dummies(df)
     labeled = df[df["actual_ppg_ppr"].notna()].sort_values("target_season")
     labeled_seasons = sorted(labeled["target_season"].unique())
+    trainable_seasons = [s for s in labeled_seasons if s >= _MIN_TRAIN_SEASON_WITH_TEAM_CONTEXT]
     live_season = df["target_season"].max()
 
     output_frames = []
 
-    if len(labeled_seasons) >= 2:
-        train_season, holdout_season = labeled_seasons[0], labeled_seasons[1]
+    if len(trainable_seasons) >= 2:
+        train_season, holdout_season = trainable_seasons[0], trainable_seasons[1]
         train = labeled[labeled["target_season"] == train_season]
         holdout = labeled[labeled["target_season"] == holdout_season].copy()
 
@@ -149,7 +158,7 @@ def build_inhouse_projections() -> None:
         )
         output_frames.append(holdout)
     else:
-        print("Fewer than 2 labeled seasons available — skipping holdout evaluation.")
+        print("Fewer than 2 trainable labeled seasons available — skipping holdout evaluation.")
 
     # Restrict live output to players who actually played in target_season - 1: without that,
     # a player with no data more recent than 2+ years back (e.g. a retiree like Tom Brady, whose

--- a/src/gold/league_settings.py
+++ b/src/gold/league_settings.py
@@ -1,0 +1,165 @@
+"""Normalize each league's scoring rules and starting-roster construction into one shared table.
+
+Pure warehouse-to-warehouse Python/SQL — no fetch step, no network. Built from `sleeper_league`
+and `espn_league` (already loaded by sleeper.py's/espn.py's load_league).
+
+Sleeper's league settings arrive as flat columns (`scoring_settings.rec`, etc.) and a plain list
+of roster slot codes (`roster_positions`). ESPN's arrive as a nested array of `{statId, points}`
+scoring items and a slot-id-keyed lineup count dict, both keyed by numeric IDs ESPN doesn't
+document anywhere. The statId/slot-id mappings below come from the widely-used cwendt94/espn-api
+project's `SETTINGS_SCORING_FORMAT_MAP`/`POSITION_MAP`, and have been spot-checked against this
+league's actual raw scoring items (statId 53 = 1.0 points, confirming full PPR).
+
+Downstream models that care about "how many points is a lot" (e.g. league-winning-RB thresholds,
+points-over-replacement) can join against this table and get a league-appropriate number instead
+of hardcoding a constant tuned to one scoring format.
+"""
+
+import ast
+from collections import Counter
+from pathlib import Path
+
+import duckdb
+import pandas as pd
+
+WAREHOUSE_PATH = Path("data/warehouse.duckdb")
+
+# ESPN's numeric stat IDs -> our normalized scoring column names.
+_ESPN_STAT_IDS = {
+    "pass_yd_pts": 3,
+    "pass_td_pts": 4,
+    "pass_2pt_pts": 19,
+    "pass_int_pts": 20,
+    "rush_yd_pts": 24,
+    "rush_td_pts": 25,
+    "rush_2pt_pts": 26,
+    "rec_pts": 53,
+    "rec_yd_pts": 42,
+    "rec_td_pts": 43,
+    "rec_2pt_pts": 44,
+    "fum_lost_pts": 72,
+}
+
+# ESPN's numeric lineup slot IDs -> our normalized roster slot columns. Slot 7 ("OP") is ESPN's
+# superflex slot (QB eligible); slot 23 ("RB/WR/TE") is the standard non-QB flex.
+_ESPN_SLOT_IDS = {
+    "qb_slots": "0",
+    "rb_slots": "2",
+    "wr_slots": "4",
+    "te_slots": "6",
+    "flex_slots": "23",
+    "superflex_slots": "7",
+    "k_slots": "17",
+    "dst_slots": "16",
+    "bench_slots": "20",
+    "ir_slots": "21",
+}
+
+_COLUMNS = [
+    "league_key", "platform", "league_id", "season", "team_count",
+    "rec_pts", "pass_yd_pts", "pass_td_pts", "pass_2pt_pts", "pass_int_pts",
+    "rush_yd_pts", "rush_td_pts", "rush_2pt_pts",
+    "rec_yd_pts", "rec_td_pts", "rec_2pt_pts", "fum_lost_pts",
+    "qb_slots", "rb_slots", "wr_slots", "te_slots", "flex_slots", "superflex_slots",
+    "k_slots", "dst_slots", "bench_slots", "ir_slots",
+]
+
+
+def _sleeper_settings(con: duckdb.DuckDBPyConnection) -> dict:
+    row = con.sql("""
+        SELECT
+            "league_id" AS league_id,
+            "season" AS season,
+            "settings.num_teams" AS team_count,
+            "roster_positions" AS roster_positions,
+            "scoring_settings.rec" AS rec_pts,
+            "scoring_settings.pass_yd" AS pass_yd_pts,
+            "scoring_settings.pass_td" AS pass_td_pts,
+            "scoring_settings.pass_2pt" AS pass_2pt_pts,
+            "scoring_settings.pass_int" AS pass_int_pts,
+            "scoring_settings.rush_yd" AS rush_yd_pts,
+            "scoring_settings.rush_td" AS rush_td_pts,
+            "scoring_settings.rush_2pt" AS rush_2pt_pts,
+            "scoring_settings.rec_yd" AS rec_yd_pts,
+            "scoring_settings.rec_td" AS rec_td_pts,
+            "scoring_settings.rec_2pt" AS rec_2pt_pts,
+            "scoring_settings.fum_lost" AS fum_lost_pts
+        FROM sleeper_league
+    """).df().iloc[0]
+
+    slots = Counter(row["roster_positions"])
+    return {
+        "league_key": "sleeper",
+        "platform": "sleeper",
+        "league_id": str(row["league_id"]),
+        "season": int(row["season"]),
+        "team_count": int(row["team_count"]),
+        "rec_pts": row["rec_pts"],
+        "pass_yd_pts": row["pass_yd_pts"],
+        "pass_td_pts": row["pass_td_pts"],
+        "pass_2pt_pts": row["pass_2pt_pts"],
+        "pass_int_pts": row["pass_int_pts"],
+        "rush_yd_pts": row["rush_yd_pts"],
+        "rush_td_pts": row["rush_td_pts"],
+        "rush_2pt_pts": row["rush_2pt_pts"],
+        "rec_yd_pts": row["rec_yd_pts"],
+        "rec_td_pts": row["rec_td_pts"],
+        "rec_2pt_pts": row["rec_2pt_pts"],
+        "fum_lost_pts": row["fum_lost_pts"],
+        "qb_slots": slots.get("QB", 0),
+        "rb_slots": slots.get("RB", 0),
+        "wr_slots": slots.get("WR", 0),
+        "te_slots": slots.get("TE", 0),
+        "flex_slots": slots.get("FLEX", 0),
+        "superflex_slots": slots.get("SUPER_FLEX", 0),
+        "k_slots": slots.get("K", 0),
+        "dst_slots": slots.get("DEF", 0),
+        "bench_slots": slots.get("BN", 0),
+        "ir_slots": slots.get("IR", 0),
+    }
+
+
+def _espn_settings(con: duckdb.DuckDBPyConnection) -> dict:
+    slot_cols = ", ".join(
+        f'"settings.rosterSettings.lineupSlotCounts.{slot_id}" AS slot_{slot_id}'
+        for slot_id in set(_ESPN_SLOT_IDS.values())
+    )
+    row = con.sql(f"""
+        SELECT
+            "id" AS league_id,
+            "seasonId" AS season,
+            "settings.size" AS team_count,
+            "settings.scoringSettings.scoringItems" AS scoring_items,
+            {slot_cols}
+        FROM espn_league
+    """).df().iloc[0]
+
+    points_by_stat_id = {
+        item["statId"]: item["points"] for item in ast.literal_eval(row["scoring_items"])
+    }
+
+    settings = {
+        "league_key": "espn",
+        "platform": "espn",
+        "league_id": str(row["league_id"]),
+        "season": int(row["season"]),
+        "team_count": int(row["team_count"]),
+    }
+    for column, stat_id in _ESPN_STAT_IDS.items():
+        settings[column] = points_by_stat_id.get(stat_id, 0.0)
+    for column, slot_id in _ESPN_SLOT_IDS.items():
+        settings[column] = int(row[f"slot_{slot_id}"])
+    return settings
+
+
+def build_league_settings() -> None:
+    con = duckdb.connect(str(WAREHOUSE_PATH))
+    df = pd.DataFrame([_sleeper_settings(con), _espn_settings(con)])[_COLUMNS]
+    con.execute("CREATE OR REPLACE TABLE league_settings AS SELECT * FROM df")
+    con.close()
+
+    print(f"Built {len(df)} rows into {WAREHOUSE_PATH} (table: league_settings)")
+
+
+if __name__ == "__main__":
+    build_league_settings()

--- a/src/gold/points_over_replacement.py
+++ b/src/gold/points_over_replacement.py
@@ -1,0 +1,155 @@
+"""Build points-over-replacement per league, season, and player.
+
+Pure warehouse-to-warehouse Python/SQL — no fetch step, no network. Built from `weekly_stats`
+(already loaded by nfl_data.py) and `league_settings` (already built by league_settings.py).
+
+Recomputes each player-season's real fantasy points under each league's own scoring rules — not
+nflverse's canned `fantasy_points_ppr`, which won't match either league's actual pass-TD/INT/
+reception values — from weekly_stats' raw counting stats times that league's `league_settings`
+coefficients. `league_settings` only has each league's current (2026) scoring row, so those
+coefficients are applied uniformly across every historical season in the warehouse. Season-total
+points, not per-game: this is a value-over-replacement calculation, not a projection, so durability
+(games played) should count rather than be normalized away, and low-game players simply rank low
+on their own without needing an artificial games-played floor.
+
+Replacement level is a combined-flex-pool Value-Based-Drafting calculation: each position's
+dedicated starters (`team_count x slots`) are filled first, then whatever's left over from
+RB/WR/TE is pooled, ranked by points, and FLEX slots (`team_count x flex_slots`) are filled from
+that pool regardless of position. A position's replacement level is whoever's first left off after
+both its dedicated slots and its share of FLEX are accounted for — so a position that wins more
+flex spots in a given season automatically gets a deeper (lower) replacement level, with no
+hardcoded split. Both leagues currently have zero superflex slots, so QB has no flex eligibility
+and sits outside the pool.
+
+Scoped to skill positions (QB/RB/WR/TE), matching adp_consensus.py/player_baselines.py.
+"""
+
+from pathlib import Path
+
+import duckdb
+import pandas as pd
+
+WAREHOUSE_PATH = Path("data/warehouse.duckdb")
+
+_SKILL_POSITIONS = ("QB", "RB", "WR", "TE")
+_FLEX_POSITIONS = ("RB", "WR", "TE")
+
+_SLOT_COLUMNS = {"QB": "qb_slots", "RB": "rb_slots", "WR": "wr_slots", "TE": "te_slots"}
+
+# weekly_stats raw counting stat -> the league_settings column with its per-unit point value.
+_STAT_COEFFICIENTS = {
+    "passing_yards": "pass_yd_pts",
+    "passing_tds": "pass_td_pts",
+    "passing_2pt_conversions": "pass_2pt_pts",
+    "interceptions": "pass_int_pts",
+    "rushing_yards": "rush_yd_pts",
+    "rushing_tds": "rush_td_pts",
+    "rushing_2pt_conversions": "rush_2pt_pts",
+    "receptions": "rec_pts",
+    "receiving_yards": "rec_yd_pts",
+    "receiving_tds": "rec_td_pts",
+    "receiving_2pt_conversions": "rec_2pt_pts",
+}
+# Every league scores all three fumble-lost types (pass-sack/rush/rec) with one shared value.
+_FUMBLE_LOST_COLUMNS = ("sack_fumbles_lost", "rushing_fumbles_lost", "receiving_fumbles_lost")
+
+_OUTPUT_COLUMNS = [
+    "league_key", "season", "player_id", "player_name", "position", "games_played",
+    "league_points", "position_rank", "starters_at_position", "replacement_level_points",
+    "points_over_replacement",
+]
+
+
+def _season_totals(con: duckdb.DuckDBPyConnection) -> pd.DataFrame:
+    sum_columns = ", ".join(
+        f"SUM({c}) AS {c}" for c in (*_STAT_COEFFICIENTS, *_FUMBLE_LOST_COLUMNS)
+    )
+    return con.sql(f"""
+        SELECT
+            player_id,
+            ANY_VALUE(player_display_name) AS player_name,
+            ANY_VALUE(position) AS position,
+            season,
+            COUNT(*) AS games_played,
+            {sum_columns}
+        FROM weekly_stats
+        WHERE season_type = 'REG'
+            AND fantasy_points_ppr IS NOT NULL
+            AND position IN {_SKILL_POSITIONS}
+        GROUP BY player_id, season
+    """).df()
+
+
+def _league_points(season_totals: pd.DataFrame, league: pd.Series) -> pd.Series:
+    points = sum(
+        season_totals[stat] * league[coefficient]
+        for stat, coefficient in _STAT_COEFFICIENTS.items()
+    )
+    fumbles_lost = season_totals[list(_FUMBLE_LOST_COLUMNS)].sum(axis=1)
+    return points + fumbles_lost * league["fum_lost_pts"]
+
+
+def _replacement_levels(season_df: pd.DataFrame, league: pd.Series) -> pd.DataFrame:
+    """One row per skill position: its starter count (dedicated + earned FLEX) and the
+    league-points value of the first player left off after those starters are filled."""
+    ranked = {
+        pos: season_df[season_df["position"] == pos]
+        .sort_values("league_points", ascending=False)
+        .reset_index(drop=True)
+        for pos in _SKILL_POSITIONS
+    }
+    dedicated_starters = {
+        pos: int(league["team_count"] * league[_SLOT_COLUMNS[pos]]) for pos in _SKILL_POSITIONS
+    }
+
+    leftover = pd.concat(
+        ranked[pos].iloc[dedicated_starters[pos]:] for pos in _FLEX_POSITIONS
+    ).sort_values("league_points", ascending=False)
+    flex_starters_count = int(league["team_count"] * league["flex_slots"])
+    flex_starters_by_position = leftover.iloc[:flex_starters_count]["position"].value_counts()
+
+    rows = []
+    for pos in _SKILL_POSITIONS:
+        starters = dedicated_starters[pos] + int(flex_starters_by_position.get(pos, 0))
+        cutoff = min(starters, len(ranked[pos]) - 1)
+        rows.append({
+            "position": pos,
+            "starters_at_position": starters,
+            "replacement_level_points": ranked[pos].loc[cutoff, "league_points"],
+        })
+    return pd.DataFrame(rows)
+
+
+def _build_league_season(season_df: pd.DataFrame, league: pd.Series) -> pd.DataFrame:
+    df = season_df.copy()
+    df["position_rank"] = (
+        df.groupby("position")["league_points"].rank(ascending=False, method="first").astype(int)
+    )
+    df = df.merge(_replacement_levels(season_df, league), on="position")
+    df["points_over_replacement"] = df["league_points"] - df["replacement_level_points"]
+    return df
+
+
+def build_points_over_replacement() -> None:
+    con = duckdb.connect(str(WAREHOUSE_PATH))
+    season_totals = _season_totals(con)
+    leagues = con.sql("SELECT * FROM league_settings").df()
+
+    frames = []
+    for _, league in leagues.iterrows():
+        df = season_totals[["player_id", "player_name", "position", "season", "games_played"]].copy()
+        df["league_key"] = league["league_key"]
+        df["league_points"] = _league_points(season_totals, league)
+
+        frames.extend(_build_league_season(season_df, league) for _, season_df in df.groupby("season"))
+
+    result = pd.concat(frames, ignore_index=True)[_OUTPUT_COLUMNS]
+    con.execute("CREATE OR REPLACE TABLE points_over_replacement AS SELECT * FROM result")
+    (count,) = con.execute("SELECT COUNT(*) FROM points_over_replacement").fetchone()
+    con.close()
+
+    print(f"Built {count} rows into {WAREHOUSE_PATH} (table: points_over_replacement)")
+
+
+if __name__ == "__main__":
+    build_points_over_replacement()

--- a/src/silver/fantasyfootballcalculator.py
+++ b/src/silver/fantasyfootballcalculator.py
@@ -1,0 +1,91 @@
+"""Fetch and load FantasyFootballCalculator's historical ADP into the DuckDB warehouse.
+
+FFC offers a free, public, unauthenticated JSON API for average draft position, broken out by
+scoring format and year, going back to at least 2012. No official API rate limit is published;
+FFC's own docs just ask not to call it too frequently, so requests here are spaced out.
+
+The `teams` query parameter turns out to be cosmetic: comparing responses for the same
+season/format across `teams=8/10/12/14` shows identical underlying `adp` values and
+`total_drafts` counts, only the `adp_formatted` round.pick display string changes. So this is one
+pooled ADP dataset per scoring format/season (not genuinely split by league size), fixed here at
+teams=12 since that's the value FFC's own site defaults to.
+
+One fetch call per (scoring format, season) pair (FFC has no batched multi-year endpoint), so raw
+files are saved one per pair and `load_adp_all` rebuilds the whole table from every raw file
+already on disk — no network access, consistent with every other `load_*` in this warehouse.
+"""
+
+import json
+import time
+from pathlib import Path
+
+import duckdb
+import pandas as pd
+import requests
+
+RAW_DIR = Path("data/raw/fantasyfootballcalculator")
+WAREHOUSE_PATH = Path("data/warehouse.duckdb")
+BASE_URL = "https://fantasyfootballcalculator.com/api/v1"
+
+TEAMS = 12
+SCORING_FORMATS = ["standard", "half-ppr", "ppr"]
+
+# 2026 included even though the season hasn't been played yet: this year's preseason ADP is
+# useful as live input to a trained model, just not as a backtestable season.
+SEASONS = list(range(2015, 2027))
+
+# Be a good citizen against an unofficial, undocumented rate limit.
+_REQUEST_DELAY_SECONDS = 0.5
+
+
+def fetch_adp(scoring_format: str, season: int) -> Path:
+    """Fetch one scoring-format/season of ADP and save the raw response to JSON."""
+    response = requests.get(
+        f"{BASE_URL}/adp/{scoring_format}", params={"teams": TEAMS, "year": season}
+    )
+    response.raise_for_status()
+    time.sleep(_REQUEST_DELAY_SECONDS)
+
+    RAW_DIR.mkdir(parents=True, exist_ok=True)
+    raw_path = RAW_DIR / f"adp_{scoring_format}_{season}.json"
+    raw_path.write_text(json.dumps(response.json()))
+    print(f"Saved {raw_path}")
+    return raw_path
+
+
+def load_adp_all() -> None:
+    """Load every raw ADP file in the archive into one combined table (no network).
+
+    Some early scoring-format/season combinations (e.g. half-PPR wasn't common yet in 2015-2017)
+    have no drafts on record; FFC returns `{"status": "Error", ...}` for those instead of a
+    players list, so they're skipped rather than treated as a load failure.
+    """
+    rows = []
+    skipped = []
+    raw_paths = sorted(RAW_DIR.glob("adp_*.json"))
+    for raw_path in raw_paths:
+        scoring_format, season = raw_path.stem.removeprefix("adp_").rsplit("_", 1)
+        data = json.loads(raw_path.read_text())
+        if "players" not in data:
+            skipped.append(raw_path.name)
+            continue
+        for player in data["players"]:
+            rows.append({**player, "scoring_format": scoring_format, "season": int(season)})
+
+    if skipped:
+        print(f"Skipped {len(skipped)} file(s) with no ADP data: {', '.join(skipped)}")
+
+    df = pd.DataFrame(rows)
+    WAREHOUSE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    con = duckdb.connect(str(WAREHOUSE_PATH))
+    con.execute("CREATE OR REPLACE TABLE ffc_adp AS SELECT * FROM df")
+    con.close()
+
+    print(f"Loaded {len(df)} rows from {len(raw_paths)} files into {WAREHOUSE_PATH} (table: ffc_adp)")
+
+
+if __name__ == "__main__":
+    for scoring_format in SCORING_FORMATS:
+        for season in SEASONS:
+            fetch_adp(scoring_format, season)
+    load_adp_all()

--- a/src/silver/fantasypros.py
+++ b/src/silver/fantasypros.py
@@ -84,6 +84,57 @@ def load_weekly_rankings(raw_path: Path, position: str) -> None:
     _load_json_to_table(raw_path, f"fantasypros_weekly_rankings_{position}")
 
 
+# FantasyPros' historical ADP-by-year page is a client-rendered app with no server-embedded data
+# (unlike the rankings pages above), so there's no clean fetch_* for it. Instead this reads
+# manually-exported CSVs the user downloads by hand from fantasypros.com/nfl/adp/overall.php and
+# drops into RAW_DIR as `FantasyPros_<year>_Overall_ADP_Rankings.csv` — same raw-archive/load split
+# as everywhere else, just with a human doing the "fetch" step instead of a network call.
+_ADP_FILENAME_RE = re.compile(r"FantasyPros_(\d{4})_Overall_ADP_Rankings\.csv")
+
+# "Player (Bye)" packs name/team/bye into one string with an irregular format: team+bye are
+# omitted entirely for a large fraction of rows (most common in FantasyPros' older archives —
+# ~90% of 2015 rows have no team/bye at all, dropping to ~5-20% by the mid-2020s), and DST rows
+# spell out the full team name with no separate abbreviation token before the bye.
+_PLAYER_BYE_RE = re.compile(r"^(?P<name>.+?)(?:\s{2,}(?:(?P<team>[A-Z]{2,3})\s)?\((?P<bye>\d+)\))?$")
+
+# "POS" is normally a position + positional rank (e.g. "RB1"), but a handful of IDP-style rows
+# (OL/CB/LB) carry just the bare position with no rank suffix.
+_POSITION_RE = re.compile(r"^([A-Z]+?)(\d+)?$")
+
+
+def load_adp_manual(raw_dir: Path = RAW_DIR) -> None:
+    """Parse every manually-downloaded ADP CSV in raw_dir into one combined table (no network)."""
+    frames = []
+    for raw_path in sorted(raw_dir.glob("FantasyPros_*_Overall_ADP_Rankings.csv")):
+        match = _ADP_FILENAME_RE.fullmatch(raw_path.name)
+        if not match:
+            continue
+        season = int(match.group(1))
+
+        df = pd.read_csv(raw_path)
+        parsed_name = df["Player (Bye)"].str.extract(_PLAYER_BYE_RE)
+        parsed_pos = df["POS"].str.extract(_POSITION_RE)
+
+        frames.append(pd.DataFrame({
+            "season": season,
+            "rank": df["Rank"],
+            "name": parsed_name["name"],
+            "team": parsed_name["team"],
+            "bye": pd.to_numeric(parsed_name["bye"]),
+            "position": parsed_pos[0],
+            "position_rank": pd.to_numeric(parsed_pos[1]),
+            "adp": df["AVG"],
+        }))
+
+    df = pd.concat(frames, ignore_index=True)
+    WAREHOUSE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    con = duckdb.connect(str(WAREHOUSE_PATH))
+    con.execute("CREATE OR REPLACE TABLE fantasypros_adp AS SELECT * FROM df")
+    con.close()
+
+    print(f"Loaded {len(df)} rows from {len(frames)} files into {WAREHOUSE_PATH} (table: fantasypros_adp)")
+
+
 if __name__ == "__main__":
     current_week = 1
 

--- a/src/silver/nfl_data.py
+++ b/src/silver/nfl_data.py
@@ -62,6 +62,11 @@ def load_schedules(raw_path: Path) -> None:
 def fetch_rosters(seasons: list[int]) -> Path:
     """Fetch weekly rosters for the given seasons and save raw to parquet."""
     df = nfl.import_weekly_rosters(seasons)
+    # nflverse published jersey_number/draft_number as strings in some seasons and floats in
+    # others; concatenated across seasons that's a mixed-type object column, which fastparquet
+    # can't serialize. Coercing to a single numeric type resolves it without touching other columns.
+    for column in ("jersey_number", "draft_number"):
+        df[column] = pd.to_numeric(df[column], errors="coerce")
     return _save_raw(df, f"rosters_{_seasons_label(seasons)}")
 
 
@@ -120,7 +125,11 @@ def load_players(raw_path: Path) -> None:
 
 
 def fetch_ngs_data(seasons: list[int]) -> Path:
-    """Fetch seasonal Next Gen Stats (passing, receiving, rushing) and save raw to parquet."""
+    """Fetch seasonal Next Gen Stats (passing, receiving, rushing) and save raw to parquet.
+
+    NGS tracking data is only available from 2016 onward; earlier seasons are dropped.
+    """
+    seasons = [s for s in seasons if s >= 2016]
     stat_types = ["passing", "receiving", "rushing"]
     frames = []
     for stat_type in stat_types:
@@ -142,6 +151,9 @@ def fetch_ftn_data(seasons: list[int]) -> Path:
     """
     seasons = [s for s in seasons if s >= 2022]
     df = nfl.import_ftn_data(seasons)
+    # Same cross-season dtype inconsistency as rosters' jersey_number/draft_number, this time
+    # bool in some seasons' files and float in others.
+    df["is_trick_play"] = df["is_trick_play"].astype(float)
     return _save_raw(df, f"ftn_{_seasons_label(seasons)}")
 
 
@@ -152,8 +164,10 @@ def load_ftn_data(raw_path: Path) -> None:
 def fetch_pfr_advstats(stat_type: str, seasons: list[int]) -> Path:
     """Fetch PFR advanced season-level stats (pass/rush/rec/def) and save raw to parquet.
 
-    Not available before 2018 (nfl_data_py raises if any requested season predates that).
+    Not available before 2018 (nfl_data_py raises if any requested season predates that); earlier
+    seasons are dropped.
     """
+    seasons = [s for s in seasons if s >= 2018]
     df = nfl.import_seasonal_pfr(stat_type, seasons)
     return _save_raw(df, f"pfr_advstats_{stat_type}_{_seasons_label(seasons)}")
 
@@ -173,7 +187,13 @@ def load_ids(raw_path: Path) -> None:
 
 
 if __name__ == "__main__":
-    seasons = list(range(2021, 2024))
+    # 2015-2024: enough draft classes for recency-weighted backtesting while staying in the
+    # modern pass-heavy/PPR era. 2025 is excluded even though it's been played — nflverse hasn't
+    # published its weekly/seasonal player-stats release for that season yet (schedules, rosters,
+    # snap counts, injuries, and depth charts are all already available for 2025, but a season
+    # with no fantasy-points outcome data isn't useful here, so it's left out entirely for
+    # consistency). 2026 is excluded since it hasn't been played yet.
+    seasons = list(range(2015, 2025))
 
     load_weekly_stats(fetch_weekly_stats(seasons))
     load_schedules(fetch_schedules(seasons))

--- a/src/silver/players.py
+++ b/src/silver/players.py
@@ -1,0 +1,26 @@
+"""Shared player-name normalization, mirroring nflverse's own `merge_name` convention.
+
+Not a data source itself. FantasyPros' ADP CSVs and FantasyFootballCalculator's API give player
+names as free text with no platform ID `ids` (the nflverse player crosswalk loaded by
+nfl_data.py) already knows, unlike ESPN/Sleeper/CBS projections in consensus.py, which carry a
+native platform ID the crosswalk can join through directly.
+
+This reproduces nflverse's own `merge_name` transform (lowercase, strip periods/apostrophes, strip
+Jr/Sr/II/III/IV/V suffixes, collapse whitespace) closely enough to join on it: applying this to
+every name in `ids` and comparing against `ids.merge_name` itself matches on 99.75% of rows
+(12,441/12,472). The remaining misses are genuine nickname aliasing nflverse's crosswalk already
+knows about (e.g. "Sauce Gardner" -> "Ahmad Gardner", "Michael Woods" -> "Mike Woods") that no
+regex could reproduce.
+"""
+
+import re
+
+_SUFFIX_RE = re.compile(r"\s+(jr|sr|ii|iii|iv|v)\.?$", re.IGNORECASE)
+_PUNCT_RE = re.compile(r"[.'’]")
+
+
+def merge_name(name: str) -> str:
+    name = name.lower()
+    name = _PUNCT_RE.sub("", name)
+    name = _SUFFIX_RE.sub("", name)
+    return re.sub(r"\s+", " ", name).strip()


### PR DESCRIPTION
## Summary
Builds out the "league-winning RB" idea end to end, plus a follow-on ADP-blind breakout-candidate model:

- **`league_settings`** — normalizes Sleeper's and ESPN's scoring rules and starting-roster construction into one shared schema, so downstream models can run one formula per league instead of a constant tuned to a single scoring format.
- **`adp_consensus`** — blends two independent historical ADP sources (FantasyPros manual CSV exports, FantasyFootballCalculator's API) back to 2015, exposing each source's own ADP alongside the blend rather than only the blend.
- **`points_over_replacement`** — recomputes each skill-position player-season's real fantasy points under each league's own scoring rules (not nflverse's canned PPR formula), minus a replacement level from a combined-flex-pool Value-Based-Drafting calculation — season-total points, not PPG, since this is a value-over-replacement calculation rather than a projection.
- **`boom_bust`** — classifies each player-season into a preseason-ADP-relative outcome bucket (Boomed/Returned on ADP/Fine/Busted/Got Injured/No Preseason ADP) via percentile comparison, format- and league-size-independent by construction.
- **Feature importance for `inhouse_projections`** — added out-of-sample permutation importance to its holdout eval, answering whether the team-context signals (`offensive_line_grades`/`skill_position_grades`) actually move the prediction.
- **`breakout_candidates`** — ranks `inhouse_projections`' already-ADP-blind prediction against `adp_consensus`'s preseason percentile, surfacing players the model likes that the draft market doesn't, as a continuous `predicted_delta`.
- Groundwork: extended `nfl_data.py`'s season range to 2015-2024 for backtesting, with a couple of cross-season dtype fixes that only surface once seasons are concatenated this far back.

## Notable findings along the way
- Two real bugs caught and fixed while validating `boom_bust` (both explained in that commit): a reference-population mismatch that inflated Boomed:Busted from a plausible ~2.5:1 to a nonsensical 58:1, and an injury-bucket mislabel that hit ~4,300 replacement-level scrubs who were never fantasy-relevant.
- `breakout_candidates`' current feature set (recency-weighted history + team-*wide* grades) can't distinguish a genuine sleeper from a backup who's simply lost his depth-chart spot — several of its top "hidden gem" results turned out to be exactly that on inspection. Documented as a known limitation, not fixed here.
- `inhouse_projections`/`breakout_candidates` are capped at `target_season=2025` until nflverse publishes 2025 weekly stats — confirmed live, not yet available. Rolls forward automatically once it is.

## Test plan
- [x] Ran every new module end-to-end (`league_settings`, `adp_consensus`, `points_over_replacement`, `boom_bust`, `inhouse_projections`, `breakout_candidates`) with no errors.
- [x] Spot-checked `points_over_replacement`/`boom_bust` against known 2024 outcomes (Barkley/Gibbs/Henry/Bijan top the RB leaderboard; Dalvin Cook 2023/Miles Sanders 2023 correctly bucket as Busted; James Robinson 2020/Phillip Lindsay 2018 correctly bucket as Boomed).
- [x] Verified flex-pool math sums exactly to `team_count x flex_slots` for both leagues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)