### PR TITLE
fix: correct and stabilise how a player/team resolves to a canonical team

### DIFF
--- a/src/gold/inhouse_projections.py
+++ b/src/gold/inhouse_projections.py
@@ -71,8 +71,15 @@ _FEATURE_SQL = f"""
 WITH team_by_player_season AS (
     SELECT
         season, player_id, normalize_team(recent_team) AS team,
+        -- COUNT(*) alone isn't a total order: a player traded at the midpoint has an equal game
+        -- count on both teams, and DuckDB then resolves the tie differently from run to run,
+        -- silently reassigning their team (and with it the ol_grade/skill_grade joined below).
+        -- MAX(week) breaks ties toward the team they finished the season on, which is also the
+        -- better signal for the following season this row is used to predict; team is a final
+        -- alphabetical backstop so the ordering is total.
         ROW_NUMBER() OVER (
-            PARTITION BY season, player_id ORDER BY COUNT(*) DESC
+            PARTITION BY season, player_id
+            ORDER BY COUNT(*) DESC, MAX(week) DESC, normalize_team(recent_team)
         ) AS rn
     FROM weekly_stats
     WHERE season_type = 'REG' AND recent_team IS NOT NULL
@@ -111,6 +118,13 @@ LEFT JOIN offensive_line_grades ol ON ol.team = pt.team AND ol.season = b.target
 LEFT JOIN skill_position_grades sk
     ON sk.team = pt.team AND sk.season = b.target_season - 1 AND sk.position = b.position
 LEFT JOIN actual_outcomes o ON o.player_id = b.player_id AND o.target_season = b.target_season
+-- Not cosmetic: DuckDB's parallel joins return these rows in a different order from run to run,
+-- and HistGradientBoostingRegressor sums gradients per histogram bin in row order. Float addition
+-- isn't associative, so a reordered frame shifts split gains just enough to flip tree splits,
+-- which cascades — back-to-back rebuilds on identical data moved projections by up to 20 points.
+-- (target_season, player_id) is unique here, so this is a total order and makes rebuilds
+-- reproducible.
+ORDER BY b.target_season, b.player_id
 """
 
 

--- a/src/gold/skill_position_grades.py
+++ b/src/gold/skill_position_grades.py
@@ -38,8 +38,12 @@ CREATE OR REPLACE TABLE skill_position_grades AS
 WITH team_by_player_season AS (
     SELECT
         stat_type, season, player_gsis_id, team_abbr,
+        -- See the matching note in inhouse_projections.py: COUNT(*) alone leaves mid-season trades
+        -- tied, and the tie resolves differently run to run. Break toward the team the player
+        -- finished on, then alphabetically so the ordering is total.
         ROW_NUMBER() OVER (
-            PARTITION BY stat_type, season, player_gsis_id ORDER BY COUNT(*) DESC
+            PARTITION BY stat_type, season, player_gsis_id
+            ORDER BY COUNT(*) DESC, MAX(week) DESC, team_abbr
         ) AS rn
     FROM ngs_data
     WHERE week BETWEEN 1 AND 18 AND team_abbr IS NOT NULL

--- a/src/silver/teams.py
+++ b/src/silver/teams.py
@@ -3,6 +3,9 @@ warehouse (e.g. the `rosters` table) — "LA" (not "LAR") for the Rams, "JAX" (n
 Jaguars. Projection sources represent team defenses inconsistently (full team names, bare
 nicknames, or a divergent abbreviation), so `normalize_team` maps any of those down to the
 canonical abbreviation, for joining DST rows across sources by team instead of a player ID.
+
+Relocated franchises fold into their current abbreviation (a 2018 "OAK" row normalizes to "LV"),
+so a franchise joins to itself across seasons that straddle its move.
 """
 
 NICKNAME_TO_ABBR = {
@@ -19,6 +22,13 @@ NICKNAME_TO_ABBR = {
 ABBR_ALIASES = {
     "LAR": "LA", "JAC": "JAX", "WSH": "WAS", "GNB": "GB", "NOR": "NO",
     "SFO": "SF", "TAM": "TB", "NWE": "NE", "KAN": "KC", "LVR": "LV",
+    "ARZ": "ARI", "BLT": "BAL", "CLV": "CLE", "HST": "HOU",
+    # Relocations, mapped to the franchise's current abbreviation so a team joins to itself across
+    # its move: a 2018 "OAK" row is the same O-line/roster lineage as a 2024 "LV" one. Sources
+    # disagree about which era's code to use for old seasons (PFR's advstats_pass says "OAK" for
+    # 2018-19 while advstats_rush says "LV"), so without these a join across two such tables
+    # silently drops the franchise instead of matching it.
+    "OAK": "LV", "SD": "LAC", "SDG": "LAC", "STL": "LA", "SL": "LA",
 }  # fmt: skip
 
 


### PR DESCRIPTION
Two related correctness bugs in how rows get attributed to a team. Both silently produced wrong numbers rather than failing.

## 1. Relocated franchises never joined to themselves

PFR's advanced stats disagree about which era's code to use for old seasons: `advstats_pass` says `OAK` for 2018-19 (then `LVR`, then `LV`), while `advstats_rush` says `LV` throughout. `normalize_team` aliased `LVR -> LV` but left `OAK` alone, so the `FULL OUTER JOIN` in `offensive_line.py` never matched the Raiders in those seasons and emitted two half-rows instead of one, each NULL on one side.

NULLs sort last under `PERCENT_RANK`, which turned "no data" into a grade — `OAK` scored a perfect 100.0 `run_block_grade` in both 2018 and 2019 purely from having no run-block data. The 33-row partitions also skewed every other team's percentile those seasons.

Adds relocation aliases (`OAK->LV`, `SD`/`SDG->LAC`, `STL`/`SL->LA`) plus the `ARZ`/`BLT`/`CLV`/`HST` spelling variants present in `rosters.team`.

| | before | after |
|---|---|---|
| `offensive_line_grades` rows | 226 | 224 (7 x 32) |
| rows with a NULL input | 4 | 0 |
| Raiders 2018 `ol_grade` | 4.7 / 75.0 (split) | 29.0 |
| Raiders 2019 `ol_grade` | 17.2 / 89.1 (split) | 56.5 |
| other 2018-19 teams changed | — | 61, all <= 1.4 |
| 2020-2024 rows changed | — | 0 |

`skill_position_grades` is unaffected (818 rows either way) — it joins the already-canonical `teams.team_abbr`.

## 2. In-house projections were not reproducible

Back-to-back rebuilds on unchanged data differed on 762/762 rows, moving individual players by up to 20 points. `random_state=0` was already set, so the model was not the cause. Narrowed by hashing each pipeline stage across processes until the diverging column appeared:

- **`team_by_player_season` had no tiebreaker.** `ROW_NUMBER() OVER (... ORDER BY COUNT(*) DESC)` is not a total order — a player traded at the season midpoint has equal game counts on both teams, and DuckDB resolved that tie differently run to run, reassigning their team and with it the `ol_grade`/`skill_grade` features joined on it. 23 player-seasons are tied. Ties now break toward the team the player finished on (`MAX(week)`), which is also the better predictor of the following season, then alphabetically for a total order. `skill_position_grades.py` carried a copy of the same window function and is fixed identically.
- **`_FEATURE_SQL` had no `ORDER BY`.** DuckDB's parallel joins returned rows in varying order, and `HistGradientBoostingRegressor` sums gradients per histogram bin in row order — float addition isn't associative, so a reordered frame shifted split gains enough to flip tree splits.

Five consecutive rebuilds now produce a byte-identical `projected_points` digest.

## Verification

No test suite in the repo, so verification is rebuild + row counts, run against the real warehouse: per-season team counts 32 across 2018-2024, zero NULL inputs, no non-canonical codes, and five identical digests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)