### PR TITLE
feat: reconcile both depth-chart formats into one weekly view

### DIFF
--- a/src/gold/depth_charts.py
+++ b/src/gold/depth_charts.py
@@ -1,0 +1,146 @@
+"""Reconcile the two depth-chart formats into one weekly per-player view.
+
+Pure warehouse-to-warehouse SQL — no fetch step, no network. Built from `depth_charts` (the
+legacy per-week format, 2015-2024) and `depth_chart_snapshots` (the dated-snapshot format nflverse
+switched to in 2025), both loaded by nfl_data.py.
+
+The two eras do not carry the same information, and this module deliberately does not pretend
+otherwise:
+
+- Legacy rows have `depth_team`, a coarse first/second/third string. Every starting receiver
+  shares depth_team = 1, so it orders strings, not players.
+- Snapshot rows have `pos_rank`, a fine ordinal over the whole position group — receivers run
+  1, 2, 3, 4 across the three receiver slots rather than tying.
+
+Collapsing those into a single "rank" column would silently present a coarse signal and a fine one
+as the same measurement. Instead each keeps its own column (`string_team` for the legacy era,
+`depth_rank` for the snapshot era, each NULL outside it) and they meet in `is_starter`, which both
+formats genuinely support. `is_starter` is the column to model on, since it's the only one that
+spans 2015-2025 — a feature that exists solely from 2025 on has one season of history and can't
+train anything.
+
+Snapshots have no week of their own, so each is assigned the week it describes: the week whose
+first regular-season game is the earliest kickoff on or after the snapshot date. Preseason
+snapshots therefore roll forward into week 1, and snapshots taken after the last regular-season
+game (the feed keeps publishing into March) fall outside the season and are dropped. Where several
+snapshots map to the same week, the last one before kickoff wins as the most current picture.
+"""
+
+from pathlib import Path
+
+import duckdb
+
+from src.silver.teams import normalize_team
+
+WAREHOUSE_PATH = Path("data/warehouse.duckdb")
+
+_SKILL_POSITIONS = ("QB", "RB", "WR", "TE")
+
+# How many of a position a team actually starts, used to turn the snapshot era's fine ordinal into
+# the same starter/non-starter call the legacy era makes natively. Three receivers because the
+# snapshot feed groups the offense as "3WR 1TE".
+_STARTER_SLOTS = {"QB": 1, "RB": 1, "WR": 3, "TE": 1}
+
+_BUILD_SQL = f"""
+CREATE OR REPLACE TABLE player_depth_chart AS
+WITH legacy AS (
+    -- depth_position filters out the special-teams duplicates: a back listed as both RB2 and the
+    -- kick returner appears twice, and the returning row isn't a statement about offensive depth.
+    SELECT
+        CAST(season AS BIGINT) AS season,
+        CAST(week AS BIGINT) AS week,
+        normalize_team(club_code) AS team,
+        gsis_id,
+        ANY_VALUE(full_name) AS player_name,
+        position,
+        MIN(CAST(depth_team AS BIGINT)) AS string_team,
+        CAST(NULL AS BIGINT) AS depth_rank
+    FROM depth_charts
+    WHERE formation = 'Offense'
+        AND position IN {_SKILL_POSITIONS}
+        AND depth_position = position
+        AND gsis_id IS NOT NULL
+        AND depth_team IS NOT NULL
+    GROUP BY season, week, normalize_team(club_code), gsis_id, position
+),
+-- Each week's kickoff, used as the boundary a snapshot is measured against.
+week_start AS (
+    SELECT season, week, MIN(CAST(gameday AS DATE)) AS first_game
+    FROM schedules
+    WHERE game_type = 'REG'
+    GROUP BY season, week
+),
+snapshot_weeks AS (
+    SELECT
+        s.dt,
+        s.season,
+        (
+            SELECT w.week FROM week_start w
+            WHERE w.season = s.season AND w.first_game >= CAST(s.dt AS DATE)
+            ORDER BY w.first_game
+            LIMIT 1
+        ) AS week
+    FROM (SELECT DISTINCT dt, season FROM depth_chart_snapshots) s
+),
+-- The most recent snapshot still ahead of each week's kickoff.
+latest_per_week AS (
+    SELECT season, week, MAX(dt) AS dt
+    FROM snapshot_weeks
+    WHERE week IS NOT NULL
+    GROUP BY season, week
+),
+snapshots AS (
+    SELECT
+        lw.season,
+        lw.week,
+        normalize_team(d.team) AS team,
+        d.gsis_id,
+        ANY_VALUE(d.player_name) AS player_name,
+        d.pos_abb AS position,
+        CAST(NULL AS BIGINT) AS string_team,
+        MIN(CAST(d.pos_rank AS BIGINT)) AS depth_rank
+    FROM depth_chart_snapshots d
+    JOIN latest_per_week lw ON lw.dt = d.dt
+    WHERE d.pos_grp = '3WR 1TE'
+        AND d.pos_abb IN {_SKILL_POSITIONS}
+        AND d.gsis_id IS NOT NULL
+    GROUP BY lw.season, lw.week, normalize_team(d.team), d.gsis_id, d.pos_abb
+),
+combined AS (
+    SELECT * FROM legacy
+    UNION ALL
+    SELECT * FROM snapshots
+)
+SELECT
+    season,
+    week,
+    team,
+    gsis_id,
+    player_name,
+    position,
+    string_team,
+    depth_rank,
+    COALESCE(
+        string_team = 1,
+        depth_rank <= CASE position {" ".join(
+            f"WHEN '{position}' THEN {slots}" for position, slots in _STARTER_SLOTS.items()
+        )} END
+    ) AS is_starter
+FROM combined
+ORDER BY season, week, team, position, COALESCE(depth_rank, string_team)
+"""
+
+
+def build_player_depth_chart() -> None:
+    con = duckdb.connect(str(WAREHOUSE_PATH))
+    con.create_function("normalize_team", normalize_team, ["VARCHAR"], "VARCHAR")
+
+    con.execute(_BUILD_SQL)
+    (count,) = con.execute("SELECT COUNT(*) FROM player_depth_chart").fetchone()
+    con.close()
+
+    print(f"Built {count} rows into {WAREHOUSE_PATH} (table: player_depth_chart)")
+
+
+if __name__ == "__main__":
+    build_player_depth_chart()

--- a/src/silver/nfl_data.py
+++ b/src/silver/nfl_data.py
@@ -117,15 +117,14 @@ def load_injuries(raw_path: Path) -> None:
 
 # nflverse reshaped depth charts from 2025 on: the old per-week rows (season/week/club_code/
 # depth_team/...) became dated snapshots (dt/team/pos_grp/pos_rank/...) with no season or week
-# column at all. Concatenating the two just unions their columns and leaves 2025 with a null
-# season, so seasons past the break are dropped rather than silently half-loaded. Nothing in src/
-# reads depth_charts yet; wiring the new format in (deriving season/week from `dt`) is its own
-# piece of work, and belongs with whatever first needs a role/snap-share feature.
+# column at all. The two can't share a table — concatenating them just unions the columns and
+# leaves every 2025 row with a null season — so each era is archived and loaded in its own shape,
+# and src/gold/depth_charts.py reconciles them into one weekly view.
 _DEPTH_CHART_SCHEMA_BREAK = 2025
 
 
 def fetch_depth_charts(seasons: list[int]) -> Path:
-    """Fetch weekly depth charts for the given seasons and save raw to parquet."""
+    """Fetch legacy per-week depth charts (pre-2025 format) and save raw to parquet."""
     seasons = [s for s in seasons if s < _DEPTH_CHART_SCHEMA_BREAK]
     df = nfl.import_depth_charts(seasons)
     return _save_raw(df, f"depth_charts_{_seasons_label(seasons)}")
@@ -133,6 +132,23 @@ def fetch_depth_charts(seasons: list[int]) -> Path:
 
 def load_depth_charts(raw_path: Path) -> None:
     _load_parquet_to_table(raw_path, "depth_charts")
+
+
+def fetch_depth_chart_snapshots(seasons: list[int]) -> Path:
+    """Fetch dated depth-chart snapshots (2025-on format) and save raw to parquet."""
+    seasons = [s for s in seasons if s >= _DEPTH_CHART_SCHEMA_BREAK]
+    df = nfl.import_depth_charts(seasons)
+    # The snapshot feed carries no season column — it's implicit in the release requested — so it's
+    # stamped on here. Without it a multi-season archive couldn't be told apart after the fact, and
+    # a snapshot's own `dt` can't stand in: a season's snapshots run from the previous August into
+    # the following March, so calendar year and season year disagree for a third of them.
+    df["season"] = df["dt"].str.slice(0, 4).astype(int)
+    df.loc[df["dt"].str.slice(5, 7) < "07", "season"] -= 1
+    return _save_raw(df, f"depth_chart_snapshots_{_seasons_label(seasons)}")
+
+
+def load_depth_chart_snapshots(raw_path: Path) -> None:
+    _load_parquet_to_table(raw_path, "depth_chart_snapshots")
 
 
 def fetch_players() -> Path:
@@ -221,6 +237,7 @@ if __name__ == "__main__":
     load_snap_counts(fetch_snap_counts(seasons))
     load_injuries(fetch_injuries(seasons))
     load_depth_charts(fetch_depth_charts(seasons))
+    load_depth_chart_snapshots(fetch_depth_chart_snapshots(seasons))
     load_ids(fetch_ids())
     load_players(fetch_players())
     load_ngs_data(fetch_ngs_data(seasons))


### PR DESCRIPTION
Off `main` — independent of #15.

## Context

nflverse reshaped depth charts in 2025: per-week rows (`season`/`week`/`club_code`/`depth_team`) became dated snapshots (`dt`/`team`/`pos_grp`/`pos_rank`) with no season or week column. #13 capped the feed at 2024 rather than ship a table where 60% of rows had a null season. This wires the new format in.

## Two eras, two shapes, one honest view

Each era is archived and loaded in its own shape — `depth_charts` (legacy) and `depth_chart_snapshots` (2025-on) — then reconciled in a new gold module, `src/gold/depth_charts.py`.

They don't carry the same information, and the model doesn't pretend they do:

- **Legacy `depth_team`** is a coarse first/second/third string. Every starting receiver ties at 1 — it orders strings, not players.
- **Snapshot `pos_rank`** is a fine ordinal over the whole position group, running 1, 2, 3, 4 across the three receiver slots.

Collapsing those into a single "rank" column would present a coarse measurement and a fine one as the same thing. Instead each keeps its own column (`string_team`, `depth_rank`, each NULL outside its era) and they meet in **`is_starter`**, which both formats genuinely support.

`is_starter` is the column to model on. It's the only one spanning 2015-2025 — a feature that exists solely from 2025 has one season of history and can't train anything.

## Deriving season and week

The snapshot feed carries no season column, so it's stamped at fetch time. A snapshot's own timestamp can't stand in: a season's snapshots run from the previous August into the following March, so calendar year and season year disagree for about a third of them.

Week is assigned as the week the snapshot *describes* — the week whose first regular-season game is the earliest kickoff on or after the snapshot date. Preseason snapshots roll forward into week 1; the 69 post-season and offseason snapshots (through 2026-03-14) fall outside and drop. Where several snapshots map to one week, the last before kickoff wins as the most current picture.

## Verification

93,421 rows, all 32 teams in every season 2015-2025.

Starters per team/week land where they should, with the legacy era's looser numbers reflecting its coarser signal:

| era | QB | RB | TE | WR |
|---|---|---|---|---|
| snapshot (2025) | 1.00 | 1.00 | 1.00 | 3.00 |
| legacy (2015-24) | 1.00 | 1.06 | 1.17 | 2.35 |

PHI 2025 week 1 resolves to Hurts (QB1), Barkley (RB1), Goedert (TE1), and Brown/Smith/Dotson (WR1-3).

Joins to `weekly_stats` REG player-weeks at 86-96% per season — highest in 2025, where the snapshot feed is more complete. The unmatched remainder is players who appeared in a game without being on that week's published chart (practice-squad elevations, late signings).

## Note

Legacy seasons carry 21-22 weeks (postseason included) while 2025 carries 18, since snapshot weeks are anchored to `game_type = 'REG'`. Regular season is what the fantasy models consume, so this doesn't affect the intended use, but it's worth knowing before querying across eras.

🤖 Generated with [Claude Code](https://claude.com/claude-code)