### PR TITLE
feat: backfill 2025 by reading nflverse's current stats_player release

### DIFF
--- a/src/gold/inhouse_projections.py
+++ b/src/gold/inhouse_projections.py
@@ -70,7 +70,7 @@ _MIN_TRAIN_SEASON_WITH_TEAM_CONTEXT = 2019
 _FEATURE_SQL = f"""
 WITH team_by_player_season AS (
     SELECT
-        season, player_id, normalize_team(recent_team) AS team,
+        season, player_id, normalize_team(team) AS team,
         -- COUNT(*) alone isn't a total order: a player traded at the midpoint has an equal game
         -- count on both teams, and DuckDB then resolves the tie differently from run to run,
         -- silently reassigning their team (and with it the ol_grade/skill_grade joined below).
@@ -79,11 +79,11 @@ WITH team_by_player_season AS (
         -- alphabetical backstop so the ordering is total.
         ROW_NUMBER() OVER (
             PARTITION BY season, player_id
-            ORDER BY COUNT(*) DESC, MAX(week) DESC, normalize_team(recent_team)
+            ORDER BY COUNT(*) DESC, MAX(week) DESC, normalize_team(team)
         ) AS rn
     FROM weekly_stats
-    WHERE season_type = 'REG' AND recent_team IS NOT NULL
-    GROUP BY season, player_id, normalize_team(recent_team)
+    WHERE season_type = 'REG' AND team IS NOT NULL
+    GROUP BY season, player_id, normalize_team(team)
 ),
 player_team AS (
     SELECT season, player_id, team FROM team_by_player_season WHERE rn = 1

--- a/src/gold/points_over_replacement.py
+++ b/src/gold/points_over_replacement.py
@@ -41,7 +41,7 @@ _STAT_COEFFICIENTS = {
     "passing_yards": "pass_yd_pts",
     "passing_tds": "pass_td_pts",
     "passing_2pt_conversions": "pass_2pt_pts",
-    "interceptions": "pass_int_pts",
+    "passing_interceptions": "pass_int_pts",
     "rushing_yards": "rush_yd_pts",
     "rushing_tds": "rush_td_pts",
     "rushing_2pt_conversions": "rush_2pt_pts",

--- a/src/silver/nfl_data.py
+++ b/src/silver/nfl_data.py
@@ -39,9 +39,23 @@ def _load_parquet_to_table(raw_path: Path, table_name: str) -> None:
     print(f"Loaded {raw_path} into {WAREHOUSE_PATH} (table: {table_name})")
 
 
+# nflverse retired the `player_stats` release in favour of `stats_player`, but nfl_data_py 0.3.3
+# (the latest release, and seemingly unmaintained) still requests the old path — so
+# import_weekly_data 404s for any season published after the switch while silently continuing to
+# work for older ones. Read the current release directly rather than pinning the warehouse to
+# whatever the last season in the retired release happened to be.
+_STATS_PLAYER_URL = (
+    "https://github.com/nflverse/nflverse-data/releases/download/stats_player/"
+    "stats_player_week_{season}.parquet"
+)
+
+
 def fetch_weekly_stats(seasons: list[int]) -> Path:
     """Fetch weekly player stats for the given seasons and save raw to parquet."""
-    df = nfl.import_weekly_data(seasons)
+    df = pd.concat(
+        [pd.read_parquet(_STATS_PLAYER_URL.format(season=season)) for season in sorted(seasons)],
+        ignore_index=True,
+    )
     return _save_raw(df, f"weekly_{_seasons_label(seasons)}")
 
 
@@ -94,18 +108,25 @@ def load_injuries(raw_path: Path) -> None:
     _load_parquet_to_table(raw_path, "injuries")
 
 
-def fetch_seasonal_data(seasons: list[int]) -> Path:
-    """Fetch season-level aggregated stats for the given seasons and save raw to parquet."""
-    df = nfl.import_seasonal_data(seasons)
-    return _save_raw(df, f"seasonal_{_seasons_label(seasons)}")
+# fetch_seasonal_data/load_seasonal_data used to live here, sourced from nfl_data_py's
+# import_seasonal_data — which reads the same retired `player_stats` release as import_weekly_data
+# and 404s for the same reason. Nothing in src/ ever read the seasonal_data table, and the
+# replacement release (stats_player_reg) has a different shape, so it was dropped rather than
+# repointed. Season-level aggregates are derivable from weekly_stats if they're ever wanted.
 
 
-def load_seasonal_data(raw_path: Path) -> None:
-    _load_parquet_to_table(raw_path, "seasonal_data")
+# nflverse reshaped depth charts from 2025 on: the old per-week rows (season/week/club_code/
+# depth_team/...) became dated snapshots (dt/team/pos_grp/pos_rank/...) with no season or week
+# column at all. Concatenating the two just unions their columns and leaves 2025 with a null
+# season, so seasons past the break are dropped rather than silently half-loaded. Nothing in src/
+# reads depth_charts yet; wiring the new format in (deriving season/week from `dt`) is its own
+# piece of work, and belongs with whatever first needs a role/snap-share feature.
+_DEPTH_CHART_SCHEMA_BREAK = 2025
 
 
 def fetch_depth_charts(seasons: list[int]) -> Path:
     """Fetch weekly depth charts for the given seasons and save raw to parquet."""
+    seasons = [s for s in seasons if s < _DEPTH_CHART_SCHEMA_BREAK]
     df = nfl.import_depth_charts(seasons)
     return _save_raw(df, f"depth_charts_{_seasons_label(seasons)}")
 
@@ -187,20 +208,18 @@ def load_ids(raw_path: Path) -> None:
 
 
 if __name__ == "__main__":
-    # 2015-2024: enough draft classes for recency-weighted backtesting while staying in the
-    # modern pass-heavy/PPR era. 2025 is excluded even though it's been played — nflverse hasn't
-    # published its weekly/seasonal player-stats release for that season yet (schedules, rosters,
-    # snap counts, injuries, and depth charts are all already available for 2025, but a season
-    # with no fantasy-points outcome data isn't useful here, so it's left out entirely for
-    # consistency). 2026 is excluded since it hasn't been played yet.
-    seasons = list(range(2015, 2025))
+    # 2015-2025: enough draft classes for recency-weighted backtesting while staying in the modern
+    # pass-heavy/PPR era. 2025 was previously excluded on the belief that nflverse hadn't published
+    # its player stats yet; in fact nflverse had moved them to the `stats_player` release and
+    # nfl_data_py was still asking for the retired one (see _STATS_PLAYER_URL). 2026 is excluded
+    # since it hasn't been played yet — it's the season the models project, not train on.
+    seasons = list(range(2015, 2026))
 
     load_weekly_stats(fetch_weekly_stats(seasons))
     load_schedules(fetch_schedules(seasons))
     load_rosters(fetch_rosters(seasons))
     load_snap_counts(fetch_snap_counts(seasons))
     load_injuries(fetch_injuries(seasons))
-    load_seasonal_data(fetch_seasonal_data(seasons))
     load_depth_charts(fetch_depth_charts(seasons))
     load_ids(fetch_ids())
     load_players(fetch_players())


### PR DESCRIPTION
> **Stacked on #12** — base is `fix/team-resolution-correctness`, not `main`. Merge #12 first; this diff is the single commit `0a0bc58`.

## The 2025 season was available all along

`nfl_data_py` 0.3.3 (latest on PyPI, and seemingly unmaintained) requests nflverse's retired `player_stats` release, which stopped gaining seasons after 2024. The resulting 404 was read as "nflverse hasn't published 2025 yet" and the pipeline was pinned to 2015-2024 on that basis — but the data had simply moved to the `stats_player` release.

```
player_stats/player_stats_2024.parquet        200
player_stats/player_stats_2025.parquet        404   <- what the library asks for
stats_player/stats_player_week_2025.parquet   200   <- where the data lives
```

Only `import_weekly_data` and `import_seasonal_data` were affected; the other nine endpoints this project uses resolve 2025 fine.

## Changes

- **Read `stats_player` directly for weekly stats.** It carries 2015-2025, so the whole range comes from one schema rather than splicing two.
- **Extend the pipeline to 2015-2025.** 2026 stays excluded — it's the season the models project, not train on.
- **Two column renames.** The new schema is a superset apart from five dropped columns, two of which were in use: `recent_team -> team` (`inhouse_projections`) and `interceptions -> passing_interceptions` (`points_over_replacement`).
- **Drop `fetch_seasonal_data`/`load_seasonal_data`.** Same retired release; nothing in `src/` ever queried the `seasonal_data` table, and the replacement release has a different shape, so repointing would change its schema for no consumer's benefit.
- **Cap depth charts at 2024.** nflverse reshaped them from 2025 on — per-week rows (`season`/`week`/`club_code`/`depth_team`) became dated snapshots (`dt`/`team`/`pos_grp`/`pos_rank`) with no season column — and concatenating just unions the columns, leaving 60% of rows with a null season. Nothing reads `depth_charts` yet; adapting the new format is separate work and belongs with whatever first needs a role/snap-share feature.

## This unblocks the in-house consensus arm

`consensus.py` scopes the in-house source to the season the external sources represent. With the warehouse ending at 2024, in-house topped out at `target_season` 2025 against the externals' 2026 and was correctly excluded — the blend never exceeded 4 sources. It now reaches 2026.

| | before | after |
|---|---|---|
| `weekly_stats` | 2015-2024 | 2015-2025 (199,868 rows) |
| `offensive_line_grades` | 226 rows, 2018-2024 | 256 rows, 2018-2025 (8 x 32) |
| `inhouse_projections` | target_season 2025 | target_season 2026 |
| consensus `num_sources` | max 4 | 180 players at 5 |

Holdout R2 improves 0.50 -> 0.56 on the larger training slice, and rebuilds remain byte-identical.

## Verification

Full `python -m src.silver.nfl_data` fetch/load, then every `src/gold` model rebuilt in dependency order. Season coverage confirmed per table; `depth_charts` reloaded clean at 2015-2024 with zero null seasons; stale `seasonal_data` table dropped from the warehouse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)