### PR TITLE
feat: expose each projection source as its own column on the consensus tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ network access of their own.
   actually represent (derived from their own data), not its own most-recent `target_season` —
   nflverse-fed `inhouse_projections` can lag the external sites' current-season projections, so a
   stale in-house number drops out of the blend instead of silently mixing with four current ones.
+  Alongside the blend, both tables expose each source's own number as its own column
+  (`espn_points`, `sleeper_points`, `cbs_points`, `fftoday_points`, plus `inhouse_points` on the
+  player table), so any consensus row can be traced back to what each site actually said.
   Pure SQL over already-loaded tables — no fetch step, no network.
 - `src/gold/adp_consensus.py` — builds `adp_consensus`: a consensus average draft position per
   player-season (QB/RB/WR/TE), blending `fantasypros_adp` and `ffc_adp` (FantasyFootballCalculator,

--- a/src/gold/consensus.py
+++ b/src/gold/consensus.py
@@ -12,6 +12,11 @@ Two output tables, because team defenses need a different join key than individu
 - consensus_dst_projections: team defenses, joined on a normalized team abbreviation (see
   teams.py) instead, since `ids` is player-level and has no team-defense entries.
 
+Both tables carry each source's own number alongside the blend (`espn_points`, `sleeper_points`,
+`cbs_points`, `fftoday_points`, and `inhouse_points` on the player table), so a consensus row can
+be traced back to what each site actually said and a missing source reads as a NULL column rather
+than just a lower `num_sources`.
+
 inhouse_projections can lag behind the other four sources: its prior-year feature data comes from
 nflverse, which publishes noticeably slower than the external sites' own current-season
 projections, so its latest `target_season` isn't guaranteed to be the season the other four
@@ -31,14 +36,34 @@ WAREHOUSE_PATH = Path("data/warehouse.duckdb")
 
 _SKILL_POSITIONS = ("QB", "RB", "WR", "TE", "K")
 
-_PERCENTILE_AGGREGATES = """
+# The sources unioned into each table's `source_projections` CTE, in blend order. Team defenses
+# have no in-house arm — inhouse_projections is player-level only.
+_SOURCES = ("espn", "sleeper", "cbs", "fftoday", "inhouse")
+_DST_SOURCES = ("espn", "sleeper", "cbs", "fftoday")
+
+
+def _aggregates(sources: tuple[str, ...]) -> str:
+    """Aggregate SELECT list for one consensus table: the blend, then each source on its own.
+
+    Both tables get their column list from here so the two can't drift apart — the per-source
+    columns are a pivot of the exact same `source_projections` rows the percentiles summarize,
+    not a second pass over the underlying tables. MAX() is just the pivot's pick-one aggregate:
+    every source contributes at most one row per key today (verified — non-null per-source columns
+    add up to `num_sources` on every row of both tables), so it never actually collapses anything.
+    """
+    per_source = ",\n".join(
+        f"    MAX(projected_points) FILTER (WHERE source = '{source}') AS {source}_points"
+        for source in sources
+    )
+    return f"""
     COUNT(*) AS num_sources,
     MIN(projected_points) AS min_points,
     MAX(projected_points) AS max_points,
     PERCENTILE_CONT(0.2) WITHIN GROUP (ORDER BY projected_points) AS floor_p20,
     PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY projected_points) AS median_p50,
     PERCENTILE_CONT(0.8) WITHIN GROUP (ORDER BY projected_points) AS ceiling_p80,
-    STDDEV(projected_points) AS stddev_points
+    STDDEV(projected_points) AS stddev_points,
+{per_source}
 """
 
 # Every join also matches on position, since the `ids` crosswalk has a handful of duplicate
@@ -110,7 +135,7 @@ SELECT
     gsis_id,
     ANY_VALUE(player_name) AS player_name,
     ANY_VALUE(position) AS position,
-    {_PERCENTILE_AGGREGATES}
+    {_aggregates(_SOURCES)}
 FROM source_projections
 WHERE gsis_id IS NOT NULL
     AND projected_points IS NOT NULL
@@ -150,7 +175,7 @@ WITH source_projections AS (
 )
 SELECT
     team,
-    {_PERCENTILE_AGGREGATES}
+    {_aggregates(_DST_SOURCES)}
 FROM source_projections
 WHERE team IS NOT NULL AND projected_points IS NOT NULL
 GROUP BY team


### PR DESCRIPTION
## What

`consensus_projections` and `consensus_dst_projections` only carried the blend (median/floor/ceiling/stddev), so a row couldn't be traced back to what any individual site actually said — a missing source only showed up as a lower `num_sources`.

Both tables now pivot each source out as its own column:

- `consensus_projections`: `espn_points`, `sleeper_points`, `cbs_points`, `fftoday_points`, `inhouse_points`
- `consensus_dst_projections`: the same minus in-house (defenses have no in-house arm — `inhouse_projections` is player-level only)

One `_aggregates(sources)` helper emits the whole aggregate SELECT list for both tables, so the two can't drift apart. The pivot reads the same `source_projections` CTE the percentiles do, so it's not a second pass over the underlying tables.

## Verification

Rebuilt both tables and reconciled every row — 728 player rows, 32 DST rows, **0 mismatches**. The check unpivots the new columns back to rows and recomputes `num_sources`/min/max/p20/median/p80/stddev against what's stored. That confirms both that the per-source values are exactly the inputs the blend saw, and that the pivot's `MAX()` never collapses anything (non-null column counts equal `num_sources` on every row, so no source contributes two rows for one key).

Source coverage on the player table, previously invisible inside `num_sources`:

| source | rows of 728 |
| --- | --- |
| espn | 542 |
| sleeper | 538 |
| inhouse | 527 |
| cbs | 408 |
| fftoday | 231 |

All 32 defenses have all four sources. FFToday being that thin is a real gap worth tracking separately.

README's `src/gold/` entry updated to describe the new columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)