### PR TITLE
feat: expose named per-source columns alongside the consensus blend

### DIFF
--- a/src/gold/consensus.py
+++ b/src/gold/consensus.py
@@ -41,6 +41,23 @@ _PERCENTILE_AGGREGATES = """
     STDDEV(projected_points) AS stddev_points
 """
 
+# The blend alone can't be interrogated: a median tells you nothing about whether the sources agree
+# or whether one outlier is dragging it, and answering "what does our own model say versus the
+# external sites" otherwise means re-querying four or five tables by hand through three different
+# ID crosswalks. Each source contributes at most one row per player/team, so MAX() FILTER is an
+# exact pivot rather than a silent pick-one. A NULL column means that source didn't project the
+# player at all, which is itself worth seeing — it's how the in-house arm reads whenever it hasn't
+# caught up to the season the external sites are on.
+_PLAYER_SOURCES = ("espn", "sleeper", "cbs", "fftoday", "inhouse")
+_DST_SOURCES = ("espn", "sleeper", "cbs", "fftoday")
+
+
+def _per_source_columns(sources: tuple[str, ...]) -> str:
+    return ",\n".join(
+        f"    MAX(projected_points) FILTER (WHERE source = '{source}') AS {source}_points"
+        for source in sources
+    )
+
 # Every join also matches on position, since the `ids` crosswalk has a handful of duplicate
 # external IDs among long-retired/free-agent players (verified harmless against current data —
 # none of them appear in any of the active-player projection sources below — but matching on
@@ -110,7 +127,8 @@ SELECT
     gsis_id,
     ANY_VALUE(player_name) AS player_name,
     ANY_VALUE(position) AS position,
-    {_PERCENTILE_AGGREGATES}
+    {_PERCENTILE_AGGREGATES},
+{_per_source_columns(_PLAYER_SOURCES)}
 FROM source_projections
 WHERE gsis_id IS NOT NULL
     AND projected_points IS NOT NULL
@@ -150,7 +168,8 @@ WITH source_projections AS (
 )
 SELECT
     team,
-    {_PERCENTILE_AGGREGATES}
+    {_PERCENTILE_AGGREGATES},
+{_per_source_columns(_DST_SOURCES)}
 FROM source_projections
 WHERE team IS NOT NULL AND projected_points IS NOT NULL
 GROUP BY team


### PR DESCRIPTION
Off `main` — not stacked.

## Why

The consensus tables carried only aggregates: `num_sources`, `min_points`, `max_points`, `floor_p20`, `median_p50`, `ceiling_p80`, `stddev_points`. That makes the blend impossible to interrogate. A median tells you nothing about whether the sources agree or whether one outlier is dragging it, and answering "what does our own model say versus the external sites?" meant re-querying five tables by hand through three different ID crosswalks.

That's not hypothetical — it's exactly what investigating the Jaxson Dart projection took. Now it's one query:

| player | sources | median | espn | sleeper | cbs | fftoday | **inhouse** |
|---|---|---|---|---|---|---|---|
| Josh Allen | 5 | 386.1 | 369.2 | 386.1 | 419.1 | 422.1 | **340.2** |
| Caleb Williams | 5 | 354.8 | 282.1 | 357.4 | 369.5 | 354.8 | **297.2** |
| Jaxson Dart | 5 | 347.6 | 301.5 | 347.6 | 358.1 | 350.9 | **224.8** |

## Changes

Adds `espn_points`, `sleeper_points`, `cbs_points`, `fftoday_points`, `inhouse_points` to `consensus_projections`, and the same minus `inhouse` to `consensus_dst_projections` (the in-house model doesn't project defenses).

Both come from one `_per_source_columns()` helper over a source tuple rather than being written out twice, so the player and DST builds can't drift apart as sources are added.

**On correctness of the pivot.** Each source contributes at most one row per player/team — verified, no player exceeds `num_sources=5` and no team exceeds 4 — so `MAX(...) FILTER (WHERE source = ...)` is an exact pivot, not a silent pick-one. A NULL column means that source didn't project that player, which is worth seeing in itself: it's how the in-house arm reads whenever it hasn't caught up to the season the external sites are on (the guard that kept it out of the blend entirely until #13).

## Verification

Reconciled the pivot against the existing aggregates across all 728 player rows and 32 DST rows — `num_sources` equals the count of non-null per-source columns, and `min_points`/`max_points` equal `least()`/`greatest()` over them. Zero mismatches on either table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)