### PR TITLE
feat: give the projection model age, experience, and draft capital

### DIFF
--- a/src/gold/inhouse_projections.py
+++ b/src/gold/inhouse_projections.py
@@ -14,6 +14,14 @@ the season being predicted doesn't exist yet, so this stays a strictly prior-yea
   `skill_position_grades` (it only grades WR/TE/RB); HistGradientBoostingRegressor takes the
   resulting NaN natively, no imputation needed.
 
+Plus a career block that is instead as of `target_season` itself — `seasons_of_experience`,
+`age_at_season`, `draft_round`, `draft_pick`. Age and years-in-league for the season being
+predicted are fixed and knowable before it starts, so using them isn't leakage the way a
+performance stat would be. Without these the model had no way to represent a player's place on
+the experience curve at all: its whole view of a high-scoring second-year player was last year's
+rate plus team context, so it could only regress them toward the mean of everyone who scored
+similarly, never toward what young ascending players specifically tend to do next.
+
 Label: actual PPG in `target_season`, only for players who played >= the same games-played floor
 `player_baselines.py` uses (imported, not redefined) — an actual season cut short by injury is as
 untrustworthy a training target as a short season is a baseline input.
@@ -48,6 +56,7 @@ WAREHOUSE_PATH = Path("data/warehouse.duckdb")
 
 _BASE_FEATURES = [
     "weighted_ppg_ppr", "weighted_games_per_season", "seasons_used", "ol_grade", "skill_grade",
+    "seasons_of_experience", "age_at_season", "draft_pick",
 ]
 _FEATURE_COLUMNS = _BASE_FEATURES + [f"position_{p}" for p in _SKILL_POSITIONS]
 
@@ -111,12 +120,33 @@ SELECT
     pt.team,
     ol.ol_grade,
     sk.grade AS skill_grade,
+    -- Unlike every feature above, these are as of target_season itself rather than
+    -- target_season - 1. That isn't leakage: how old a player will be and how many years they'll
+    -- have been in the league are both fixed facts about the season being predicted, known before
+    -- a snap of it is played, which is exactly not true of performance or team-context stats.
+    -- 0 = rookie year, 1 = entering year two, and so on.
+    b.target_season - pl.rookie_season AS seasons_of_experience,
+    -- birth_date arrives as an ISO string, and TRY_CAST leaves an unparseable one as NULL rather
+    -- than failing the whole build over one bad row.
+    b.target_season - YEAR(TRY_CAST(pl.birth_date AS DATE)) AS age_at_season,
+    -- A static career fact, so no as-of question arises. NULL means undrafted, which is signal
+    -- rather than absence — HistGradientBoostingRegressor consumes the NaN natively, the same way
+    -- it already does for skill_grade on every QB row. Coverage is 56-81% across rookie eras with
+    -- no gradient, so a null doesn't stand in for "old season". draft_round is deliberately left
+    -- out: pick number already encodes it, and carrying both scored marginally worse in the
+    -- walk-forward backtest while adding no permutation importance.
+    pl.draft_pick,
     o.actual_ppg_ppr
 FROM player_weighted_baselines b
 LEFT JOIN player_team pt ON pt.player_id = b.player_id AND pt.season = b.target_season - 1
 LEFT JOIN offensive_line_grades ol ON ol.team = pt.team AND ol.season = b.target_season - 1
 LEFT JOIN skill_position_grades sk
     ON sk.team = pt.team AND sk.season = b.target_season - 1 AND sk.position = b.position
+-- players.years_of_experience is deliberately unused: it's one static value per player that
+-- doesn't equal seasons-since-rookie (Brady reads 23 against a 2000 rookie season and a final
+-- 2022 season), so applying it to a historical row would leak how the career eventually turned
+-- out. rookie_season and birth_date are immutable, so deriving from them is safe at any season.
+LEFT JOIN players pl ON pl.gsis_id = b.player_id
 LEFT JOIN actual_outcomes o ON o.player_id = b.player_id AND o.target_season = b.target_season
 -- Not cosmetic: DuckDB's parallel joins return these rows in a different order from run to run,
 -- and HistGradientBoostingRegressor sums gradients per histogram bin in row order. Float addition


### PR DESCRIPTION
> **Stacked on #13** (which is stacked on #12). Base is `feat/backfill-2025-stats-player`. Merge #12 and #13 first; this diff is the single commit on top.

## The gap this closes

Investigating why the in-house model projected Jaxson Dart at 214.7 while the external consensus had him at 347.6, the projection decomposed as `15.33 PPG x 14.0 games` — against a 2025 rookie season of 17.26 PPG over 14 games. The model took his rate and shrank it 11%.

Backtesting the holdout showed that shrinkage is systematic at the top end:

| prior-year baseline | n | baseline in | predicted | actual | bias |
|---|---|---|---|---|---|
| **>=15 PPG** | 47 | 17.70 | 16.08 | 17.15 | **-1.08** |
| 10-15 | 70 | 12.35 | 11.70 | 11.88 | -0.18 |
| 5-10 | 93 | 7.22 | 6.91 | 7.47 | -0.55 |
| <5 | 87 | 2.96 | 3.72 | 4.35 | -0.63 |

Two things it was *not*: there's no rookie penalty (grouped by history depth, `seasons_used=1` runs **+0.38**, slightly over-projecting), and games aren't the cause (`expected_games` runs 1.5-2.0 games *optimistic* league-wide).

The real cause is structural. The feature set was `weighted_ppg_ppr`, `weighted_games_per_season`, `seasons_used`, `ol_grade`, `skill_grade`, position dummies — nothing encoding age, experience, or draft capital. A gradient booster on those inputs can only regress a player toward the conditional mean of similar scorers. It had no way to represent "1st-round QB, age 23, entering year two", so it couldn't learn the sophomore curve even in principle.

## Changes

Adds `seasons_of_experience` (`target_season - rookie_season`), `age_at_season`, and `draft_pick`, joined from `players` on `gsis_id` at 100% coverage.

**On leakage.** These are as of `target_season`, not `target_season - 1` like every other feature. That's deliberate and not leakage — a player's age and years in the league during the season being predicted are fixed and knowable before it starts, unlike performance or team context.

**`players.years_of_experience` is deliberately unused.** It's one static value per player that doesn't equal seasons-since-rookie (Brady reads 23 against a 2000 rookie season and a 2022 final season; Josh Allen reads 9 against a 2018 rookie season), so applying it to a historical row would leak how the career eventually turned out. `rookie_season` and `birth_date` are immutable, so deriving from them is safe at any season.

**`draft_round` is left out.** `draft_pick` already encodes it, and carrying both scored marginally worse in the backtest while adding no permutation importance. NULL `draft_pick` means undrafted — signal, not absence — and HistGBR takes the NaN natively, as it already does for `skill_grade` on QB rows. Coverage is 56-81% across rookie eras with no gradient, so a null doesn't stand in for "old season".

## Validation

The built-in holdout is a single season (n=331), too thin to trust alone, so this was validated walk-forward: train on all prior labeled seasons, predict each season out of sample.

| season | R2 base → new | MAE base → new |
|---|---|---|
| 2020 | 0.592 → 0.599 | 2.942 → 2.890 |
| 2021 | 0.597 → 0.641 | 2.868 → 2.678 |
| 2022 | 0.675 → 0.680 | 2.575 → 2.578 |
| 2023 | 0.535 → 0.548 | 2.939 → 2.912 |
| 2024 | 0.627 → 0.659 | 2.854 → 2.701 |
| 2025 | 0.665 → 0.698 | 2.539 → 2.450 |
| **mean** | **0.615 → 0.638** | **2.786 → 2.701** |

Better in 6 of 6 seasons; only 2022 MAE is a hair worse. `draft_pick` lands second in permutation importance behind `weighted_ppg_ppr`. Rebuilds remain byte-identical.

## What this does and doesn't fix

Dart moves 214.7 → 224.8, and the model now projects some young QBs *above* their baseline (Caleb Williams 17.0 → 17.5) rather than always shrinking them. But it stays far below the external 347.6, because `expected_games` is still 14.0 — his rookie-year total, low because he wasn't the week-1 starter. `expected_games` is just `weighted_games_per_season`, which can't distinguish "wasn't the starter yet" from "gets injured". That's a separate fix, and likely needs the role/snap-share data currently blocked on the depth-chart format migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)