### PR TITLE
feat: close the gap to the external projection sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,24 @@ network access of their own.
   only counts toward the baseline if the player played at least 6 games in it, so an
   injury-shortened or backup-role cameo doesn't distort the per-game rate. Also outputs
   `weighted_games_per_season`, the same recency-weighted average applied to games played instead —
-  a durability signal. A feature-engineering building block, not a projection itself. Pure SQL
-  over already-loaded tables — no fetch step, no network.
+  a durability signal.
+
+  A points-per-game number alone throws away everything about *how* those points were earned,
+  which is most of what makes next season predictable — volume is far more stable year over year
+  than touchdown rate, so 17 PPG on 9 targets a game means something very different from 17 PPG on
+  4 targets and triple the league's touchdown rate. The same recency weighting is therefore also
+  applied to a component block: **volume** (targets/receptions/carries/attempts/yards/touchdowns
+  per game, with touchdowns kept separate from yards so an unsustainable scoring rate stays its own
+  visible signal), **role** (target share, air-yards share, WOPR, and snap share joined from
+  `snap_counts` through the `ids` crosswalk at 99%+ coverage), and **efficiency** (passing/rushing/
+  receiving EPA and CPOE, left NULL where a position doesn't do that thing rather than zero-filled,
+  so "didn't do this" stays distinguishable from "did this badly"). Plus
+  `weighted_td_regressed_ppg` — PPG recomputed with the player's own touchdowns swapped for the
+  touchdowns their yardage would have produced at that season's league-average rate, per position
+  but falling back to a pooled rate where a position-season is too thin to estimate from (RBs threw
+  for 3 touchdowns on 9 yards league-wide in 2024, a rate of 0.33 touchdowns *per yard*). A
+  feature-engineering building block, not a projection itself. Pure SQL over already-loaded
+  tables — no fetch step, no network.
 - `src/gold/league_settings.py` — builds `league_settings`: one row per league (Sleeper, ESPN)
   normalizing each platform's scoring rules (points per reception/yard/TD/turnover, etc.) and
   starting-roster construction (team count and QB/RB/WR/TE/FLEX/superflex/bench/IR slot counts)
@@ -125,7 +141,8 @@ network access of their own.
   loaded tables — no fetch step, no network.
 - `src/gold/inhouse_projections.py` — builds `inhouse_projections`: a home-grown PPG projection
   from a gradient-boosted model (scikit-learn's `HistGradientBoostingRegressor`), trained on a
-  shift-based setup — `player_weighted_baselines` plus prior-season `offensive_line_grades`/
+  shift-based setup — `player_weighted_baselines` (its full volume/role/efficiency component block,
+  not just `weighted_ppg_ppr`) plus prior-season `offensive_line_grades`/
   `skill_position_grades` as features, actual next-season PPG as the label — then converted to a
   season-total point projection. Emits that total twice, because the model and the external sites
   don't answer the same question: `projected_points_full` (PPG x season length, read from

--- a/README.md
+++ b/README.md
@@ -23,7 +23,12 @@ network access of their own.
 
 - `src/silver/nfl_data.py` — nflverse data via `nfl_data_py`: weekly stats, schedules, rosters,
   snap counts, injuries, seasonal data, depth charts, player bios, Next Gen Stats, FTN charting
-  data, PFR advanced pass/rush stats, and a cross-platform player ID crosswalk.
+  data, PFR advanced pass/rush stats, and a cross-platform player ID crosswalk. Most feeds are a
+  record of games already played and stop at the last completed season, but schedules and
+  depth-chart snapshots describe a season *before* it's played — the schedule is published in May,
+  snapshots run from the previous March through the summer — so both are fetched a year further
+  forward, which is what gives `inhouse_projections` a role signal for the season it projects.
+  Bump `_UPCOMING_SEASON` once a year.
 - `src/silver/sleeper.py` — Sleeper's public league API (no auth required): league settings,
   rosters, users, weekly matchups (including starting lineups), transactions, current NFL state,
   and the full player dictionary. Set `LEAGUE_ID` in the module before running.
@@ -79,14 +84,15 @@ network access of their own.
   Alongside the blend, both tables expose each source's own number as its own column
   (`espn_points`, `sleeper_points`, `cbs_points`, `fftoday_points`, plus `inhouse_points` on the
   player table), so any consensus row can be traced back to what each site actually said.
-  All four external sources publish a *full-season* number — verified against CBS, the one source
-  that gives per-game points alongside the season total: its implied games played is 17.0 for all
-  888 of its rows, and the other three land within a percent of the same assumption. None of them
-  discounts for injury risk, so the in-house arm is blended in through its `projected_points_full`
-  column rather than its availability-discounted `projected_points`; mixing the two would be a
-  units mismatch rather than a difference of opinion, and would pull every percentile down hardest
-  on exactly the players most likely to miss time. Pure SQL over already-loaded tables — no fetch
-  step, no network.
+  The external sources decompose a season differently from the in-house model, and reconciling that
+  is what makes the five numbers averageable. Verified against CBS, the one source giving per-game
+  points alongside the season total: it projects 17.0 games for every player it covers, backups
+  included — so it never discounts for injury risk, but it does discount for *role*, through the
+  per-game term instead (Jake Browning: 0.9 points per game across a full 17). The other three
+  behave the same way. The in-house arm is therefore blended through `projected_points_full`, which
+  reproduces that same split, rather than its availability-discounted `projected_points`; mixing
+  the two would pull every percentile down hardest on exactly the players most likely to miss time.
+  Pure SQL over already-loaded tables — no fetch step, no network.
 - `src/gold/adp_consensus.py` — builds `adp_consensus`: a consensus average draft position per
   player-season (QB/RB/WR/TE), blending `fantasypros_adp` and `ffc_adp` (FantasyFootballCalculator,
   PPR format) onto a shared `gsis_id` via the `merge_name` normalization in `players.py`, since
@@ -144,13 +150,23 @@ network access of their own.
   shift-based setup — `player_weighted_baselines` (its full volume/role/efficiency component block,
   not just `weighted_ppg_ppr`) plus prior-season `offensive_line_grades`/
   `skill_position_grades` as features, actual next-season PPG as the label — then converted to a
-  season-total point projection. Emits that total twice, because the model and the external sites
-  don't answer the same question: `projected_points_full` (PPG x season length, read from
-  `schedules` rather than hardcoded to 17, since the warehouse still holds 16-game seasons) is the
-  health-neutral number every external site publishes, and is what `consensus.py` blends;
-  `projected_points` (PPG x separately-modelled `expected_games`) is the same projection scaled by
-  expected availability — more informative for ranking a real roster, just not comparable to what
-  the sites print. The only `src/gold` module that isn't pure SQL (Python/pandas/scikit-learn over
+  season-total point projection. Also takes a role block as of the start of the season being
+  projected — `target_is_starter` and `changed_team`, from that season's week 1 depth chart, which
+  is published before a snap is played and so says nothing about the label. That is what lets the
+  model tell an incumbent from a career backup with an identical per-game history, and it also
+  repoints the OL/skill-corps grades at the team a player is *joining* rather than the one he left.
+
+  Emits the season total twice, because the model and the sites decompose a season differently.
+  `projected_points` (PPG x separately-modelled `expected_games`) is the honest expectation, and
+  the number to rank a real roster on. `projected_points_full` is what `consensus.py` blends: it
+  keeps the role discount the sites apply but drops the injury discount they don't, by measuring a
+  player's expected games against a starter's at the same position and season. Season length is
+  read from `schedules` rather than hardcoded to 17, since the warehouse still holds 16-game
+  seasons. One known bias remains in both totals: `expected_games` counts appearances in
+  `weekly_stats`, so a player who never takes a snap has no row to count and the label bottoms out
+  at 1 game rather than 0 — career backups are projected for more games than they'll play, and the
+  walk-forward can't see it, because the scoring label's games floor excludes exactly those
+  players. The only `src/gold` module that isn't pure SQL (Python/pandas/scikit-learn over
   already-loaded tables instead). Feeds into `consensus.py` as a fifth projection source.
 
   Also builds `inhouse_backtest`, the accept/reject instrument for any future change to the model:

--- a/README.md
+++ b/README.md
@@ -79,7 +79,14 @@ network access of their own.
   Alongside the blend, both tables expose each source's own number as its own column
   (`espn_points`, `sleeper_points`, `cbs_points`, `fftoday_points`, plus `inhouse_points` on the
   player table), so any consensus row can be traced back to what each site actually said.
-  Pure SQL over already-loaded tables — no fetch step, no network.
+  All four external sources publish a *full-season* number — verified against CBS, the one source
+  that gives per-game points alongside the season total: its implied games played is 17.0 for all
+  888 of its rows, and the other three land within a percent of the same assumption. None of them
+  discounts for injury risk, so the in-house arm is blended in through its `projected_points_full`
+  column rather than its availability-discounted `projected_points`; mixing the two would be a
+  units mismatch rather than a difference of opinion, and would pull every percentile down hardest
+  on exactly the players most likely to miss time. Pure SQL over already-loaded tables — no fetch
+  step, no network.
 - `src/gold/adp_consensus.py` — builds `adp_consensus`: a consensus average draft position per
   player-season (QB/RB/WR/TE), blending `fantasypros_adp` and `ffc_adp` (FantasyFootballCalculator,
   PPR format) onto a shared `gsis_id` via the `merge_name` normalization in `players.py`, since
@@ -120,13 +127,27 @@ network access of their own.
   from a gradient-boosted model (scikit-learn's `HistGradientBoostingRegressor`), trained on a
   shift-based setup — `player_weighted_baselines` plus prior-season `offensive_line_grades`/
   `skill_position_grades` as features, actual next-season PPG as the label — then converted to a
-  season-total point projection via the `weighted_games_per_season` durability signal. The only
-  `src/gold` module that isn't pure SQL (Python/pandas/scikit-learn over already-loaded tables
-  instead), and the only one with a genuine train/holdout split, printing out-of-sample MAE/R2 on
-  each run, alongside out-of-sample permutation feature importance — which preseason signals
-  (recency-weighted history, durability, OL/skill-position grades) actually move the prediction,
-  not just which ones are in the feature list. Feeds into `consensus.py` as a fifth projection
-  source.
+  season-total point projection. Emits that total twice, because the model and the external sites
+  don't answer the same question: `projected_points_full` (PPG x season length, read from
+  `schedules` rather than hardcoded to 17, since the warehouse still holds 16-game seasons) is the
+  health-neutral number every external site publishes, and is what `consensus.py` blends;
+  `projected_points` (PPG x separately-modelled `expected_games`) is the same projection scaled by
+  expected availability — more informative for ranking a real roster, just not comparable to what
+  the sites print. The only `src/gold` module that isn't pure SQL (Python/pandas/scikit-learn over
+  already-loaded tables instead). Feeds into `consensus.py` as a fifth projection source.
+
+  Also builds `inhouse_backtest`, the accept/reject instrument for any future change to the model:
+  a **walk-forward** evaluation that predicts each labeled season from a model trained only on the
+  seasons before it, one fold per season, scored per position (MAE, R2, Spearman) against three
+  benchmarks — carrying last season's weighted rate forward unchanged, the preseason draft market's
+  own ordering (`adp_consensus`, re-scored on the ADP-covered players so both sit on the same
+  population), and for the availability half, `weighted_games_per_season`. ADP is the parity
+  benchmark rather than a feature: `breakout_candidates.py`'s whole premise is that this model is
+  ADP-blind, so a model that had seen ADP couldn't meaningfully disagree with it. Every fold's
+  out-of-sample predictions are stored in `inhouse_projections` alongside the live season, so
+  downstream models can be backtested too. Each run also prints out-of-sample permutation feature
+  importance — which preseason signals actually move the prediction, not just which ones are in the
+  feature list.
 - `src/gold/points_over_replacement.py` — builds `points_over_replacement`: each skill-position
   player's season-total fantasy points, recomputed from nflverse weekly stats under each league's
   own `league_settings` scoring coefficients (not nflverse's canned PPR formula), minus that

--- a/README.md
+++ b/README.md
@@ -163,28 +163,34 @@ network access of their own.
   keeps the role discount the sites apply but drops the injury discount they don't, by measuring a
   player's expected games against a starter's at the same position and season. Season length is
   read from `schedules` rather than hardcoded to 17, since the warehouse still holds 16-game
-  seasons. One known bias remains in both totals: `expected_games` counts appearances in
-  `weekly_stats`, so a player who never takes a snap has no row to count and the label bottoms out
-  at 1 game rather than 0 — career backups are projected for more games than they'll play, and the
-  walk-forward can't see it, because the scoring label's games floor excludes exactly those
-  players.
+  seasons. Both totals depend on `expected_games`, whose label is anchored on the **roster** rather
+  than the box score: a player who was in the league all season and never took a snap has no
+  `weekly_stats` row at all, so counting only those rows made him read as unobserved instead of as
+  the zero he is (~90-110 players a season). Without those zeros the model can't answer below about
+  4 games and career backups keep season totals they'll never earn. The scoring walk-forward can't
+  see any of this — its games floor excludes exactly the affected players — so availability is
+  scored on its own population.
 
-  A second, much smaller model covers **first-season players**, who have no prior-season history
-  for any of the above to read and so were absent from the table entirely (150 players ESPN
-  projected and this warehouse didn't, the whole incoming rookie class among them). It reads what a
-  human reads for a rookie: draft capital, the landing spot's line and skill-corps grades, and
-  whether he has already won a week 1 job. Its cohort — every first-season player reaching that
-  season's week 1 depth chart — is a *closed* population, which makes its availability label the
-  one genuinely uncensored label here: a rookie with no `weekly_stats` row didn't play, so 0 is
-  honest rather than missing. Draft capital comes from `rosters.draft_number` rather than
+  A second, much smaller model covers everyone the first structurally can't see: players with **no
+  `player_weighted_baselines` row**, having never put together a season of 6+ games. Every feature
+  above derives from that row, so without one there's nothing to predict from, and those players
+  were absent from the table entirely (150 that ESPN projected and this warehouse didn't). Two
+  groups land there and they're the same modelling problem — rookies with no NFL history at all,
+  and fringe veterans who've played but never enough in one season to earn a baseline. It reads
+  what a human reads for an unproven player: draft capital, the landing spot's line and skill-corps
+  grades, whether he's already won a week 1 job, and an unweighted career rate that's NULL for a
+  true rookie and so tells the model which of the two it's looking at. Its cohort — every such
+  player reaching that season's week 1 depth chart — is a *closed* population, so its availability
+  label is uncensored by construction. Draft capital comes from `rosters.draft_number` rather than
   `players.draft_pick`, which is the more natural home for it but lags by months and carried no
   2026 class at all during the 2026 preseason. Both arms write to the same table, so `role_games`
   normalises over one combined population and consumers don't need to know there are two models
-  behind the column. Backtested the same walk-forward way, the rookie arm is the one place in this
-  warehouse that **beats** preseason ADP at ranking (Spearman 0.620 vs 0.503 pooled over 2020-2025),
-  which is less surprising than it sounds: rookie ADP is hype-driven, while draft slot and a won
-  job are not. The only `src/gold` module that isn't pure SQL (Python/pandas/scikit-learn over
-  already-loaded tables instead). Feeds into `consensus.py` as a fifth projection source.
+  behind the column. Backtested the same walk-forward way, this arm is the one place in the
+  warehouse that **beats** preseason ADP at ranking (Spearman 0.618 vs 0.494 pooled over
+  2020-2025), which is less surprising than it sounds: ADP for unproven players is hype-driven,
+  while draft slot and a won job are not. The only `src/gold` module that isn't pure SQL
+  (Python/pandas/scikit-learn over already-loaded tables instead). Feeds into `consensus.py` as a
+  fifth projection source.
 
   Also builds `inhouse_backtest`, the accept/reject instrument for any future change to the model:
   a **walk-forward** evaluation that predicts each labeled season from a model trained only on the

--- a/README.md
+++ b/README.md
@@ -24,10 +24,11 @@ network access of their own.
 - `src/silver/nfl_data.py` — nflverse data via `nfl_data_py`: weekly stats, schedules, rosters,
   snap counts, injuries, seasonal data, depth charts, player bios, Next Gen Stats, FTN charting
   data, PFR advanced pass/rush stats, and a cross-platform player ID crosswalk. Most feeds are a
-  record of games already played and stop at the last completed season, but schedules and
-  depth-chart snapshots describe a season *before* it's played — the schedule is published in May,
-  snapshots run from the previous March through the summer — so both are fetched a year further
-  forward, which is what gives `inhouse_projections` a role signal for the season it projects.
+  record of games already played and stop at the last completed season, but schedules, depth-chart
+  snapshots and rosters all describe a season *before* it's played — the schedule is published in
+  May, snapshots run from the previous March through the summer, and preseason rosters carry
+  `draft_number`/`years_exp` — so those three are fetched a year further forward. That is what
+  gives `inhouse_projections` a role signal and a rookie draft board for the season it projects.
   Bump `_UPCOMING_SEASON` once a year.
 - `src/silver/sleeper.py` — Sleeper's public league API (no auth required): league settings,
   rosters, users, weekly matchups (including starting lineups), transactions, current NFL state,
@@ -166,7 +167,23 @@ network access of their own.
   `weekly_stats`, so a player who never takes a snap has no row to count and the label bottoms out
   at 1 game rather than 0 — career backups are projected for more games than they'll play, and the
   walk-forward can't see it, because the scoring label's games floor excludes exactly those
-  players. The only `src/gold` module that isn't pure SQL (Python/pandas/scikit-learn over
+  players.
+
+  A second, much smaller model covers **first-season players**, who have no prior-season history
+  for any of the above to read and so were absent from the table entirely (150 players ESPN
+  projected and this warehouse didn't, the whole incoming rookie class among them). It reads what a
+  human reads for a rookie: draft capital, the landing spot's line and skill-corps grades, and
+  whether he has already won a week 1 job. Its cohort — every first-season player reaching that
+  season's week 1 depth chart — is a *closed* population, which makes its availability label the
+  one genuinely uncensored label here: a rookie with no `weekly_stats` row didn't play, so 0 is
+  honest rather than missing. Draft capital comes from `rosters.draft_number` rather than
+  `players.draft_pick`, which is the more natural home for it but lags by months and carried no
+  2026 class at all during the 2026 preseason. Both arms write to the same table, so `role_games`
+  normalises over one combined population and consumers don't need to know there are two models
+  behind the column. Backtested the same walk-forward way, the rookie arm is the one place in this
+  warehouse that **beats** preseason ADP at ranking (Spearman 0.620 vs 0.503 pooled over 2020-2025),
+  which is less surprising than it sounds: rookie ADP is hype-driven, while draft slot and a won
+  job are not. The only `src/gold` module that isn't pure SQL (Python/pandas/scikit-learn over
   already-loaded tables instead). Feeds into `consensus.py` as a fifth projection source.
 
   Also builds `inhouse_backtest`, the accept/reject instrument for any future change to the model:

--- a/scripts/build_warehouse.sh
+++ b/scripts/build_warehouse.sh
@@ -12,15 +12,28 @@ python -m src.silver.nfl_data
 python -m src.silver.sleeper
 python -m src.silver.espn
 python -m src.silver.fantasypros
+python -m src.silver.fantasyfootballcalculator
 python -m src.silver.fftoday
 python -m src.silver.cbs
 
-# Gold layer, in dependency order: the team-context grades and player baseline are pure
-# transforms of nfl_data.py's tables; inhouse_projections depends on all three of those; consensus
-# depends on every source above (external sites joined through the nflverse `ids` crosswalk,
-# inhouse_projections joined directly since it's already keyed on that same ID space).
+# Gold layer, in dependency order.
+#
+# First tier — pure transforms of a silver table, depending on nothing else in gold:
 python -m src.gold.offensive_line
 python -m src.gold.skill_position_grades
 python -m src.gold.player_baselines
+python -m src.gold.depth_charts
+python -m src.gold.adp_consensus
+python -m src.gold.league_settings
+
+# Second tier — inhouse_projections needs every first-tier table except league_settings
+# (player_weighted_baselines, the two grade tables, player_depth_chart, and adp_consensus as its
+# backtest benchmark); points_over_replacement needs league_settings for per-league scoring.
 python -m src.gold.inhouse_projections
+python -m src.gold.points_over_replacement
+
+# Third tier — consensus blends every external source plus inhouse_projections; boom_bust and
+# breakout_candidates each read a second-tier table alongside adp_consensus.
 python -m src.gold.consensus
+python -m src.gold.boom_bust
+python -m src.gold.breakout_candidates

--- a/src/gold/consensus.py
+++ b/src/gold/consensus.py
@@ -17,14 +17,18 @@ Both tables carry each source's own number alongside the blend (`espn_points`, `
 be traced back to what each site actually said and a missing source reads as a NULL column rather
 than just a lower `num_sources`.
 
-Every external source here projects a *full* season for every player it covers — verified against
-CBS, the one source that publishes per-game points alongside the season total: its implied games
-played is 17.0 for all 888 of its rows, with the others' totals landing within a percent of the
-same assumption. None of them is discounting for injury risk. inhouse_projections is therefore
-blended in through `projected_points_full` (PPG x season length) rather than its default
-`projected_points` (PPG x *expected* games), which would otherwise be the only availability-
-discounted number in a pool of four health-neutral ones and would drag every consensus percentile
-down on exactly the players most likely to miss time.
+The external sources decompose a season differently from inhouse_projections, in a way that has to
+be reconciled before the five numbers can be averaged at all. Verified against CBS, the one source
+publishing per-game points alongside the season total: it projects 17.0 games for every player it
+covers, backups included, so it never discounts for injury risk — but it does discount for *role*,
+through the per-game term instead (Jake Browning: 0.9 points per game across a full 17). The other
+three sites' totals behave the same way.
+
+inhouse_projections is therefore blended in through `projected_points_full`, which reproduces that
+split — role discount kept, injury discount dropped — rather than its `projected_points`, the
+honest expectation including injury risk. Blending the latter would put the only availability-
+discounted number in a pool of four health-neutral ones and drag every consensus percentile down on
+exactly the players most likely to miss time.
 
 inhouse_projections can lag behind the other four sources: its prior-year feature data comes from
 nflverse, which publishes noticeably slower than the external sites' own current-season

--- a/src/gold/consensus.py
+++ b/src/gold/consensus.py
@@ -17,6 +17,15 @@ Both tables carry each source's own number alongside the blend (`espn_points`, `
 be traced back to what each site actually said and a missing source reads as a NULL column rather
 than just a lower `num_sources`.
 
+Every external source here projects a *full* season for every player it covers — verified against
+CBS, the one source that publishes per-game points alongside the season total: its implied games
+played is 17.0 for all 888 of its rows, with the others' totals landing within a percent of the
+same assumption. None of them is discounting for injury risk. inhouse_projections is therefore
+blended in through `projected_points_full` (PPG x season length) rather than its default
+`projected_points` (PPG x *expected* games), which would otherwise be the only availability-
+discounted number in a pool of four health-neutral ones and would drag every consensus percentile
+down on exactly the players most likely to miss time.
+
 inhouse_projections can lag behind the other four sources: its prior-year feature data comes from
 nflverse, which publishes noticeably slower than the external sites' own current-season
 projections, so its latest `target_season` isn't guaranteed to be the season the other four
@@ -127,7 +136,11 @@ source_projections AS (
     -- this source never goes through ids at all. Scoped to current_season, not inhouse's own
     -- MAX(target_season) — if inhouse hasn't caught up to the season the other sources represent,
     -- it drops out of the blend entirely rather than contributing a stale number.
-    SELECT player_id, player_name, position, 'inhouse', projected_points
+    --
+    -- projected_points_full, not projected_points: the external sources all publish a
+    -- health-neutral full-season number (see module docstring), so blending in inhouse's
+    -- availability-discounted one would be a units mismatch, not a difference of opinion.
+    SELECT player_id, player_name, position, 'inhouse', projected_points_full
     FROM inhouse_projections
     WHERE target_season = (SELECT season FROM current_season)
 )

--- a/src/gold/inhouse_projections.py
+++ b/src/gold/inhouse_projections.py
@@ -33,6 +33,20 @@ Label: actual PPG in `target_season`, only for players who played >= the same ga
 `player_baselines.py` uses (imported, not redefined) — an actual season cut short by injury is as
 untrustworthy a training target as a short season is a baseline input.
 
+A second, much smaller model covers first-season players, who have no prior-season history for the
+features above to read and so were simply absent from this table — 150 players ESPN projected and
+this warehouse didn't, the entire incoming rookie class among them. It reads what a drafting human
+reads for a rookie instead: draft capital, the landing spot's line and skill-corps grades, and
+whether he's already won a week 1 job. Its cohort is every first-season player who reaches that
+season's week 1 depth chart, which makes its availability label genuinely uncensored — that
+population is closed, so a rookie with no weekly_stats row didn't play, and 0 is the honest label
+rather than a missing row. Both arms write to this one table so that `_role_games` normalises over
+one combined population and consumers don't need to know there are two models behind the column.
+
+Draft capital comes from `rosters.draft_number`, not `players.draft_pick`: the latter is the more
+natural home for it but is published on a long enough lag that it carried no 2026 draft class at
+all during the 2026 preseason, which would have left the arm blind in exactly the season it's for.
+
 Every stored prediction is produced without the model having seen its own label:
 - each labeled `target_season` from the first fold onward is predicted by a model trained only on
   the labeled seasons *before* it — a walk-forward backtest, one fold per season (see
@@ -145,7 +159,118 @@ WHERE game_type = 'REG'
 GROUP BY season
 """
 
+# Rookies get their own model rather than a row in the one above, because the veteran model's
+# entire input is a prior-season history they don't have — a first-year player has no
+# player_weighted_baselines row at all, which is why they were simply absent from this table until
+# now (150 players ESPN projected and this warehouse didn't, including every 2026 first-rounder).
+#
+# What replaces that history is what a drafting human uses for a rookie anyway: where he went in
+# the draft, what he walked into, and whether he's already won a job. Kept deliberately small —
+# roughly 60-95 rookies reach a week 1 depth chart per season, so this trains on hundreds of rows
+# where the veteran arm has thousands, and a wide feature set would just memorise them.
+_ROOKIE_FEATURES = [
+    "draft_number", "age_at_season", "ol_grade", "skill_grade", "target_is_starter",
+]
+_ROOKIE_FEATURE_COLUMNS = _ROOKIE_FEATURES + [f"position_{p}" for p in _SKILL_POSITIONS]
+
+# Draft capital and a won job are close to the whole story on whether a rookie sees the field;
+# nothing about the landing spot's blocking tells you much about his own availability.
+_ROOKIE_GAMES_FEATURE_COLUMNS = [
+    "draft_number", "age_at_season", "target_is_starter",
+] + [f"position_{p}" for p in _SKILL_POSITIONS]
+
 _COMPONENT_SELECTS = ",\n".join(f"    b.{column}" for column in _COMPONENT_COLUMNS)
+
+# The rookie cohort is every first-season player who reaches that season's week 1 depth chart.
+# Roster membership alone would be the wrong test: it isn't comparable across eras (the current
+# feed lists a preseason 90-man roster where the older ones list far fewer), and a rookie who never
+# reaches a depth chart is not a player any draft board needs a number for.
+#
+# draft_number comes from rosters rather than players.draft_pick, which is the more natural home
+# for it but is published on a long enough lag that it had no 2026 class at all while the roster
+# feed already carried the full board. NULL means undrafted, which is signal, not absence.
+_ROOKIE_FEATURE_SQL = f"""
+WITH rookie_cohort AS (
+    SELECT
+        player_id,
+        season,
+        MIN(draft_number) AS draft_number,
+        ANY_VALUE(player_name) AS player_name,
+        MIN(position) AS position
+    FROM rosters
+    WHERE years_exp = 0 AND position IN {_SKILL_POSITIONS}
+    GROUP BY player_id, season
+),
+week_one_role AS (
+    SELECT
+        season,
+        gsis_id,
+        MIN(team) AS team,
+        MAX(CASE WHEN is_starter THEN 1 ELSE 0 END) AS is_starter
+    FROM player_depth_chart
+    WHERE week = 1
+    GROUP BY season, gsis_id
+),
+actual_scoring AS (
+    SELECT
+        player_id,
+        season AS target_season,
+        SUM(fantasy_points_ppr) / COUNT(*) AS actual_ppg_ppr
+    FROM weekly_stats
+    WHERE season_type = 'REG'
+        AND fantasy_points_ppr IS NOT NULL
+        AND position IN {_SKILL_POSITIONS}
+    GROUP BY player_id, season
+    HAVING COUNT(*) >= {_MIN_GAMES_PLAYED}
+),
+actual_availability AS (
+    SELECT player_id, season AS target_season, COUNT(*) AS actual_games
+    FROM weekly_stats
+    WHERE season_type = 'REG'
+        AND fantasy_points_ppr IS NOT NULL
+        AND position IN {_SKILL_POSITIONS}
+    GROUP BY player_id, season
+)
+SELECT
+    r.season AS target_season,
+    r.player_id,
+    r.player_name,
+    r.position,
+    r.draft_number,
+    w.team AS context_team,
+    w.is_starter AS target_is_starter,
+    r.season - YEAR(TRY_CAST(pl.birth_date AS DATE)) AS age_at_season,
+    ol.ol_grade,
+    sk.grade AS skill_grade,
+    -- Benchmark only, never a feature, for the same reason as the veteran arm.
+    adp.consensus_adp,
+    o.actual_ppg_ppr,
+    -- Unlike the veteran arm, this label is genuinely uncensored. The cohort is a closed
+    -- population — every first-season player on the week 1 chart — so a rookie with no
+    -- weekly_stats row didn't play, rather than being unobserved, and 0 is the honest label. That
+    -- is exactly the bias the veteran games model still carries and this one doesn't.
+    --
+    -- Guarded on the season having actually been played: without it the live season's rookies,
+    -- who have no weekly_stats rows because the season hasn't started, would every one of them be
+    -- labelled a genuine 0 and train the games model to predict that nobody plays.
+    CASE
+        WHEN r.season <= (SELECT MAX(season) FROM weekly_stats)
+        THEN COALESCE(av.actual_games, 0)
+    END AS actual_games
+FROM rookie_cohort r
+JOIN week_one_role w ON w.gsis_id = r.player_id AND w.season = r.season
+LEFT JOIN players pl ON pl.gsis_id = r.player_id
+LEFT JOIN offensive_line_grades ol ON ol.team = w.team AND ol.season = r.season - 1
+LEFT JOIN skill_position_grades sk
+    ON sk.team = w.team AND sk.season = r.season - 1 AND sk.position = r.position
+LEFT JOIN adp_consensus adp ON adp.gsis_id = r.player_id AND adp.season = r.season
+LEFT JOIN actual_scoring o ON o.player_id = r.player_id AND o.target_season = r.season
+LEFT JOIN actual_availability av
+    ON av.player_id = r.player_id AND av.target_season = r.season
+-- Same reproducibility guard as the veteran query: a stable total order over the frame, so
+-- histogram binning can't shift between runs on identical data.
+ORDER BY r.season, r.player_id
+"""
 
 # player_team resolves each player's most-played team in a season (mirrors the
 # team_by_player_season pattern in skill_position_grades.py, over weekly_stats instead of
@@ -354,6 +479,16 @@ def _fit_games(train: pd.DataFrame) -> HistGradientBoostingRegressor:
     return model
 
 
+def _fit_generic(
+    train: pd.DataFrame, feature_columns: list[str], label: str
+) -> HistGradientBoostingRegressor:
+    """Same estimator and settings, with the feature set and label passed in — the rookie arm uses
+    a different set of both, but there's no reason for it to use different hyperparameters."""
+    model = HistGradientBoostingRegressor(**_MODEL_PARAMS)
+    model.fit(train[feature_columns], train[label])
+    return model
+
+
 def _metrics(fold: pd.DataFrame, target_season: int, position: str) -> dict:
     """Score one fold (or one position within it) against every benchmark worth beating.
 
@@ -411,6 +546,78 @@ def _games_metrics(games_fold: pd.DataFrame) -> dict:
         "games_naive_mae": mean_absolute_error(games_fold["actual_games"],
                                                games_fold["weighted_games_per_season"]),
     }
+
+
+def _rookie_metrics(fold: pd.DataFrame, target_season: int) -> dict:
+    """Score one rookie fold.
+
+    The naive benchmark can't be "carry last season forward" the way it is for veterans — there is
+    no last season. It's the position's mean rookie PPG over the training seasons instead, which is
+    the honest "no model, just know what rookies at this position usually do" baseline. ADP is the
+    same parity benchmark as everywhere else, and matters more here than anywhere: a rookie's draft
+    position is most of what the market is going on too, so this is close to a like-for-like test.
+    """
+    actual, predicted = fold["actual_ppg_ppr"], fold["predicted_ppg_ppr"]
+    drafted = fold[fold["consensus_adp"].notna()]
+    has_adp = len(drafted) >= _MIN_METRIC_ROWS
+    return {
+        "target_season": target_season,
+        "position": "ROOKIE",
+        "n": len(fold),
+        "mae": mean_absolute_error(actual, predicted),
+        "r2": r2_score(actual, predicted),
+        "spearman": spearmanr(predicted, actual).statistic,
+        "naive_mae": mean_absolute_error(actual, fold["position_mean_ppg"]),
+        "naive_spearman": spearmanr(fold["position_mean_ppg"], actual).statistic,
+        "adp_spearman": (
+            spearmanr(-drafted["consensus_adp"], drafted["actual_ppg_ppr"]).statistic
+            if has_adp else float("nan")
+        ),
+        "model_spearman_vs_adp": (
+            spearmanr(drafted["predicted_ppg_ppr"], drafted["actual_ppg_ppr"]).statistic
+            if has_adp else float("nan")
+        ),
+        "adp_n": len(drafted),
+    }
+
+
+def _walk_forward_rookies(
+    labeled: pd.DataFrame, cohort: pd.DataFrame, fold_seasons: list[int]
+) -> tuple[list[pd.DataFrame], list[pd.DataFrame], pd.DataFrame]:
+    """Walk-forward for the rookie arm, same shape as the veteran one.
+
+    The games half trains on the whole cohort rather than only the scoring-labelled part, because
+    here the whole cohort *is* the label: a rookie who never played is a real 0, not a missing row.
+    """
+    predictions, games_predictions, metrics = [], [], []
+    for season in fold_seasons:
+        train = labeled[labeled["target_season"] < season]
+        train_cohort = cohort[cohort["target_season"] < season]
+        if train.empty or train_cohort.empty:
+            continue
+        games_model = _fit_generic(train_cohort, _ROOKIE_GAMES_FEATURE_COLUMNS, "actual_games")
+        scoring_model = _fit_generic(train, _ROOKIE_FEATURE_COLUMNS, "actual_ppg_ppr")
+
+        fold = labeled[labeled["target_season"] == season].copy()
+        if not fold.empty:
+            fold["predicted_ppg_ppr"] = scoring_model.predict(fold[_ROOKIE_FEATURE_COLUMNS])
+            fold["expected_games"] = games_model.predict(fold[_ROOKIE_GAMES_FEATURE_COLUMNS])
+            # Position means come from the training slice only — a benchmark computed on the fold
+            # would have seen the answers the model is being graded against.
+            position_means = train.groupby("position")["actual_ppg_ppr"].mean()
+            fold["position_mean_ppg"] = fold["position"].map(position_means).fillna(
+                train["actual_ppg_ppr"].mean()
+            )
+            predictions.append(fold)
+            if len(fold) >= _MIN_METRIC_ROWS:
+                metrics.append(_rookie_metrics(fold, season))
+
+        games_fold = cohort[cohort["target_season"] == season].copy()
+        games_fold["expected_games"] = games_model.predict(
+            games_fold[_ROOKIE_GAMES_FEATURE_COLUMNS]
+        )
+        games_predictions.append(games_fold)
+    return predictions, games_predictions, pd.DataFrame(metrics)
 
 
 def _role_games(frame: pd.DataFrame) -> pd.Series:
@@ -474,6 +681,46 @@ def _walk_forward(
     return predictions, games_predictions, pd.DataFrame(metrics)
 
 
+def _print_rookie_report(
+    metrics: pd.DataFrame, folds: list[pd.DataFrame], games_folds: list[pd.DataFrame]
+) -> None:
+    print("\nRookie arm walk-forward (first-season players, no prior history to work from):")
+    print(f"  {'season':>6} {'n':>5} {'MAE':>6} {'R2':>6} {'rho':>6} | "
+          f"{'naive MAE':>9} {'naive rho':>9} | {'ADP rho':>7} {'model rho':>9} {'(n)':>6}")
+    for row in metrics.itertuples():
+        print(f"  {row.target_season:>6} {row.n:>5} {row.mae:>6.2f} {row.r2:>6.3f} "
+              f"{row.spearman:>6.3f} | {row.naive_mae:>9.2f} {row.naive_spearman:>9.3f} | "
+              f"{row.adp_spearman:>7.3f} {row.model_spearman_vs_adp:>9.3f} {row.adp_n:>6}")
+
+    pooled = pd.concat(folds, ignore_index=True)
+    row = _rookie_metrics(pooled, 0)
+    print(f"  {'pooled':>6} {row['n']:>5} {row['mae']:>6.2f} {row['r2']:>6.3f} "
+          f"{row['spearman']:>6.3f} | {row['naive_mae']:>9.2f} {row['naive_spearman']:>9.3f} | "
+          f"{row['adp_spearman']:>7.3f} {row['model_spearman_vs_adp']:>9.3f} {row['adp_n']:>6}")
+
+    games = _games_metrics_rookie(pd.concat(games_folds, ignore_index=True))
+    print(f"  Games played, pooled over the whole cohort including true zeros "
+          f"(n={games['games_n']}): MAE={games['games_mae']:.2f} vs {games['games_naive_mae']:.2f} "
+          f"for always guessing the cohort mean")
+
+
+def _games_metrics_rookie(games_fold: pd.DataFrame) -> dict:
+    """Rookie availability error, against always guessing the cohort's mean games played.
+
+    The veteran baseline (`weighted_games_per_season`) doesn't exist here for the same reason the
+    scoring one doesn't — there is no prior season to average.
+    """
+    return {
+        "games_n": len(games_fold),
+        "games_mae": mean_absolute_error(games_fold["actual_games"],
+                                         games_fold["expected_games"]),
+        "games_naive_mae": mean_absolute_error(
+            games_fold["actual_games"],
+            pd.Series(games_fold["actual_games"].mean(), index=games_fold.index),
+        ),
+    }
+
+
 def _print_backtest_report(
     metrics: pd.DataFrame, folds: list[pd.DataFrame], games_folds: list[pd.DataFrame]
 ) -> None:
@@ -511,6 +758,7 @@ def build_inhouse_projections() -> None:
     con = duckdb.connect(str(WAREHOUSE_PATH))
     con.create_function("normalize_team", normalize_team, ["VARCHAR"], "VARCHAR")
     df = con.execute(_FEATURE_SQL).df()
+    rookies = con.execute(_ROOKIE_FEATURE_SQL).df()
     season_games = dict(con.execute(_SEASON_GAMES_SQL).fetchall())
     con.close()
 
@@ -580,6 +828,33 @@ def build_inhouse_projections() -> None:
         live["expected_games"] = float("nan")
         print("No labeled seasons available yet — live cohort predictions left null.")
     output_frames.append(live)
+
+    # The rookie arm, backtested and predicted the same way, then concatenated into the same table.
+    # One table rather than two so that role_games below is normalised over one combined
+    # population, and so every consumer (consensus.py, breakout_candidates.py) picks rookies up
+    # without needing to know there are two models behind the column.
+    rookies = _add_position_dummies(rookies)
+    rookie_labeled = rookies[rookies["actual_ppg_ppr"].notna()].sort_values("target_season")
+    rookie_cohort = rookies[rookies["actual_games"].notna()].sort_values("target_season")
+    rookie_folds, rookie_games_folds, rookie_metrics = _walk_forward_rookies(
+        rookie_labeled, rookie_cohort, fold_seasons
+    )
+    if not rookie_metrics.empty:
+        _print_rookie_report(rookie_metrics, rookie_folds, rookie_games_folds)
+        metrics = pd.concat([metrics, rookie_metrics], ignore_index=True)
+    output_frames.extend(rookie_folds)
+
+    live_rookies = rookies[rookies["target_season"] == live_season].copy()
+    if not rookie_labeled.empty and not live_rookies.empty:
+        live_rookies["predicted_ppg_ppr"] = _fit_generic(
+            rookie_labeled, _ROOKIE_FEATURE_COLUMNS, "actual_ppg_ppr"
+        ).predict(live_rookies[_ROOKIE_FEATURE_COLUMNS])
+        live_rookies["expected_games"] = _fit_generic(
+            rookie_cohort, _ROOKIE_GAMES_FEATURE_COLUMNS, "actual_games"
+        ).predict(live_rookies[_ROOKIE_GAMES_FEATURE_COLUMNS])
+        output_frames.append(live_rookies)
+        print(f"\nRookie arm: {len(live_rookies)} first-season players projected for "
+              f"{live_season}, trained on {len(rookie_labeled)} labelled rookie seasons.")
 
     result = pd.concat(output_frames, ignore_index=True)
     result["season_games"] = result["target_season"].map(season_games)

--- a/src/gold/inhouse_projections.py
+++ b/src/gold/inhouse_projections.py
@@ -33,15 +33,22 @@ Label: actual PPG in `target_season`, only for players who played >= the same ga
 `player_baselines.py` uses (imported, not redefined) — an actual season cut short by injury is as
 untrustworthy a training target as a short season is a baseline input.
 
-A second, much smaller model covers first-season players, who have no prior-season history for the
-features above to read and so were simply absent from this table — 150 players ESPN projected and
-this warehouse didn't, the entire incoming rookie class among them. It reads what a drafting human
-reads for a rookie instead: draft capital, the landing spot's line and skill-corps grades, and
-whether he's already won a week 1 job. Its cohort is every first-season player who reaches that
-season's week 1 depth chart, which makes its availability label genuinely uncensored — that
-population is closed, so a rookie with no weekly_stats row didn't play, and 0 is the honest label
-rather than a missing row. Both arms write to this one table so that `_role_games` normalises over
-one combined population and consumers don't need to know there are two models behind the column.
+A second, much smaller model covers everyone the arm above structurally cannot see: players with no
+`player_weighted_baselines` row for the season, because they have never put together a season of
+`_MIN_GAMES_PLAYED` games. Every feature above derives from that row, so without one there is
+nothing to predict from, and those players were simply absent from this table — 150 of them that
+ESPN projected and this warehouse didn't. Two groups land there and they are the same modelling
+problem: rookies with no NFL history at all, and fringe veterans who have played but never enough
+in one season to earn a baseline. It reads what a human reads for an unproven player instead —
+draft capital, the landing spot's line and skill-corps grades, whether he has already won a week 1
+job, and an unweighted career rate that is NULL for a true rookie and so tells the model which of
+the two it's looking at.
+
+Its cohort is every such player reaching that season's week 1 depth chart, which makes its
+availability label uncensored: that population is closed, so no weekly_stats row means he didn't
+play, and 0 is honest rather than missing. Both arms write to this one table so that `_role_games`
+normalises over one combined population and consumers don't need to know there are two models
+behind the column.
 
 Draft capital comes from `rosters.draft_number`, not `players.draft_pick`: the latter is the more
 natural home for it but is published on a long enough lag that it carried no 2026 draft class at
@@ -77,12 +84,13 @@ points per game across a full 17. Their product is what `projected_points_full` 
 comparable to, so it keeps the role discount and drops the injury one. `_role_games` does that by
 measuring a player's expected games against a starter's at the same position and season.
 
-That leaves one known bias, in `expected_games` and so in both totals. Its label counts appearances
-in `weekly_stats`, so a player who never takes a snap has no row to count and the label bottoms out
-at 1 game rather than 0. Career backups are consequently projected for more games than they'll
-play, and their season totals run high — Browning lands around 55 points against ESPN's 10. Closing
-that gap needs the roster, not the box scores. Note the walk-forward can't see this at all: the
-scoring label's games floor excludes exactly the players it affects.
+Both arms' availability labels are anchored on the roster rather than the box score, because a
+player who was in the league all season and never took a snap has no `weekly_stats` row at all and
+would otherwise read as unobserved rather than as the zero he is — roughly 90-110 players a season
+on the veteran side alone. Without those zeros the model cannot answer below about 4 games, and
+career backups keep season totals they will never earn. Note the scoring walk-forward can't see any
+of this: its games floor excludes exactly the players it affects, so the availability metrics are
+reported on their own population.
 """
 
 from pathlib import Path
@@ -159,47 +167,77 @@ WHERE game_type = 'REG'
 GROUP BY season
 """
 
-# Rookies get their own model rather than a row in the one above, because the veteran model's
-# entire input is a prior-season history they don't have — a first-year player has no
-# player_weighted_baselines row at all, which is why they were simply absent from this table until
-# now (150 players ESPN projected and this warehouse didn't, including every 2026 first-rounder).
+# A second arm for players the veteran model structurally cannot see: those with no
+# player_weighted_baselines row for the season being projected, because they've never put together
+# a season of `_MIN_GAMES_PLAYED` games. Everything the veteran arm reads is derived from that row,
+# so without one there's nothing to predict from and the player was simply absent from this table.
 #
-# What replaces that history is what a drafting human uses for a rookie anyway: where he went in
-# the draft, what he walked into, and whether he's already won a job. Kept deliberately small —
-# roughly 60-95 rookies reach a week 1 depth chart per season, so this trains on hundreds of rows
-# where the veteran arm has thousands, and a wide feature set would just memorise them.
-_ROOKIE_FEATURES = [
-    "draft_number", "age_at_season", "ol_grade", "skill_grade", "target_is_starter",
+# Two groups land here, and they're the same modelling problem. Rookies, who have no NFL history at
+# all (~55-95 a season), and fringe veterans who have played but never enough in one season to earn
+# a baseline (~35-55 a season). Covering only the first left the second uncovered — 38 of the 39
+# skill players ESPN projected and this warehouse still didn't. Pooling them also roughly doubles
+# the training data, which the rookie half benefits from too.
+#
+# What replaces the missing history is what a human reads for an unproven player anyway: where he
+# went in the draft, what he walked into, whether he's already won a job, and — for the ones who
+# have played at all — their unweighted career rate, which is NULL for a true rookie and so tells
+# the model which of the two groups it's looking at. Kept deliberately small: this trains on
+# hundreds of rows where the veteran arm has thousands, and a wide feature set would just memorise.
+_NO_BASELINE_FEATURES = [
+    "draft_number", "age_at_season", "seasons_of_experience", "career_ppg", "career_games",
+    "ol_grade", "skill_grade", "target_is_starter",
 ]
-_ROOKIE_FEATURE_COLUMNS = _ROOKIE_FEATURES + [f"position_{p}" for p in _SKILL_POSITIONS]
+_NO_BASELINE_FEATURE_COLUMNS = (
+    _NO_BASELINE_FEATURES + [f"position_{p}" for p in _SKILL_POSITIONS]
+)
 
-# Draft capital and a won job are close to the whole story on whether a rookie sees the field;
-# nothing about the landing spot's blocking tells you much about his own availability.
-_ROOKIE_GAMES_FEATURE_COLUMNS = [
-    "draft_number", "age_at_season", "target_is_starter",
+# Draft capital, experience and a won job are close to the whole story on whether an unproven
+# player sees the field; nothing about the landing spot's blocking tells you much about his own
+# availability.
+_NO_BASELINE_GAMES_FEATURE_COLUMNS = [
+    "draft_number", "age_at_season", "seasons_of_experience", "career_games", "target_is_starter",
 ] + [f"position_{p}" for p in _SKILL_POSITIONS]
 
 _COMPONENT_SELECTS = ",\n".join(f"    b.{column}" for column in _COMPONENT_COLUMNS)
 
-# The rookie cohort is every first-season player who reaches that season's week 1 depth chart.
-# Roster membership alone would be the wrong test: it isn't comparable across eras (the current
-# feed lists a preseason 90-man roster where the older ones list far fewer), and a rookie who never
-# reaches a depth chart is not a player any draft board needs a number for.
+# The cohort is every player reaching that season's week 1 depth chart who has no
+# player_weighted_baselines row for it. Roster membership alone would be the wrong test: it isn't
+# comparable across eras (the current feed lists a preseason 90-man roster where the older ones
+# list far fewer), and a player who never reaches a depth chart is not one any draft board needs a
+# number for.
 #
 # draft_number comes from rosters rather than players.draft_pick, which is the more natural home
 # for it but is published on a long enough lag that it had no 2026 class at all while the roster
 # feed already carried the full board. NULL means undrafted, which is signal, not absence.
-_ROOKIE_FEATURE_SQL = f"""
-WITH rookie_cohort AS (
+_NO_BASELINE_FEATURE_SQL = f"""
+WITH roster_facts AS (
     SELECT
         player_id,
         season,
         MIN(draft_number) AS draft_number,
+        MIN(years_exp) AS seasons_of_experience,
         ANY_VALUE(player_name) AS player_name,
         MIN(position) AS position
     FROM rosters
-    WHERE years_exp = 0 AND position IN {_SKILL_POSITIONS}
+    WHERE position IN {_SKILL_POSITIONS}
     GROUP BY player_id, season
+),
+-- Every prior season's games and points, with no games-played floor — the floor is precisely why
+-- these players have no baseline, so applying it again would zero out the only history they have.
+-- Unweighted, unlike player_weighted_baselines: there's too little of it for recency weighting to
+-- say anything a plain career rate doesn't.
+career_to_date AS (
+    SELECT
+        w.player_id,
+        s.season,
+        SUM(w.fantasy_points_ppr) / COUNT(*) AS career_ppg,
+        COUNT(*) AS career_games
+    FROM weekly_stats w
+    JOIN (SELECT DISTINCT season FROM roster_facts) s ON w.season < s.season
+    WHERE w.season_type = 'REG'
+        AND w.fantasy_points_ppr IS NOT NULL
+        AND w.position IN {_SKILL_POSITIONS}
+    GROUP BY w.player_id, s.season
 ),
 week_one_role AS (
     SELECT
@@ -237,6 +275,9 @@ SELECT
     r.player_name,
     r.position,
     r.draft_number,
+    r.seasons_of_experience,
+    c.career_ppg,
+    c.career_games,
     w.team AS context_team,
     w.is_starter AS target_is_starter,
     r.season - YEAR(TRY_CAST(pl.birth_date AS DATE)) AS age_at_season,
@@ -257,8 +298,13 @@ SELECT
         WHEN r.season <= (SELECT MAX(season) FROM weekly_stats)
         THEN COALESCE(av.actual_games, 0)
     END AS actual_games
-FROM rookie_cohort r
+FROM roster_facts r
 JOIN week_one_role w ON w.gsis_id = r.player_id AND w.season = r.season
+-- The defining condition: no usable prior-season baseline, so the veteran arm has nothing to read.
+-- This is what keeps the two arms disjoint — every player gets a number from exactly one of them.
+LEFT JOIN player_weighted_baselines b
+    ON b.player_id = r.player_id AND b.target_season = r.season
+LEFT JOIN career_to_date c ON c.player_id = r.player_id AND c.season = r.season
 LEFT JOIN players pl ON pl.gsis_id = r.player_id
 LEFT JOIN offensive_line_grades ol ON ol.team = w.team AND ol.season = r.season - 1
 LEFT JOIN skill_position_grades sk
@@ -267,6 +313,7 @@ LEFT JOIN adp_consensus adp ON adp.gsis_id = r.player_id AND adp.season = r.seas
 LEFT JOIN actual_scoring o ON o.player_id = r.player_id AND o.target_season = r.season
 LEFT JOIN actual_availability av
     ON av.player_id = r.player_id AND av.target_season = r.season
+WHERE b.player_id IS NULL
 -- Same reproducibility guard as the veteran query: a stable total order over the frame, so
 -- histogram binning can't shift between runs on identical data.
 ORDER BY r.season, r.player_id
@@ -311,23 +358,41 @@ actual_scoring AS (
     HAVING COUNT(*) >= {_MIN_GAMES_PLAYED}
 ),
 -- The availability label deliberately does *not*, because the floor censors exactly the outcome
--- the games model most needs to be able to predict. Trained only on seasons of 6+ games, it could
--- not represent a backup at all — its smallest conceivable answer was 6, so career backups came
--- back at 8-9 games and their season totals were inflated to match. Every appearance counts here.
+-- the games model most needs to be able to predict, and it's anchored on the roster rather than
+-- the box score for the same reason. Counting only weekly_stats rows means a player who was in the
+-- league all year and never took a snap has no row at all, so he reads as unobserved rather than
+-- as the zero he actually is — roughly 90-110 players a season, on top of the 75-100 who play 1-5
+-- games. Left to itself the model then can't answer below about 4 games, and career backups keep
+-- season totals they'll never earn.
 --
--- Still censored at 1, not 0: a player who never takes a snap has no weekly_stats row to count,
--- so true zeros would have to come from the roster instead. That understates how little the
--- deepest backups play, and is the remaining known bias in expected_games.
-actual_availability AS (
-    SELECT
-        player_id,
-        season AS target_season,
-        COUNT(*) AS actual_games
+-- Anchoring on rosters supplies those zeros: roster membership is the statement "in the league
+-- this season", and the appearance count is then a genuine 0 rather than a missing row. Practice
+-- squad and cut spells are deliberately kept — a player on the practice squad really does play
+-- zero games, which is the case being modelled. FULL OUTER so a weekly_stats row with no matching
+-- roster row (nflverse has a handful) keeps its label instead of silently vanishing.
+roster_seasons AS (
+    SELECT DISTINCT player_id, season
+    FROM rosters
+    WHERE position IN {_SKILL_POSITIONS}
+        -- Without this the live season, whose rosters are published but whose games haven't been
+        -- played, would label every player a real 0.
+        AND season <= (SELECT MAX(season) FROM weekly_stats)
+),
+appearances AS (
+    SELECT player_id, season, COUNT(*) AS games
     FROM weekly_stats
     WHERE season_type = 'REG'
         AND fantasy_points_ppr IS NOT NULL
         AND position IN {_SKILL_POSITIONS}
     GROUP BY player_id, season
+),
+actual_availability AS (
+    SELECT
+        COALESCE(rs.player_id, a.player_id) AS player_id,
+        COALESCE(rs.season, a.season) AS target_season,
+        COALESCE(a.games, 0) AS actual_games
+    FROM roster_seasons rs
+    FULL OUTER JOIN appearances a ON a.player_id = rs.player_id AND a.season = rs.season
 ),
 -- Role as of target_season - 1, which is what separates "wasn't the starter yet" from "kept
 -- getting hurt" — two very different stories that a games-played average alone tells identically.
@@ -482,8 +547,8 @@ def _fit_games(train: pd.DataFrame) -> HistGradientBoostingRegressor:
 def _fit_generic(
     train: pd.DataFrame, feature_columns: list[str], label: str
 ) -> HistGradientBoostingRegressor:
-    """Same estimator and settings, with the feature set and label passed in — the rookie arm uses
-    a different set of both, but there's no reason for it to use different hyperparameters."""
+    """Same estimator and settings, with the feature set and label passed in — the unproven arm
+    uses a different set of both, but no reason to use different hyperparameters."""
     model = HistGradientBoostingRegressor(**_MODEL_PARAMS)
     model.fit(train[feature_columns], train[label])
     return model
@@ -548,21 +613,21 @@ def _games_metrics(games_fold: pd.DataFrame) -> dict:
     }
 
 
-def _rookie_metrics(fold: pd.DataFrame, target_season: int) -> dict:
-    """Score one rookie fold.
+def _no_baseline_metrics(fold: pd.DataFrame, target_season: int) -> dict:
+    """Score one unproven-player fold.
 
     The naive benchmark can't be "carry last season forward" the way it is for veterans — there is
-    no last season. It's the position's mean rookie PPG over the training seasons instead, which is
-    the honest "no model, just know what rookies at this position usually do" baseline. ADP is the
-    same parity benchmark as everywhere else, and matters more here than anywhere: a rookie's draft
-    position is most of what the market is going on too, so this is close to a like-for-like test.
+    no qualifying last season, which is what put these players here. It's the position's mean PPG
+    over the training seasons instead: the honest "no model, just know what players at this
+    position usually do" baseline. ADP is the same parity benchmark as everywhere else, and matters
+    more here than anywhere, since draft capital is most of what the market is going on too.
     """
     actual, predicted = fold["actual_ppg_ppr"], fold["predicted_ppg_ppr"]
     drafted = fold[fold["consensus_adp"].notna()]
     has_adp = len(drafted) >= _MIN_METRIC_ROWS
     return {
         "target_season": target_season,
-        "position": "ROOKIE",
+        "position": "NO_BASELINE",
         "n": len(fold),
         "mae": mean_absolute_error(actual, predicted),
         "r2": r2_score(actual, predicted),
@@ -581,13 +646,14 @@ def _rookie_metrics(fold: pd.DataFrame, target_season: int) -> dict:
     }
 
 
-def _walk_forward_rookies(
+def _walk_forward_no_baseline(
     labeled: pd.DataFrame, cohort: pd.DataFrame, fold_seasons: list[int]
 ) -> tuple[list[pd.DataFrame], list[pd.DataFrame], pd.DataFrame]:
-    """Walk-forward for the rookie arm, same shape as the veteran one.
+    """Walk-forward for the unproven arm, same shape as the veteran one.
 
     The games half trains on the whole cohort rather than only the scoring-labelled part, because
-    here the whole cohort *is* the label: a rookie who never played is a real 0, not a missing row.
+    here the whole cohort *is* the label: a player who never appeared is a real 0, not a missing
+    row.
     """
     predictions, games_predictions, metrics = [], [], []
     for season in fold_seasons:
@@ -595,13 +661,13 @@ def _walk_forward_rookies(
         train_cohort = cohort[cohort["target_season"] < season]
         if train.empty or train_cohort.empty:
             continue
-        games_model = _fit_generic(train_cohort, _ROOKIE_GAMES_FEATURE_COLUMNS, "actual_games")
-        scoring_model = _fit_generic(train, _ROOKIE_FEATURE_COLUMNS, "actual_ppg_ppr")
+        games_model = _fit_generic(train_cohort, _NO_BASELINE_GAMES_FEATURE_COLUMNS, "actual_games")
+        scoring_model = _fit_generic(train, _NO_BASELINE_FEATURE_COLUMNS, "actual_ppg_ppr")
 
         fold = labeled[labeled["target_season"] == season].copy()
         if not fold.empty:
-            fold["predicted_ppg_ppr"] = scoring_model.predict(fold[_ROOKIE_FEATURE_COLUMNS])
-            fold["expected_games"] = games_model.predict(fold[_ROOKIE_GAMES_FEATURE_COLUMNS])
+            fold["predicted_ppg_ppr"] = scoring_model.predict(fold[_NO_BASELINE_FEATURE_COLUMNS])
+            fold["expected_games"] = games_model.predict(fold[_NO_BASELINE_GAMES_FEATURE_COLUMNS])
             # Position means come from the training slice only — a benchmark computed on the fold
             # would have seen the answers the model is being graded against.
             position_means = train.groupby("position")["actual_ppg_ppr"].mean()
@@ -610,11 +676,11 @@ def _walk_forward_rookies(
             )
             predictions.append(fold)
             if len(fold) >= _MIN_METRIC_ROWS:
-                metrics.append(_rookie_metrics(fold, season))
+                metrics.append(_no_baseline_metrics(fold, season))
 
         games_fold = cohort[cohort["target_season"] == season].copy()
         games_fold["expected_games"] = games_model.predict(
-            games_fold[_ROOKIE_GAMES_FEATURE_COLUMNS]
+            games_fold[_NO_BASELINE_GAMES_FEATURE_COLUMNS]
         )
         games_predictions.append(games_fold)
     return predictions, games_predictions, pd.DataFrame(metrics)
@@ -681,10 +747,10 @@ def _walk_forward(
     return predictions, games_predictions, pd.DataFrame(metrics)
 
 
-def _print_rookie_report(
+def _print_no_baseline_report(
     metrics: pd.DataFrame, folds: list[pd.DataFrame], games_folds: list[pd.DataFrame]
 ) -> None:
-    print("\nRookie arm walk-forward (first-season players, no prior history to work from):")
+    print("\nUnproven arm walk-forward (no qualifying prior season to work from):")
     print(f"  {'season':>6} {'n':>5} {'MAE':>6} {'R2':>6} {'rho':>6} | "
           f"{'naive MAE':>9} {'naive rho':>9} | {'ADP rho':>7} {'model rho':>9} {'(n)':>6}")
     for row in metrics.itertuples():
@@ -693,22 +759,22 @@ def _print_rookie_report(
               f"{row.adp_spearman:>7.3f} {row.model_spearman_vs_adp:>9.3f} {row.adp_n:>6}")
 
     pooled = pd.concat(folds, ignore_index=True)
-    row = _rookie_metrics(pooled, 0)
+    row = _no_baseline_metrics(pooled, 0)
     print(f"  {'pooled':>6} {row['n']:>5} {row['mae']:>6.2f} {row['r2']:>6.3f} "
           f"{row['spearman']:>6.3f} | {row['naive_mae']:>9.2f} {row['naive_spearman']:>9.3f} | "
           f"{row['adp_spearman']:>7.3f} {row['model_spearman_vs_adp']:>9.3f} {row['adp_n']:>6}")
 
-    games = _games_metrics_rookie(pd.concat(games_folds, ignore_index=True))
+    games = _games_metrics_no_baseline(pd.concat(games_folds, ignore_index=True))
     print(f"  Games played, pooled over the whole cohort including true zeros "
           f"(n={games['games_n']}): MAE={games['games_mae']:.2f} vs {games['games_naive_mae']:.2f} "
           f"for always guessing the cohort mean")
 
 
-def _games_metrics_rookie(games_fold: pd.DataFrame) -> dict:
-    """Rookie availability error, against always guessing the cohort's mean games played.
+def _games_metrics_no_baseline(games_fold: pd.DataFrame) -> dict:
+    """Unproven-player availability error, against always guessing the cohort's mean games played.
 
     The veteran baseline (`weighted_games_per_season`) doesn't exist here for the same reason the
-    scoring one doesn't — there is no prior season to average.
+    scoring one doesn't — there is no qualifying prior season to average.
     """
     return {
         "games_n": len(games_fold),
@@ -758,7 +824,7 @@ def build_inhouse_projections() -> None:
     con = duckdb.connect(str(WAREHOUSE_PATH))
     con.create_function("normalize_team", normalize_team, ["VARCHAR"], "VARCHAR")
     df = con.execute(_FEATURE_SQL).df()
-    rookies = con.execute(_ROOKIE_FEATURE_SQL).df()
+    unproven = con.execute(_NO_BASELINE_FEATURE_SQL).df()
     season_games = dict(con.execute(_SEASON_GAMES_SQL).fetchall())
     con.close()
 
@@ -833,28 +899,28 @@ def build_inhouse_projections() -> None:
     # One table rather than two so that role_games below is normalised over one combined
     # population, and so every consumer (consensus.py, breakout_candidates.py) picks rookies up
     # without needing to know there are two models behind the column.
-    rookies = _add_position_dummies(rookies)
-    rookie_labeled = rookies[rookies["actual_ppg_ppr"].notna()].sort_values("target_season")
-    rookie_cohort = rookies[rookies["actual_games"].notna()].sort_values("target_season")
-    rookie_folds, rookie_games_folds, rookie_metrics = _walk_forward_rookies(
-        rookie_labeled, rookie_cohort, fold_seasons
+    unproven = _add_position_dummies(unproven)
+    unproven_labeled = unproven[unproven["actual_ppg_ppr"].notna()].sort_values("target_season")
+    unproven_cohort = unproven[unproven["actual_games"].notna()].sort_values("target_season")
+    unproven_folds, unproven_games_folds, unproven_metrics = _walk_forward_no_baseline(
+        unproven_labeled, unproven_cohort, fold_seasons
     )
-    if not rookie_metrics.empty:
-        _print_rookie_report(rookie_metrics, rookie_folds, rookie_games_folds)
-        metrics = pd.concat([metrics, rookie_metrics], ignore_index=True)
-    output_frames.extend(rookie_folds)
+    if not unproven_metrics.empty:
+        _print_no_baseline_report(unproven_metrics, unproven_folds, unproven_games_folds)
+        metrics = pd.concat([metrics, unproven_metrics], ignore_index=True)
+    output_frames.extend(unproven_folds)
 
-    live_rookies = rookies[rookies["target_season"] == live_season].copy()
-    if not rookie_labeled.empty and not live_rookies.empty:
-        live_rookies["predicted_ppg_ppr"] = _fit_generic(
-            rookie_labeled, _ROOKIE_FEATURE_COLUMNS, "actual_ppg_ppr"
-        ).predict(live_rookies[_ROOKIE_FEATURE_COLUMNS])
-        live_rookies["expected_games"] = _fit_generic(
-            rookie_cohort, _ROOKIE_GAMES_FEATURE_COLUMNS, "actual_games"
-        ).predict(live_rookies[_ROOKIE_GAMES_FEATURE_COLUMNS])
-        output_frames.append(live_rookies)
-        print(f"\nRookie arm: {len(live_rookies)} first-season players projected for "
-              f"{live_season}, trained on {len(rookie_labeled)} labelled rookie seasons.")
+    live_unproven = unproven[unproven["target_season"] == live_season].copy()
+    if not unproven_labeled.empty and not live_unproven.empty:
+        live_unproven["predicted_ppg_ppr"] = _fit_generic(
+            unproven_labeled, _NO_BASELINE_FEATURE_COLUMNS, "actual_ppg_ppr"
+        ).predict(live_unproven[_NO_BASELINE_FEATURE_COLUMNS])
+        live_unproven["expected_games"] = _fit_generic(
+            unproven_cohort, _NO_BASELINE_GAMES_FEATURE_COLUMNS, "actual_games"
+        ).predict(live_unproven[_NO_BASELINE_GAMES_FEATURE_COLUMNS])
+        output_frames.append(live_unproven)
+        print(f"\nUnproven arm: {len(live_unproven)} players with no qualifying prior season "
+              f"projected for {live_season}, trained on {len(unproven_labeled)} labelled seasons.")
 
     result = pd.concat(output_frames, ignore_index=True)
     result["season_games"] = result["target_season"].map(season_games)

--- a/src/gold/inhouse_projections.py
+++ b/src/gold/inhouse_projections.py
@@ -62,15 +62,24 @@ from sklearn.ensemble import HistGradientBoostingRegressor
 from sklearn.inspection import permutation_importance
 from sklearn.metrics import mean_absolute_error, r2_score
 
-from src.gold.player_baselines import _MIN_GAMES_PLAYED, _SKILL_POSITIONS
+from src.gold.player_baselines import (
+    _COMPONENT_COLUMNS,
+    _MIN_GAMES_PLAYED,
+    _SKILL_POSITIONS,
+)
 from src.silver.teams import normalize_team
 
 WAREHOUSE_PATH = Path("data/warehouse.duckdb")
 
+# _COMPONENT_COLUMNS is imported rather than restated so that a column added to
+# player_baselines.py reaches the model automatically instead of being built and then silently
+# ignored. It's the volume/role/efficiency block: how the player's prior scoring was actually
+# earned, which is the part that carries across a change of team or role, where a bare
+# points-per-game average carries nothing.
 _BASE_FEATURES = [
     "weighted_ppg_ppr", "weighted_games_per_season", "seasons_used", "ol_grade", "skill_grade",
     "seasons_of_experience", "age_at_season", "draft_pick",
-]
+] + _COMPONENT_COLUMNS
 _FEATURE_COLUMNS = _BASE_FEATURES + [f"position_{p}" for p in _SKILL_POSITIONS]
 
 # Availability is its own question, so it gets its own model rather than sharing the PPG feature
@@ -112,6 +121,8 @@ FROM schedules
 WHERE game_type = 'REG'
 GROUP BY season
 """
+
+_COMPONENT_SELECTS = ",\n".join(f"    b.{column}" for column in _COMPONENT_COLUMNS)
 
 # player_team resolves each player's most-played team in a season (mirrors the
 # team_by_player_season pattern in skill_position_grades.py, over weekly_stats instead of
@@ -173,6 +184,7 @@ SELECT
     b.seasons_used,
     b.weighted_ppg_ppr,
     b.weighted_games_per_season,
+{_COMPONENT_SELECTS},
     pt.team,
     ol.ol_grade,
     sk.grade AS skill_grade,

--- a/src/gold/inhouse_projections.py
+++ b/src/gold/inhouse_projections.py
@@ -26,28 +26,38 @@ Label: actual PPG in `target_season`, only for players who played >= the same ga
 `player_baselines.py` uses (imported, not redefined) — an actual season cut short by injury is as
 untrustworthy a training target as a short season is a baseline input.
 
-Only two cohorts ever get a *stored* prediction, both produced without seeing their own label:
-- the earliest labeled `target_season` has no prior labeled season to train on, so no honest
-  out-of-sample prediction is possible for it — it's used only as training data, not stored.
-- the next labeled `target_season` is held out as a genuine backtest: trained on the earliest
-  season only, predicted out-of-sample, with MAE/R2 printed.
+Every stored prediction is produced without the model having seen its own label:
+- each labeled `target_season` from the first fold onward is predicted by a model trained only on
+  the labeled seasons *before* it — a walk-forward backtest, one fold per season (see
+  `_walk_forward`). The per-fold, per-position error is written to `inhouse_backtest`.
 - the live (unlabeled) `target_season` — the one that actually feeds `consensus.py` — is predicted
   by a model refit on *all* labeled seasons combined, since there's no reason to hold data back
   from the projection that actually matters once the honest backtest above has already run.
 
-`projected_points` (season-total, matching the units every other source in `consensus.py` uses) is
-`predicted_ppg_ppr * expected_games`. The two halves are predicted separately, by models with
-different feature sets, because "how good per game" and "how many games will they play" are
-different questions — prior-year scoring rate says nothing about availability, and the role signals
-that do carry it (see `_GAMES_FEATURE_COLUMNS`) say little about scoring. Expect the games half to
-stay weak whatever is thrown at it: most of what decides availability is injury luck, which nothing
-in this warehouse observes.
+Two season-total columns, because the external projection sites and this model don't answer the
+same question:
+- `projected_points_full` = `predicted_ppg_ppr * season_games` — points if the player is available
+  all season. This is what every external source in `consensus.py` publishes (verified: CBS's own
+  `fppg` implies exactly 17 games for all 888 of its players, and the others match to within a
+  percent), so it's the column `consensus.py` blends. Anything else silently discounts the in-house
+  arm against four health-neutral ones and drags the consensus median down.
+- `projected_points` = `predicted_ppg_ppr * expected_games` — the same projection scaled by how
+  many games the player is actually expected to play. Strictly more informative than the full
+  season number for ranking real rosters; just not comparable to what the sites publish.
+
+`predicted_ppg_ppr` and `expected_games` are predicted separately, by models with different feature
+sets, because "how good per game" and "how many games will they play" are different questions —
+prior-year scoring rate says nothing about availability, and the role signals that do carry it (see
+`_GAMES_FEATURE_COLUMNS`) say little about scoring. Expect the games half to stay weak whatever is
+thrown at it: most of what decides availability is injury luck, which nothing in this warehouse
+observes.
 """
 
 from pathlib import Path
 
 import duckdb
 import pandas as pd
+from scipy.stats import spearmanr
 from sklearn.ensemble import HistGradientBoostingRegressor
 from sklearn.inspection import permutation_importance
 from sklearn.metrics import mean_absolute_error, r2_score
@@ -80,12 +90,28 @@ _GAMES_FEATURE_COLUMNS = [
 _MODEL_PARAMS = dict(max_depth=3, min_samples_leaf=15, learning_rate=0.1, random_state=0)
 
 # offensive_line_grades needs target_season - 1 >= 2018 (PFR advanced stats' own floor) before it
-# has any non-null values at all. Picking an earlier target_season as the single-season holdout
-# training slice would hand it a feature column that's 100% missing rather than just sparse, which
-# breaks HistGradientBoostingRegressor's binning outright. The final live-season model further
-# down still trains on every labeled season combined (pre-2019 ones included), since per-row (not
-# per-column) missingness there is exactly what skill_grade already looks like for every QB row.
+# has any non-null values at all. A walk-forward fold whose entire training slice sits below that
+# would be handed a feature column that's 100% missing rather than just sparse, which breaks
+# HistGradientBoostingRegressor's binning outright — so folds start at the first labeled season
+# *after* this one, which is the first whose training slice is guaranteed to contain a season with
+# real team-context values. Per-row (rather than per-column) missingness inside a fold is fine:
+# it's exactly what skill_grade already looks like for every QB row.
 _MIN_TRAIN_SEASON_WITH_TEAM_CONTEXT = 2019
+
+# A fold/position slice below this many rows gets no metrics row: R2 and Spearman over a handful of
+# players are noise reported to three decimals, which is worse than reporting nothing.
+_MIN_METRIC_ROWS = 20
+
+# Season length for the `projected_points_full` multiplier, read from the schedule rather than
+# hardcoded to 17 — the warehouse still holds 16-game seasons (<= 2020), and the number moving
+# again is a live possibility. The live target_season has no schedule published yet, so it falls
+# back to the most recent season that does.
+_SEASON_GAMES_SQL = """
+SELECT season, CAST(ROUND(COUNT(*) * 2.0 / COUNT(DISTINCT home_team)) AS BIGINT) AS games
+FROM schedules
+WHERE game_type = 'REG'
+GROUP BY season
+"""
 
 # player_team resolves each player's most-played team in a season (mirrors the
 # team_by_player_season pattern in skill_position_grades.py, over weekly_stats instead of
@@ -169,6 +195,12 @@ SELECT
     pr.weeks_on_depth_chart,
     pr.starter_share,
     pr.end_starter,
+    -- Benchmark only, deliberately absent from _FEATURE_COLUMNS: what the preseason draft market
+    -- thought of this player, so the walk-forward can answer "does the model rank better than ADP
+    -- already does" instead of only "better than doing nothing". It must never become a feature —
+    -- breakout_candidates.py's entire premise is that this model is ADP-blind, and a model that
+    -- had seen ADP could not meaningfully disagree with it.
+    adp.consensus_adp,
     o.actual_ppg_ppr,
     o.actual_games
 FROM player_weighted_baselines b
@@ -182,6 +214,10 @@ LEFT JOIN skill_position_grades sk
 -- out. rookie_season and birth_date are immutable, so deriving from them is safe at any season.
 LEFT JOIN players pl ON pl.gsis_id = b.player_id
 LEFT JOIN prior_role pr ON pr.gsis_id = b.player_id AND pr.season = b.target_season - 1
+-- As of target_season itself, unlike every other prior-year join here: preseason ADP is published
+-- before the season starts, so lining it up with the season it was drafted for is what makes it a
+-- fair benchmark rather than a lagged one.
+LEFT JOIN adp_consensus adp ON adp.gsis_id = b.player_id AND adp.season = b.target_season
 LEFT JOIN actual_outcomes o ON o.player_id = b.player_id AND o.target_season = b.target_season
 -- Not cosmetic: DuckDB's parallel joins return these rows in a different order from run to run,
 -- and HistGradientBoostingRegressor sums gradients per histogram bin in row order. Float addition
@@ -214,70 +250,158 @@ def _fit_games(train: pd.DataFrame) -> HistGradientBoostingRegressor:
     return model
 
 
+def _metrics(fold: pd.DataFrame, target_season: int, position: str) -> dict:
+    """Score one fold (or one position within it) against every benchmark worth beating.
+
+    Three comparisons, because "the model has some skill" and "the model is worth running" are
+    different claims:
+    - `naive_*` — carrying last season's recency-weighted rate forward unchanged, i.e. what
+      `player_weighted_baselines` alone would say. Losing to this means the model is subtracting.
+    - `adp_spearman` — the preseason draft market's own ordering. This is the parity benchmark:
+      ADP is thousands of drafters pricing in offseason information (job changes, scheme, camp
+      reports) that nothing in this warehouse observes.
+    - `model_spearman_vs_adp` — the model re-scored on *only* the ADP-covered players, so the two
+      Spearmans above sit on the same population. Scored over the full pool the model would get
+      credit for correctly ranking undrafted players ADP never had an opinion on.
+    """
+    actual, predicted = fold["actual_ppg_ppr"], fold["predicted_ppg_ppr"]
+    drafted = fold[fold["consensus_adp"].notna()]
+    has_adp = len(drafted) >= _MIN_METRIC_ROWS
+    return {
+        "target_season": target_season,
+        "position": position,
+        "n": len(fold),
+        "mae": mean_absolute_error(actual, predicted),
+        "r2": r2_score(actual, predicted),
+        "spearman": spearmanr(predicted, actual).statistic,
+        "naive_mae": mean_absolute_error(actual, fold["weighted_ppg_ppr"]),
+        "naive_spearman": spearmanr(fold["weighted_ppg_ppr"], actual).statistic,
+        # Negated so a better draft pick sorts the same direction as more points, making this
+        # Spearman directly comparable to the two above rather than its mirror image.
+        "adp_spearman": (
+            spearmanr(-drafted["consensus_adp"], drafted["actual_ppg_ppr"]).statistic
+            if has_adp else float("nan")
+        ),
+        "model_spearman_vs_adp": (
+            spearmanr(drafted["predicted_ppg_ppr"], drafted["actual_ppg_ppr"]).statistic
+            if has_adp else float("nan")
+        ),
+        "adp_n": len(drafted),
+        "games_mae": mean_absolute_error(fold["actual_games"], fold["expected_games"]),
+        "games_naive_mae": mean_absolute_error(
+            fold["actual_games"], fold["weighted_games_per_season"]
+        ),
+    }
+
+
+def _walk_forward(
+    labeled: pd.DataFrame, fold_seasons: list[int]
+) -> tuple[list[pd.DataFrame], pd.DataFrame]:
+    """Predict each labeled season from a model trained only on the seasons before it.
+
+    Replaces what used to be a single train-2019/holdout-2020 split (n=331). One split can't
+    distinguish a real improvement from fold noise, which makes it useless as the accept/reject
+    instrument for any change to the feature set — hence one fold per labeled season, each training
+    on everything that came before it, exactly mirroring how the live model is fit.
+    """
+    predictions, metrics = [], []
+    for season in fold_seasons:
+        train = labeled[labeled["target_season"] < season]
+        fold = labeled[labeled["target_season"] == season].copy()
+        fold["predicted_ppg_ppr"] = _fit(train).predict(fold[_FEATURE_COLUMNS])
+        fold["expected_games"] = _fit_games(train).predict(fold[_GAMES_FEATURE_COLUMNS])
+        predictions.append(fold)
+
+        metrics.append(_metrics(fold, season, "ALL"))
+        for position, group in fold.groupby("position"):
+            if len(group) >= _MIN_METRIC_ROWS:
+                metrics.append(_metrics(group, season, position))
+    return predictions, pd.DataFrame(metrics)
+
+
+def _print_backtest_report(metrics: pd.DataFrame, folds: list[pd.DataFrame]) -> None:
+    overall = metrics[metrics["position"] == "ALL"]
+    print("\nWalk-forward backtest — each season predicted by a model trained only on prior ones:")
+    print(f"  {'season':>6} {'n':>5} {'MAE':>6} {'R2':>6} {'rho':>6} | "
+          f"{'naive MAE':>9} {'naive rho':>9} | {'ADP rho':>7} {'model rho':>9} {'(n)':>6}")
+    for row in overall.itertuples():
+        print(f"  {row.target_season:>6} {row.n:>5} {row.mae:>6.2f} {row.r2:>6.3f} "
+              f"{row.spearman:>6.3f} | {row.naive_mae:>9.2f} {row.naive_spearman:>9.3f} | "
+              f"{row.adp_spearman:>7.3f} {row.model_spearman_vs_adp:>9.3f} {row.adp_n:>6}")
+
+    # Pooled over every fold rather than averaged over per-fold numbers, so a season with more
+    # qualifying players counts for more and small positions (TE, QB) don't get a whole fold's
+    # worth of weight from 25 rows.
+    pooled = pd.concat(folds, ignore_index=True)
+    print("\n  Pooled across all folds, by position:")
+    for position in ("QB", "RB", "WR", "TE"):
+        group = pooled[pooled["position"] == position]
+        if len(group) < _MIN_METRIC_ROWS:
+            continue
+        row = _metrics(group, 0, position)
+        print(f"  {position:>6} {row['n']:>5} {row['mae']:>6.2f} {row['r2']:>6.3f} "
+              f"{row['spearman']:>6.3f} | {row['naive_mae']:>9.2f} {row['naive_spearman']:>9.3f} | "
+              f"{row['adp_spearman']:>7.3f} {row['model_spearman_vs_adp']:>9.3f} "
+              f"{row['adp_n']:>6}")
+
+    games = _metrics(pooled, 0, "ALL")
+    print(f"\n  Games played, pooled: MAE={games['games_mae']:.2f} vs "
+          f"{games['games_naive_mae']:.2f} for the weighted average it replaces")
+
+
 def build_inhouse_projections() -> None:
     con = duckdb.connect(str(WAREHOUSE_PATH))
     con.create_function("normalize_team", normalize_team, ["VARCHAR"], "VARCHAR")
     df = con.execute(_FEATURE_SQL).df()
+    season_games = dict(con.execute(_SEASON_GAMES_SQL).fetchall())
     con.close()
 
     df = _add_position_dummies(df)
+    # The live target_season's schedule isn't published yet (and nflverse won't carry it until
+    # well after these projections are wanted), so it inherits the most recent season that is —
+    # the same assumption every external site is making when it projects 17 games.
+    latest_scheduled = season_games[max(season_games)]
+    for season in df["target_season"].unique():
+        season_games.setdefault(int(season), latest_scheduled)
+
     labeled = df[df["actual_ppg_ppr"].notna()].sort_values("target_season")
     labeled_seasons = sorted(labeled["target_season"].unique())
-    trainable_seasons = [s for s in labeled_seasons if s >= _MIN_TRAIN_SEASON_WITH_TEAM_CONTEXT]
+    fold_seasons = [s for s in labeled_seasons if s > _MIN_TRAIN_SEASON_WITH_TEAM_CONTEXT]
     live_season = df["target_season"].max()
 
     output_frames = []
+    metrics = pd.DataFrame()
 
-    if len(trainable_seasons) >= 2:
-        train_season, holdout_season = trainable_seasons[0], trainable_seasons[1]
-        train = labeled[labeled["target_season"] == train_season]
-        holdout = labeled[labeled["target_season"] == holdout_season].copy()
+    if fold_seasons:
+        output_frames, metrics = _walk_forward(labeled, fold_seasons)
+        _print_backtest_report(metrics, output_frames)
 
-        holdout_model = _fit(train)
-        holdout["predicted_ppg_ppr"] = holdout_model.predict(holdout[_FEATURE_COLUMNS])
-        mae = mean_absolute_error(holdout["actual_ppg_ppr"], holdout["predicted_ppg_ppr"])
-        r2 = r2_score(holdout["actual_ppg_ppr"], holdout["predicted_ppg_ppr"])
-        print(
-            f"Holdout eval: trained on target_season={train_season} (n={len(train)}), "
-            f"evaluated out-of-sample on target_season={holdout_season} (n={len(holdout)}) "
-            f"-> MAE={mae:.2f} R2={r2:.2f}"
-        )
-
-        holdout["expected_games"] = _fit_games(train).predict(holdout[_GAMES_FEATURE_COLUMNS])
-        # Reported against the weighted average this model replaces, since "better than no model"
-        # is the only claim worth making about a target this noisy — most of what decides games
-        # played is injury luck, which nothing here observes.
-        games_mae = mean_absolute_error(holdout["actual_games"], holdout["expected_games"])
-        naive_mae = mean_absolute_error(holdout["actual_games"], holdout["weighted_games_per_season"])
-        print(
-            f"Games holdout: MAE={games_mae:.2f} vs {naive_mae:.2f} for the weighted average "
-            f"it replaces"
-        )
-
-        # Out-of-sample (on the holdout, not train) so a feature the model overfit to doesn't look
-        # important just because it memorized train-set noise. Answers "do the team-context signals
-        # (ol_grade/skill_grade) actually carry weight" rather than assuming they do because they're
-        # in the feature list.
+        # Out-of-sample (on the fold, not its training slice) so a feature the model overfit to
+        # doesn't look important just because it memorized training noise. Answers "do the
+        # team-context signals (ol_grade/skill_grade) actually carry weight" rather than assuming
+        # they do because they're in the feature list. Run on the last fold: it has the most
+        # training data behind it, so it's the fold closest to the live model actually shipped.
+        last_fold = output_frames[-1]
+        last_model = _fit(labeled[labeled["target_season"] < fold_seasons[-1]])
         importances = permutation_importance(
-            holdout_model, holdout[_FEATURE_COLUMNS], holdout["actual_ppg_ppr"],
+            last_model, last_fold[_FEATURE_COLUMNS], last_fold["actual_ppg_ppr"],
             n_repeats=20, random_state=0,
         )
         ranked_importances = sorted(
             zip(_FEATURE_COLUMNS, importances.importances_mean), key=lambda x: -x[1]
         )
         importance_str = ", ".join(f"{name}={score:.3f}" for name, score in ranked_importances)
-        print(f"Permutation feature importance (mean R2 drop when shuffled): {importance_str}")
-
-        output_frames.append(holdout)
+        print(f"\nPermutation feature importance on the {fold_seasons[-1]} fold "
+              f"(mean R2 drop when shuffled): {importance_str}")
     else:
-        print("Fewer than 2 trainable labeled seasons available — skipping holdout evaluation.")
+        print("No labeled season has a trainable prior slice yet — skipping the backtest.")
 
     # Restrict live output to players who actually played in target_season - 1: without that,
     # a player with no data more recent than 2+ years back (e.g. a retiree like Tom Brady, whose
     # last game was 2022) still gets extrapolated forward from their old numbers, with nothing in
-    # the feature set signaling they're no longer active. Training/holdout are untouched — a
-    # missing prior-year team there is just a smaller feature signal, not a "don't show this"
-    # judgment call the way it is for the live cohort actually feeding consensus.py.
+    # the feature set signaling they're no longer active. Backtest folds are untouched — a missing
+    # prior-year team there is just a smaller feature signal, not a "don't show this" judgment call
+    # the way it is for the live cohort actually feeding consensus.py.
     live = df[(df["target_season"] == live_season) & df["team"].notna()].copy()
     if not labeled.empty:
         final_model = _fit(labeled)
@@ -290,18 +414,24 @@ def build_inhouse_projections() -> None:
     output_frames.append(live)
 
     result = pd.concat(output_frames, ignore_index=True)
+    result["season_games"] = result["target_season"].map(season_games)
     result["projected_points"] = result["predicted_ppg_ppr"] * result["expected_games"]
+    result["projected_points_full"] = result["predicted_ppg_ppr"] * result["season_games"]
     result = result[[
         "player_id", "player_name", "position", "target_season",
-        "predicted_ppg_ppr", "expected_games", "projected_points",
+        "predicted_ppg_ppr", "expected_games", "season_games",
+        "projected_points", "projected_points_full",
     ]]
 
     con = duckdb.connect(str(WAREHOUSE_PATH))
     con.execute("CREATE OR REPLACE TABLE inhouse_projections AS SELECT * FROM result")
     (count,) = con.execute("SELECT COUNT(*) FROM inhouse_projections").fetchone()
+    con.execute("CREATE OR REPLACE TABLE inhouse_backtest AS SELECT * FROM metrics")
+    (metric_count,) = con.execute("SELECT COUNT(*) FROM inhouse_backtest").fetchone()
     con.close()
 
-    print(f"Built {count} rows into {WAREHOUSE_PATH} (table: inhouse_projections)")
+    print(f"\nBuilt {count} rows into {WAREHOUSE_PATH} (table: inhouse_projections)")
+    print(f"Built {metric_count} rows into {WAREHOUSE_PATH} (table: inhouse_backtest)")
 
 
 if __name__ == "__main__":

--- a/src/gold/inhouse_projections.py
+++ b/src/gold/inhouse_projections.py
@@ -5,14 +5,21 @@ over the warehouse (still no fetch step, no network). It's the "home-grown predi
 from project notes: prior-year weighted baseline + team context -> next-year PPG, meant to become
 a fifth voice in `consensus.py`'s aggregation alongside the external sites.
 
-Features, all as of `target_season - 1` (the most recent season actually played — team context for
-the season being predicted doesn't exist yet, so this stays a strictly prior-year-only setup):
+Features as of `target_season - 1` (the most recent season actually played):
 - `player_weighted_baselines.weighted_ppg_ppr` / `weighted_games_per_season` / `seasons_used` —
-  the player's own recency-weighted history and durability.
-- `offensive_line_grades.ol_grade` and `skill_position_grades.grade` (own position) for the
-  player's most-played team that season — a LEFT JOIN, since QB never matches
-  `skill_position_grades` (it only grades WR/TE/RB); HistGradientBoostingRegressor takes the
-  resulting NaN natively, no imputation needed.
+  the player's own recency-weighted history and durability, plus that table's volume/role/
+  efficiency component block and its touchdown-luck-neutral `weighted_td_regressed_ppg`.
+- `offensive_line_grades.ol_grade` and `skill_position_grades.grade` (own position) — a LEFT JOIN,
+  since QB never matches `skill_position_grades` (it only grades WR/TE/RB);
+  HistGradientBoostingRegressor takes the resulting NaN natively, no imputation needed.
+
+Plus a role block as of the start of `target_season` itself — `target_is_starter` and
+`changed_team`, from that season's week 1 depth chart. A depth chart published before a snap is
+played says nothing about the label, so this isn't leakage, and it's what lets the model tell an
+incumbent from a career backup whose per-game history looks identical. The grades above are still
+*measured* on `target_season - 1` (the season being predicted hasn't happened) but are attached to
+the team the player is joining, so an offseason move changes his supporting cast rather than
+carrying his old team's line into the projection.
 
 Plus a career block that is instead as of `target_season` itself — `seasons_of_experience`,
 `age_at_season`, `draft_pick`. Age and years-in-league for the season being
@@ -34,23 +41,34 @@ Every stored prediction is produced without the model having seen its own label:
   by a model refit on *all* labeled seasons combined, since there's no reason to hold data back
   from the projection that actually matters once the honest backtest above has already run.
 
-Two season-total columns, because the external projection sites and this model don't answer the
-same question:
-- `projected_points_full` = `predicted_ppg_ppr * season_games` — points if the player is available
-  all season. This is what every external source in `consensus.py` publishes (verified: CBS's own
-  `fppg` implies exactly 17 games for all 888 of its players, and the others match to within a
-  percent), so it's the column `consensus.py` blends. Anything else silently discounts the in-house
-  arm against four health-neutral ones and drags the consensus median down.
-- `projected_points` = `predicted_ppg_ppr * expected_games` — the same projection scaled by how
-  many games the player is actually expected to play. Strictly more informative than the full
-  season number for ranking real rosters; just not comparable to what the sites publish.
-
 `predicted_ppg_ppr` and `expected_games` are predicted separately, by models with different feature
 sets, because "how good per game" and "how many games will they play" are different questions —
 prior-year scoring rate says nothing about availability, and the role signals that do carry it (see
-`_GAMES_FEATURE_COLUMNS`) say little about scoring. Expect the games half to stay weak whatever is
-thrown at it: most of what decides availability is injury luck, which nothing in this warehouse
-observes.
+`_GAMES_FEATURE_COLUMNS`) say little about scoring.
+
+Two season-total columns come out of those two halves, because this model and the external
+projection sites decompose a season differently:
+
+- `projected_points` = `predicted_ppg_ppr * expected_games`. The honest expectation: points per
+  game he plays, times the games he's expected to play. This is the number to rank a real roster
+  on, and it is *not* what the sites publish.
+- `projected_points_full` = `predicted_ppg_ppr * role_games`, the column `consensus.py` blends.
+
+The distinction matters because the sites are internally inconsistent in a specific way, and
+matching them requires reproducing that inconsistency rather than being more correct than it. They
+do not discount a starter for injury risk — CBS projects 17.0 games for every starter it covers,
+and the others land within a percent of the same assumption — but they *do* discount a backup for
+role, expressed through the per-game term instead of through games: CBS has Jake Browning at 0.9
+points per game across a full 17. Their product is what `projected_points_full` has to be
+comparable to, so it keeps the role discount and drops the injury one. `_role_games` does that by
+measuring a player's expected games against a starter's at the same position and season.
+
+That leaves one known bias, in `expected_games` and so in both totals. Its label counts appearances
+in `weekly_stats`, so a player who never takes a snap has no row to count and the label bottoms out
+at 1 game rather than 0. Career backups are consequently projected for more games than they'll
+play, and their season totals run high — Browning lands around 55 points against ESPN's 10. Closing
+that gap needs the roster, not the box scores. Note the walk-forward can't see this at all: the
+scoring label's games floor excludes exactly the players it affects.
 """
 
 from pathlib import Path
@@ -79,6 +97,7 @@ WAREHOUSE_PATH = Path("data/warehouse.duckdb")
 _BASE_FEATURES = [
     "weighted_ppg_ppr", "weighted_games_per_season", "seasons_used", "ol_grade", "skill_grade",
     "seasons_of_experience", "age_at_season", "draft_pick",
+    "target_is_starter", "changed_team",
 ] + _COMPONENT_COLUMNS
 _FEATURE_COLUMNS = _BASE_FEATURES + [f"position_{p}" for p in _SKILL_POSITIONS]
 
@@ -91,6 +110,10 @@ _GAMES_FEATURE_COLUMNS = [
     "weighted_games_per_season", "seasons_used",
     "seasons_of_experience", "age_at_season", "draft_pick",
     "weeks_on_depth_chart", "starter_share", "end_starter",
+    # Availability's own version of the same blind spot the PPG model had: a player who won't be
+    # on the field at all is a different proposition from one who was hurt, and only the target
+    # season's depth chart separates them before the season starts.
+    "target_is_starter",
 ] + [f"position_{p}" for p in _SKILL_POSITIONS]
 
 # Conservative for a dataset this small (a few hundred rows per cohort): shallow trees, a decent
@@ -148,18 +171,38 @@ WITH team_by_player_season AS (
 player_team AS (
     SELECT season, player_id, team FROM team_by_player_season WHERE rn = 1
 ),
-actual_outcomes AS (
+-- The scoring label keeps the games-played floor: a season cut short by injury is as untrustworthy
+-- a training target for a per-game rate as a short season is a baseline input.
+actual_scoring AS (
     SELECT
         player_id,
         season AS target_season,
-        SUM(fantasy_points_ppr) / COUNT(*) AS actual_ppg_ppr,
-        COUNT(*) AS actual_games
+        SUM(fantasy_points_ppr) / COUNT(*) AS actual_ppg_ppr
     FROM weekly_stats
     WHERE season_type = 'REG'
         AND fantasy_points_ppr IS NOT NULL
         AND position IN {_SKILL_POSITIONS}
     GROUP BY player_id, season
     HAVING COUNT(*) >= {_MIN_GAMES_PLAYED}
+),
+-- The availability label deliberately does *not*, because the floor censors exactly the outcome
+-- the games model most needs to be able to predict. Trained only on seasons of 6+ games, it could
+-- not represent a backup at all — its smallest conceivable answer was 6, so career backups came
+-- back at 8-9 games and their season totals were inflated to match. Every appearance counts here.
+--
+-- Still censored at 1, not 0: a player who never takes a snap has no weekly_stats row to count,
+-- so true zeros would have to come from the roster instead. That understates how little the
+-- deepest backups play, and is the remaining known bias in expected_games.
+actual_availability AS (
+    SELECT
+        player_id,
+        season AS target_season,
+        COUNT(*) AS actual_games
+    FROM weekly_stats
+    WHERE season_type = 'REG'
+        AND fantasy_points_ppr IS NOT NULL
+        AND position IN {_SKILL_POSITIONS}
+    GROUP BY player_id, season
 ),
 -- Role as of target_season - 1, which is what separates "wasn't the starter yet" from "kept
 -- getting hurt" — two very different stories that a games-played average alone tells identically.
@@ -175,6 +218,26 @@ prior_role AS (
         CAST(ARG_MAX(is_starter, week) AS BIGINT) AS end_starter
     FROM player_depth_chart
     GROUP BY season, gsis_id
+),
+-- Role as of the start of target_season itself, not the season before it — the one thing here
+-- that describes the season being predicted rather than the last one played. It isn't leakage:
+-- a week 1 depth chart is published before a snap of the season is played, so it says nothing
+-- about the label. It's also the single largest thing the model was missing. Without it a backup
+-- quarterback who last started ten games two years ago looks identical to the incumbent, which is
+-- why the model was projecting career backups as starters.
+--
+-- MIN(team)/MAX(is_starter) rather than ANY_VALUE: a player holds one week 1 depth chart slot in
+-- practice, but the aggregate has to be a total order regardless, or DuckDB's parallel scan
+-- resolves ties differently run to run and the projections stop being reproducible.
+target_role AS (
+    SELECT
+        season,
+        gsis_id,
+        MIN(team) AS team,
+        MAX(CASE WHEN is_starter THEN 1 ELSE 0 END) AS is_starter
+    FROM player_depth_chart
+    WHERE week = 1
+    GROUP BY season, gsis_id
 )
 SELECT
     b.target_season,
@@ -186,6 +249,24 @@ SELECT
     b.weighted_games_per_season,
 {_COMPONENT_SELECTS},
     pt.team,
+    -- The team whose supporting cast this player will actually be in: the target season's depth
+    -- chart where it knows, last season's box scores otherwise. This is what makes an offseason
+    -- move visible at all — a receiver who signs elsewhere in March used to carry his old team's
+    -- line and skill-corps grades straight into the projection.
+    COALESCE(tr.team, pt.team) AS context_team,
+    -- Absent from the depth chart is folded into "not a starter" rather than left NULL on purpose.
+    -- Being *listed at all* isn't comparable across eras — the legacy feed lists a post-cuts
+    -- 53-man roster while the current snapshot feed lists a preseason 90-man one, so coverage of
+    -- the baseline cohort runs 43% in 2019 against 68% in 2026 — but the starter call itself is
+    -- stable at 22-25% in every season. Collapsing the unstable distinction keeps the feature
+    -- meaning one fixed thing at training time and at prediction time.
+    COALESCE(tr.is_starter, 0) AS target_is_starter,
+    -- Left NULL when either side is unknown: a move that can't be observed is genuinely unknown,
+    -- unlike the starter call above, where absence carries a real meaning worth encoding.
+    CASE
+        WHEN tr.team IS NOT NULL AND pt.team IS NOT NULL
+        THEN CAST(tr.team != pt.team AS BIGINT)
+    END AS changed_team,
     ol.ol_grade,
     sk.grade AS skill_grade,
     -- Unlike every feature above, these are as of target_season itself rather than
@@ -214,12 +295,21 @@ SELECT
     -- had seen ADP could not meaningfully disagree with it.
     adp.consensus_adp,
     o.actual_ppg_ppr,
-    o.actual_games
+    av.actual_games
 FROM player_weighted_baselines b
 LEFT JOIN player_team pt ON pt.player_id = b.player_id AND pt.season = b.target_season - 1
-LEFT JOIN offensive_line_grades ol ON ol.team = pt.team AND ol.season = b.target_season - 1
+LEFT JOIN target_role tr ON tr.gsis_id = b.player_id AND tr.season = b.target_season
+-- Grades are still measured on target_season - 1 (the season being predicted hasn't been played,
+-- so it has no team context of its own) but are now attached to the team the player is joining
+-- rather than the one he left. "How good was my new supporting cast last year" is the question
+-- worth asking; "how good was the one I no longer play for" is not. Both joins have to sit after
+-- pt and tr, since they read the COALESCE across them.
+LEFT JOIN offensive_line_grades ol
+    ON ol.team = COALESCE(tr.team, pt.team) AND ol.season = b.target_season - 1
 LEFT JOIN skill_position_grades sk
-    ON sk.team = pt.team AND sk.season = b.target_season - 1 AND sk.position = b.position
+    ON sk.team = COALESCE(tr.team, pt.team)
+    AND sk.season = b.target_season - 1
+    AND sk.position = b.position
 -- players.years_of_experience is deliberately unused: it's one static value per player that
 -- doesn't equal seasons-since-rookie (Brady reads 23 against a 2000 rookie season and a final
 -- 2022 season), so applying it to a historical row would leak how the career eventually turned
@@ -230,7 +320,9 @@ LEFT JOIN prior_role pr ON pr.gsis_id = b.player_id AND pr.season = b.target_sea
 -- before the season starts, so lining it up with the season it was drafted for is what makes it a
 -- fair benchmark rather than a lagged one.
 LEFT JOIN adp_consensus adp ON adp.gsis_id = b.player_id AND adp.season = b.target_season
-LEFT JOIN actual_outcomes o ON o.player_id = b.player_id AND o.target_season = b.target_season
+LEFT JOIN actual_scoring o ON o.player_id = b.player_id AND o.target_season = b.target_season
+LEFT JOIN actual_availability av
+    ON av.player_id = b.player_id AND av.target_season = b.target_season
 -- Not cosmetic: DuckDB's parallel joins return these rows in a different order from run to run,
 -- and HistGradientBoostingRegressor sums gradients per histogram bin in row order. Float addition
 -- isn't associative, so a reordered frame shifts split gains just enough to flip tree splits,
@@ -299,15 +391,56 @@ def _metrics(fold: pd.DataFrame, target_season: int, position: str) -> dict:
             if has_adp else float("nan")
         ),
         "adp_n": len(drafted),
-        "games_mae": mean_absolute_error(fold["actual_games"], fold["expected_games"]),
-        "games_naive_mae": mean_absolute_error(
-            fold["actual_games"], fold["weighted_games_per_season"]
-        ),
     }
 
 
+def _games_metrics(games_fold: pd.DataFrame) -> dict:
+    """Score the availability half on its own population — everyone who appeared, not just the
+    players who cleared the scoring label's 6-game floor.
+
+    Scoring it on the 6+ games population instead would grade the model on a subgroup it is
+    deliberately no longer specialised to: once it can predict backups at all, its predictions for
+    everyone shift down, which reads as a regression when measured only on players who by
+    construction played a lot. The naive comparison moves to the same wider population with it, so
+    the two stay like for like.
+    """
+    return {
+        "games_n": len(games_fold),
+        "games_mae": mean_absolute_error(games_fold["actual_games"],
+                                         games_fold["expected_games"]),
+        "games_naive_mae": mean_absolute_error(games_fold["actual_games"],
+                                               games_fold["weighted_games_per_season"]),
+    }
+
+
+def _role_games(frame: pd.DataFrame) -> pd.Series:
+    """How many games this player would play at full health, given the role he's expected to hold.
+
+    `expected_games` mixes two very different reasons a player misses time — he gets hurt, or he
+    was never going to be on the field — and the external sources treat those differently. None of
+    them discounts a starter for injury risk (CBS projects 17.0 games for every starter it covers),
+    but all of them do discount a backup for role: CBS has Jake Browning at 0.9 points per game
+    across a full 17, which is a role judgment expressed through the per-game term rather than
+    through games. Their *product* is what `projected_points_full` has to be comparable to.
+
+    Dividing a player's expected games by what a starter at his position and season is expected to
+    get strips out the league-wide injury discount, which is roughly common to everyone, and leaves
+    the part that is specifically about role. A week 1 starter lands at ~1.0 and so keeps the full
+    season; a backup at half a starter's expected games keeps half of it. Capped at 1.0, since
+    "healthier than a typical starter" is not a thing this should extrapolate into extra games.
+    """
+    starters = frame[frame["target_is_starter"] == 1]
+    reference = starters.groupby(["target_season", "position"])["expected_games"].mean()
+    key = pd.MultiIndex.from_frame(frame[["target_season", "position"]])
+    reference_games = pd.Series(reference.reindex(key).to_numpy(), index=frame.index)
+    # A season/position with no listed starter at all leaves the ratio undefined; falling back to
+    # 1.0 keeps that player on the full season rather than silently zeroing his projection.
+    ratio = (frame["expected_games"] / reference_games).clip(upper=1.0).fillna(1.0)
+    return frame["season_games"] * ratio
+
+
 def _walk_forward(
-    labeled: pd.DataFrame, fold_seasons: list[int]
+    labeled: pd.DataFrame, labeled_games: pd.DataFrame, fold_seasons: list[int]
 ) -> tuple[list[pd.DataFrame], pd.DataFrame]:
     """Predict each labeled season from a model trained only on the seasons before it.
 
@@ -316,22 +449,34 @@ def _walk_forward(
     instrument for any change to the feature set — hence one fold per labeled season, each training
     on everything that came before it, exactly mirroring how the live model is fit.
     """
-    predictions, metrics = [], []
+    predictions, games_predictions, metrics = [], [], []
     for season in fold_seasons:
         train = labeled[labeled["target_season"] < season]
+        # The games half trains on its own, wider slice — every player who appeared at all, not
+        # just those clearing the scoring label's games floor — and is scored on that same wider
+        # population below.
+        train_games = labeled_games[labeled_games["target_season"] < season]
+        games_model = _fit_games(train_games)
+
         fold = labeled[labeled["target_season"] == season].copy()
         fold["predicted_ppg_ppr"] = _fit(train).predict(fold[_FEATURE_COLUMNS])
-        fold["expected_games"] = _fit_games(train).predict(fold[_GAMES_FEATURE_COLUMNS])
+        fold["expected_games"] = games_model.predict(fold[_GAMES_FEATURE_COLUMNS])
         predictions.append(fold)
 
-        metrics.append(_metrics(fold, season, "ALL"))
+        games_fold = labeled_games[labeled_games["target_season"] == season].copy()
+        games_fold["expected_games"] = games_model.predict(games_fold[_GAMES_FEATURE_COLUMNS])
+        games_predictions.append(games_fold)
+
+        metrics.append(_metrics(fold, season, "ALL") | _games_metrics(games_fold))
         for position, group in fold.groupby("position"):
             if len(group) >= _MIN_METRIC_ROWS:
                 metrics.append(_metrics(group, season, position))
-    return predictions, pd.DataFrame(metrics)
+    return predictions, games_predictions, pd.DataFrame(metrics)
 
 
-def _print_backtest_report(metrics: pd.DataFrame, folds: list[pd.DataFrame]) -> None:
+def _print_backtest_report(
+    metrics: pd.DataFrame, folds: list[pd.DataFrame], games_folds: list[pd.DataFrame]
+) -> None:
     overall = metrics[metrics["position"] == "ALL"]
     print("\nWalk-forward backtest — each season predicted by a model trained only on prior ones:")
     print(f"  {'season':>6} {'n':>5} {'MAE':>6} {'R2':>6} {'rho':>6} | "
@@ -356,9 +501,10 @@ def _print_backtest_report(metrics: pd.DataFrame, folds: list[pd.DataFrame]) -> 
               f"{row['adp_spearman']:>7.3f} {row['model_spearman_vs_adp']:>9.3f} "
               f"{row['adp_n']:>6}")
 
-    games = _metrics(pooled, 0, "ALL")
-    print(f"\n  Games played, pooled: MAE={games['games_mae']:.2f} vs "
-          f"{games['games_naive_mae']:.2f} for the weighted average it replaces")
+    games = _games_metrics(pd.concat(games_folds, ignore_index=True))
+    print(f"\n  Games played, pooled over every player who appeared (n={games['games_n']}): "
+          f"MAE={games['games_mae']:.2f} vs {games['games_naive_mae']:.2f} for the weighted "
+          f"average it replaces")
 
 
 def build_inhouse_projections() -> None:
@@ -377,6 +523,7 @@ def build_inhouse_projections() -> None:
         season_games.setdefault(int(season), latest_scheduled)
 
     labeled = df[df["actual_ppg_ppr"].notna()].sort_values("target_season")
+    labeled_games = df[df["actual_games"].notna()].sort_values("target_season")
     labeled_seasons = sorted(labeled["target_season"].unique())
     fold_seasons = [s for s in labeled_seasons if s > _MIN_TRAIN_SEASON_WITH_TEAM_CONTEXT]
     live_season = df["target_season"].max()
@@ -385,8 +532,10 @@ def build_inhouse_projections() -> None:
     metrics = pd.DataFrame()
 
     if fold_seasons:
-        output_frames, metrics = _walk_forward(labeled, fold_seasons)
-        _print_backtest_report(metrics, output_frames)
+        output_frames, games_frames, metrics = _walk_forward(
+            labeled, labeled_games, fold_seasons
+        )
+        _print_backtest_report(metrics, output_frames, games_frames)
 
         # Out-of-sample (on the fold, not its training slice) so a feature the model overfit to
         # doesn't look important just because it memorized training noise. Answers "do the
@@ -408,17 +557,24 @@ def build_inhouse_projections() -> None:
     else:
         print("No labeled season has a trainable prior slice yet — skipping the backtest.")
 
-    # Restrict live output to players who actually played in target_season - 1: without that,
-    # a player with no data more recent than 2+ years back (e.g. a retiree like Tom Brady, whose
-    # last game was 2022) still gets extrapolated forward from their old numbers, with nothing in
-    # the feature set signaling they're no longer active. Backtest folds are untouched — a missing
-    # prior-year team there is just a smaller feature signal, not a "don't show this" judgment call
-    # the way it is for the live cohort actually feeding consensus.py.
-    live = df[(df["target_season"] == live_season) & df["team"].notna()].copy()
+    # Restrict live output to players with some evidence they're actually in the league: either
+    # they're on the target season's week 1 depth chart, or they played the season before. Without
+    # that, a player with no data more recent than 2+ years back (e.g. a retiree like Tom Brady,
+    # whose last game was 2022) still gets extrapolated forward from their old numbers.
+    #
+    # The depth chart half is what the previous prior-season-only test was missing: it admits ~40
+    # players returning from a lost season, whose presence on a current depth chart is direct
+    # evidence of exactly the "are they still active" question that used to have no answer here.
+    # It deliberately does not go the other way and *drop* players the chart hasn't listed — 61 of
+    # them played last season, and they include genuine free agents still likely to sign.
+    #
+    # Backtest folds are untouched: a missing team there is just a smaller feature signal, not a
+    # "don't show this" judgment call the way it is for the live cohort feeding consensus.py.
+    live = df[(df["target_season"] == live_season) & df["context_team"].notna()].copy()
     if not labeled.empty:
         final_model = _fit(labeled)
         live["predicted_ppg_ppr"] = final_model.predict(live[_FEATURE_COLUMNS])
-        live["expected_games"] = _fit_games(labeled).predict(live[_GAMES_FEATURE_COLUMNS])
+        live["expected_games"] = _fit_games(labeled_games).predict(live[_GAMES_FEATURE_COLUMNS])
     else:
         live["predicted_ppg_ppr"] = float("nan")
         live["expected_games"] = float("nan")
@@ -427,11 +583,12 @@ def build_inhouse_projections() -> None:
 
     result = pd.concat(output_frames, ignore_index=True)
     result["season_games"] = result["target_season"].map(season_games)
+    result["role_games"] = _role_games(result)
     result["projected_points"] = result["predicted_ppg_ppr"] * result["expected_games"]
-    result["projected_points_full"] = result["predicted_ppg_ppr"] * result["season_games"]
+    result["projected_points_full"] = result["predicted_ppg_ppr"] * result["role_games"]
     result = result[[
         "player_id", "player_name", "position", "target_season",
-        "predicted_ppg_ppr", "expected_games", "season_games",
+        "predicted_ppg_ppr", "expected_games", "season_games", "role_games",
         "projected_points", "projected_points_full",
     ]]
 

--- a/src/gold/player_baselines.py
+++ b/src/gold/player_baselines.py
@@ -1,24 +1,44 @@
-"""Build a recency- and playing-time-weighted multi-year PPG baseline per player.
+"""Build a recency- and playing-time-weighted multi-year baseline per player.
 
 Pure warehouse-to-warehouse SQL — no fetch step, no network. Built from nflverse's weekly stats
-(already loaded by nfl_data.py's fetch_weekly_stats/load_weekly_stats).
+(already loaded by nfl_data.py's fetch_weekly_stats/load_weekly_stats), plus snap counts joined
+through the `ids` crosswalk.
 
 For every player, and for every "target season" one year past each season present in the
-warehouse, looks back up to `_MAX_YEARS_BACK` prior seasons and computes a recency-weighted PPR
-points-per-game baseline — the further back a season is, the less it counts (1.0 / 0.9 / 0.8 /
-0.7, the same decay VinGuar/Fantasy-Football-Rankings-With-ML uses for this problem). A season
-only counts at all if the player played at least `_MIN_GAMES_PLAYED` games in it: weekly_stats has
-plenty of one-game cameo rows (a Week 18 call-up, a player who tore an ACL in Week 2), and letting
-those set a full-weight per-game rate would badly distort the baseline rather than just add noise
-to it.
+warehouse, looks back up to `_MAX_YEARS_BACK` prior seasons and computes a recency-weighted
+average — the further back a season is, the less it counts (1.0 / 0.9 / 0.8 / 0.7, the same decay
+VinGuar/Fantasy-Football-Rankings-With-ML uses for this problem). A season only counts at all if
+the player played at least `_MIN_GAMES_PLAYED` games in it: weekly_stats has plenty of one-game
+cameo rows (a Week 18 call-up, a player who tore an ACL in Week 2), and letting those set a
+full-weight per-game rate would badly distort the baseline rather than just add noise to it.
 
-Alongside the PPG baseline, also outputs a `weighted_games_per_season` durability signal — the
-same recency-weighted average, but of games played rather than points per game — since a player's
-expected next-season games played is itself a useful feature (workload correlates with role) and
-the multiplier needed to turn a PPG prediction into a season-total point projection.
+`weighted_ppg_ppr` is the headline column, but a single points-per-game number throws away
+everything about *how* those points were earned, which is most of what makes next season
+predictable. Volume is far more stable year over year than touchdown rate, so the same 17 PPG
+means something very different at 9 targets a game than at 4 targets and three times the league's
+touchdown rate. So the same recency weighting is also applied to:
 
-This is a feature-engineering building block, not a projection itself — it's meant to feed a
-future in-house predictive model (prior-year weighted baseline + team context -> next-year PPG).
+- **Volume** (`_PER_GAME_TOTALS`) — targets, receptions, carries, pass attempts, yards and
+  touchdowns, each as a per-game rate. Touchdowns are deliberately kept separate from yards rather
+  than folded into a points total, so a model can see an unsustainable scoring rate as its own
+  signal instead of having it baked into the same number as the volume that generated it.
+- **Role** (`_PER_GAME_AVERAGES`) — target share, air-yards share, WOPR and snap share: what
+  fraction of an offense the player actually commanded, which survives a change of team or
+  quarterback far better than raw yardage does.
+- **Efficiency** (`_PER_GAME_AVERAGES`) — passing/rushing/receiving EPA and CPOE. Sparse by
+  construction (a TE has no passing EPA), left NULL rather than zero-filled so a consumer can tell
+  "didn't do this" from "did this badly".
+- **`weighted_td_regressed_ppg`** — PPG recomputed with the player's actual touchdowns swapped out
+  for the touchdowns their yardage would have produced at that season's league-average rate. A
+  direct "what would this have been with neutral touchdown luck" number, encoding a relationship
+  that a model would otherwise have to learn as a multi-way interaction from a few thousand rows.
+
+Alongside all of that, `weighted_games_per_season` is the same recency-weighted average applied to
+games played — a durability signal, since a player's expected next-season games played is itself a
+useful feature (workload correlates with role).
+
+This is a feature-engineering building block, not a projection itself — it feeds
+inhouse_projections.py, which imports the column lists below rather than restating them.
 """
 
 from pathlib import Path
@@ -45,21 +65,181 @@ _RECENCY_WEIGHT_CASE = """
     END
 """
 
+# Counting stats, summed over a season then divided by games played. Keyed by the output column
+# suffix, valued by the weekly_stats column being counted.
+_PER_GAME_TOTALS = {
+    "targets": "targets",
+    "receptions": "receptions",
+    "receiving_yards": "receiving_yards",
+    "receiving_tds": "receiving_tds",
+    "carries": "carries",
+    "rushing_yards": "rushing_yards",
+    "rushing_tds": "rushing_tds",
+    "pass_attempts": "attempts",
+    "passing_yards": "passing_yards",
+    "passing_tds": "passing_tds",
+    "passing_interceptions": "passing_interceptions",
+}
+
+# Stats weekly_stats already expresses as a per-week rate or share, so a season value is their mean
+# over the weeks that have one. AVG skips NULLs, which is what's wanted here: the efficiency
+# columns are only populated in weeks the player actually did the thing (racr/EPA/CPOE are NULL for
+# a receiver who wasn't targeted), so averaging over played games instead would silently drag a
+# specialist's rate toward zero.
+_PER_GAME_AVERAGES = {
+    "target_share": "target_share",
+    "air_yards_share": "air_yards_share",
+    "wopr": "wopr",
+    "passing_epa": "passing_epa",
+    "rushing_epa": "rushing_epa",
+    "receiving_epa": "receiving_epa",
+    "passing_cpoe": "passing_cpoe",
+}
+
+# Populated from snap_counts rather than weekly_stats, so it's joined in separately below.
+_SNAP_SHARE_COLUMN = "snap_share"
+
+# The component columns this table exposes beyond weighted_ppg_ppr/weighted_games_per_season.
+# inhouse_projections.py imports this instead of restating the list, so a column added here can't
+# silently fail to reach the model.
+_COMPONENT_COLUMNS = (
+    [f"weighted_{name}_per_game" for name in _PER_GAME_TOTALS]
+    + [f"weighted_{name}" for name in _PER_GAME_AVERAGES]
+    + [f"weighted_{_SNAP_SHARE_COLUMN}", "weighted_td_regressed_ppg"]
+)
+
+# PPR values for the touchdowns swapped out in weighted_td_regressed_ppg. These mirror nflverse's
+# own fantasy_points_ppr formula, which is what's being adjusted — if that formula ever changes,
+# these have to change with it or the swap stops being a like-for-like substitution.
+_RECEIVING_TD_POINTS = 6
+_RUSHING_TD_POINTS = 6
+_PASSING_TD_POINTS = 4
+
+# A position-season needs this many league-wide yards before its own touchdown-per-yard rate is
+# trusted; below it, the rate is borrowed from every position pooled. Without the guard, positions
+# that barely do a thing produce absurd rates off a tiny denominator — RBs threw for 3 touchdowns
+# on 9 yards league-wide in 2024, a rate of 0.33 touchdowns *per yard*, which would have credited
+# every pass-catching back with phantom points.
+_MIN_LEAGUE_YARDS_FOR_RATE = 5000
+
+
+def _weighted(expression: str, alias: str) -> str:
+    """Recency-weighted mean of a per-season value, skipping seasons where it's NULL.
+
+    The FILTER matters for the sparse efficiency columns: without it a player with EPA in two of
+    three qualifying seasons would have the numerator skip the NULL season while the denominator
+    still counted its weight, quietly shrinking the result toward zero in proportion to how much
+    was missing.
+    """
+    return (
+        f"SUM({expression} * h.recency_weight) FILTER (WHERE {expression} IS NOT NULL)\n"
+        f"        / SUM(h.recency_weight) FILTER (WHERE {expression} IS NOT NULL) AS {alias}"
+    )
+
+
+_SEASON_STAT_SELECTS = ",\n".join(
+    [f"        SUM({column}) / COUNT(*) AS {name}_per_game"
+     for name, column in _PER_GAME_TOTALS.items()]
+    + [f"        AVG({column}) AS {name}" for name, column in _PER_GAME_AVERAGES.items()]
+)
+
+_HISTORY_PASSTHROUGH = ",\n".join(
+    f"        s.{name}" for name in
+    [f"{name}_per_game" for name in _PER_GAME_TOTALS]
+    + list(_PER_GAME_AVERAGES)
+    + [_SNAP_SHARE_COLUMN, "td_regressed_ppg"]
+)
+
+_WEIGHTED_SELECTS = ",\n    ".join(
+    [_weighted(f"h.{name}_per_game", f"weighted_{name}_per_game") for name in _PER_GAME_TOTALS]
+    + [_weighted(f"h.{name}", f"weighted_{name}") for name in _PER_GAME_AVERAGES]
+    + [
+        _weighted(f"h.{_SNAP_SHARE_COLUMN}", f"weighted_{_SNAP_SHARE_COLUMN}"),
+        _weighted("h.td_regressed_ppg", "weighted_td_regressed_ppg"),
+    ]
+)
+
 _BUILD_SQL = f"""
 CREATE OR REPLACE TABLE player_weighted_baselines AS
-WITH season_stats AS (
+WITH snap_share_by_season AS (
+    -- snap_counts is keyed on PFR's player id, so it reaches gsis_id through the `ids` crosswalk
+    -- (99%+ of qualifying player-seasons match). Grouped to one row per player-season before it
+    -- joins anything, so a duplicate crosswalk row can't fan out the season_stats join.
+    SELECT i.gsis_id AS player_id, sc.season, AVG(sc.offense_pct) AS {_SNAP_SHARE_COLUMN}
+    FROM snap_counts sc
+    JOIN ids i ON i.pfr_id = sc.pfr_player_id
+    WHERE sc.game_type = 'REG' AND i.gsis_id IS NOT NULL
+    GROUP BY i.gsis_id, sc.season
+),
+-- League-average touchdowns per yard, for the weighted_td_regressed_ppg swap. Per position, since
+-- a tight end scores at a genuinely different rate per yard than a running back, but falling back
+-- to every position pooled when a position-season is too thin to estimate from (see
+-- _MIN_LEAGUE_YARDS_FOR_RATE).
+league_rates_pooled AS (
     SELECT
-        player_id,
-        ANY_VALUE(player_display_name) AS player_name,
-        ANY_VALUE(position) AS position,
         season,
-        COUNT(*) AS games_played,
-        SUM(fantasy_points_ppr) / COUNT(*) AS ppg_ppr
+        SUM(receiving_tds) / NULLIF(SUM(receiving_yards), 0) AS receiving_td_per_yard,
+        SUM(rushing_tds) / NULLIF(SUM(rushing_yards), 0) AS rushing_td_per_yard,
+        SUM(passing_tds) / NULLIF(SUM(passing_yards), 0) AS passing_td_per_yard
     FROM weekly_stats
-    WHERE season_type = 'REG'
-        AND fantasy_points_ppr IS NOT NULL
-        AND position IN {_SKILL_POSITIONS}
-    GROUP BY player_id, season
+    WHERE season_type = 'REG' AND position IN {_SKILL_POSITIONS}
+    GROUP BY season
+),
+league_rates AS (
+    SELECT
+        p.season,
+        p.position,
+        COALESCE(
+            CASE WHEN SUM(p.receiving_yards) >= {_MIN_LEAGUE_YARDS_FOR_RATE}
+                 THEN SUM(p.receiving_tds) / NULLIF(SUM(p.receiving_yards), 0) END,
+            ANY_VALUE(lp.receiving_td_per_yard)
+        ) AS receiving_td_per_yard,
+        COALESCE(
+            CASE WHEN SUM(p.rushing_yards) >= {_MIN_LEAGUE_YARDS_FOR_RATE}
+                 THEN SUM(p.rushing_tds) / NULLIF(SUM(p.rushing_yards), 0) END,
+            ANY_VALUE(lp.rushing_td_per_yard)
+        ) AS rushing_td_per_yard,
+        COALESCE(
+            CASE WHEN SUM(p.passing_yards) >= {_MIN_LEAGUE_YARDS_FOR_RATE}
+                 THEN SUM(p.passing_tds) / NULLIF(SUM(p.passing_yards), 0) END,
+            ANY_VALUE(lp.passing_td_per_yard)
+        ) AS passing_td_per_yard
+    FROM weekly_stats p
+    JOIN league_rates_pooled lp ON lp.season = p.season
+    WHERE p.season_type = 'REG' AND p.position IN {_SKILL_POSITIONS}
+    GROUP BY p.season, p.position
+),
+season_stats AS (
+    SELECT
+        w.player_id,
+        ANY_VALUE(w.player_display_name) AS player_name,
+        ANY_VALUE(w.position) AS position,
+        w.season,
+        COUNT(*) AS games_played,
+        SUM(w.fantasy_points_ppr) / COUNT(*) AS ppg_ppr,
+        -- The same points, with the player's own touchdowns removed and the touchdowns their
+        -- yardage would have produced at league average added back. Yardage, receptions and
+        -- turnovers are left exactly as they were: this isolates touchdown luck rather than
+        -- rebuilding the whole stat line.
+        (
+            SUM(w.fantasy_points_ppr)
+            - {_RECEIVING_TD_POINTS} * SUM(w.receiving_tds)
+            - {_RUSHING_TD_POINTS} * SUM(w.rushing_tds)
+            - {_PASSING_TD_POINTS} * SUM(w.passing_tds)
+            + {_RECEIVING_TD_POINTS} * SUM(w.receiving_yards) * ANY_VALUE(r.receiving_td_per_yard)
+            + {_RUSHING_TD_POINTS} * SUM(w.rushing_yards) * ANY_VALUE(r.rushing_td_per_yard)
+            + {_PASSING_TD_POINTS} * SUM(w.passing_yards) * ANY_VALUE(r.passing_td_per_yard)
+        ) / COUNT(*) AS td_regressed_ppg,
+        ANY_VALUE(ss.{_SNAP_SHARE_COLUMN}) AS {_SNAP_SHARE_COLUMN},
+{_SEASON_STAT_SELECTS}
+    FROM weekly_stats w
+    JOIN league_rates r ON r.season = w.season AND r.position = w.position
+    LEFT JOIN snap_share_by_season ss
+        ON ss.player_id = w.player_id AND ss.season = w.season
+    WHERE w.season_type = 'REG'
+        AND w.fantasy_points_ppr IS NOT NULL
+        AND w.position IN {_SKILL_POSITIONS}
+    GROUP BY w.player_id, w.season
     HAVING COUNT(*) >= {_MIN_GAMES_PLAYED}
 ),
 -- One row per season past every season actually in the warehouse (e.g. seasons 2021-2023 produce
@@ -78,6 +258,7 @@ history AS (
         s.season,
         s.games_played,
         s.ppg_ppr,
+{_HISTORY_PASSTHROUGH},
         {_RECENCY_WEIGHT_CASE} AS recency_weight
     FROM target_seasons t
     JOIN season_stats s
@@ -98,7 +279,8 @@ SELECT
     COUNT(*) AS seasons_used,
     SUM(h.games_played) AS games_used,
     SUM(h.ppg_ppr * h.recency_weight) / SUM(h.recency_weight) AS weighted_ppg_ppr,
-    SUM(h.games_played * h.recency_weight) / SUM(h.recency_weight) AS weighted_games_per_season
+    SUM(h.games_played * h.recency_weight) / SUM(h.recency_weight) AS weighted_games_per_season,
+    {_WEIGHTED_SELECTS}
 FROM history h
 JOIN most_recent_season m
     ON m.target_season = h.target_season AND m.player_id = h.player_id AND m.rn = 1

--- a/src/silver/nfl_data.py
+++ b/src/silver/nfl_data.py
@@ -236,18 +236,25 @@ if __name__ == "__main__":
     # Bump _UPCOMING_SEASON once a year, after the last one has been played out.
     played_seasons = list(range(2015, _UPCOMING_SEASON))
 
-    # Two of these feeds describe a season *before* it's played rather than after, and the upcoming
-    # season is exactly the one the models project — so they're fetched a year further forward than
-    # everything else. The schedule is published in May; depth-chart snapshots run from the March
-    # after the previous season right through the summer, which is what lets inhouse_projections
-    # know who is actually starting for the season it's projecting rather than inferring role from
-    # last year's box scores. Every other feed here is a record of games already played, and asking
-    # for a season that hasn't happened returns nothing.
+    # Three of these feeds describe a season *before* it's played rather than after, and the
+    # upcoming season is exactly the one the models project — so they're fetched a year further
+    # forward than everything else. The schedule is published in May; depth-chart snapshots run
+    # from the March after the previous season right through the summer, which is what lets
+    # inhouse_projections know who is actually starting for the season it's projecting rather than
+    # inferring role from last year's box scores; and preseason rosters carry `draft_number` and
+    # `years_exp`, which is how the rookie arm gets draft capital and identifies a first-season
+    # player at all. Every other feed here is a record of games already played, and asking for a
+    # season that hasn't happened returns nothing.
+    #
+    # Rosters specifically: the `players` release is the more natural home for draft capital, but
+    # nflverse publishes it there on a long lag — as of the 2026 preseason it still had no 2026
+    # draft class at all, while the roster feed already carried the full board. Reading draft
+    # capital from rosters is what makes the rookie arm work in the season it's needed.
     forward_looking_seasons = played_seasons + [_UPCOMING_SEASON]
 
     load_weekly_stats(fetch_weekly_stats(played_seasons))
     load_schedules(fetch_schedules(forward_looking_seasons))
-    load_rosters(fetch_rosters(played_seasons))
+    load_rosters(fetch_rosters(forward_looking_seasons))
     load_snap_counts(fetch_snap_counts(played_seasons))
     load_injuries(fetch_injuries(played_seasons))
     load_depth_charts(fetch_depth_charts(played_seasons))

--- a/src/silver/nfl_data.py
+++ b/src/silver/nfl_data.py
@@ -122,6 +122,10 @@ def load_injuries(raw_path: Path) -> None:
 # and src/gold/depth_charts.py reconciles them into one weekly view.
 _DEPTH_CHART_SCHEMA_BREAK = 2025
 
+# The season the models project: not yet played, so it has no stats, but its schedule and
+# depth charts are already published. Bump this once a year.
+_UPCOMING_SEASON = 2026
+
 
 def fetch_depth_charts(seasons: list[int]) -> Path:
     """Fetch legacy per-week depth charts (pre-2025 format) and save raw to parquet."""
@@ -224,20 +228,30 @@ def load_ids(raw_path: Path) -> None:
 
 
 if __name__ == "__main__":
-    # 2015-2025: enough draft classes for recency-weighted backtesting while staying in the modern
-    # pass-heavy/PPR era. 2025 was previously excluded on the belief that nflverse hadn't published
-    # its player stats yet; in fact nflverse had moved them to the `stats_player` release and
-    # nfl_data_py was still asking for the retired one (see _STATS_PLAYER_URL). 2026 is excluded
-    # since it hasn't been played yet — it's the season the models project, not train on.
-    seasons = list(range(2015, 2026))
+    # 2015 onward: enough draft classes for recency-weighted backtesting while staying in the
+    # modern pass-heavy/PPR era. 2025 was previously excluded on the belief that nflverse hadn't
+    # published its player stats yet; in fact nflverse had moved them to the `stats_player` release
+    # and nfl_data_py was still asking for the retired one (see _STATS_PLAYER_URL).
+    #
+    # Bump _UPCOMING_SEASON once a year, after the last one has been played out.
+    played_seasons = list(range(2015, _UPCOMING_SEASON))
 
-    load_weekly_stats(fetch_weekly_stats(seasons))
-    load_schedules(fetch_schedules(seasons))
-    load_rosters(fetch_rosters(seasons))
-    load_snap_counts(fetch_snap_counts(seasons))
-    load_injuries(fetch_injuries(seasons))
-    load_depth_charts(fetch_depth_charts(seasons))
-    load_depth_chart_snapshots(fetch_depth_chart_snapshots(seasons))
+    # Two of these feeds describe a season *before* it's played rather than after, and the upcoming
+    # season is exactly the one the models project — so they're fetched a year further forward than
+    # everything else. The schedule is published in May; depth-chart snapshots run from the March
+    # after the previous season right through the summer, which is what lets inhouse_projections
+    # know who is actually starting for the season it's projecting rather than inferring role from
+    # last year's box scores. Every other feed here is a record of games already played, and asking
+    # for a season that hasn't happened returns nothing.
+    forward_looking_seasons = played_seasons + [_UPCOMING_SEASON]
+
+    load_weekly_stats(fetch_weekly_stats(played_seasons))
+    load_schedules(fetch_schedules(forward_looking_seasons))
+    load_rosters(fetch_rosters(played_seasons))
+    load_snap_counts(fetch_snap_counts(played_seasons))
+    load_injuries(fetch_injuries(played_seasons))
+    load_depth_charts(fetch_depth_charts(played_seasons))
+    load_depth_chart_snapshots(fetch_depth_chart_snapshots(forward_looking_seasons))
     load_ids(fetch_ids())
     load_players(fetch_players())
     load_ngs_data(fetch_ngs_data(seasons))


### PR DESCRIPTION
Started from one question — why does the in-house model have Jaxson Dart at 223 when ESPN says 301 — and worked through five phases. **Dart now projects 308 against ESPN's 301.**

## The instrument, first

The old evaluation was one split: train on 2019, hold out 2020, n=331. That can't tell a real improvement from fold noise, so it couldn't be used to accept or reject anything.

Replaced with a **walk-forward backtest** — one fold per labelled season, each trained only on the seasons before it — scored per position against three benchmarks: the naive carry-forward, preseason ADP, and (for availability) the weighted average it replaces. Results land in a new `inhouse_backtest` table. ADP joins as a benchmark column **only, never a feature**, since `breakout_candidates.py` depends on this model staying ADP-blind.

Every number below comes from that backtest.

## Model-vs-ADP Spearman, pooled 2020-2025

| | before | after | ADP |
|---|---|---|---|
| QB | 0.468 | **0.526** | 0.646 |
| RB | 0.616 | **0.679** | 0.745 |
| WR | 0.689 | **0.718** | 0.744 |
| TE | 0.503 | **0.607** | 0.659 |
| unproven players | *no model* | **0.618** | 0.494 |

The unproven arm is the one place in the warehouse that beats the draft market.

## What changed

**1. Units.** The four external sites never discount a starter for injury risk — CBS projects 17.0 games for every starter it covers — but they *do* discount backups, through the per-game term (CBS has Jake Browning at 0.9 fppg across a full 17). The in-house arm was the only availability-discounted number in a pool of four health-neutral ones. `projected_points_full` now reproduces the sites' split (role discount kept, injury discount dropped) and is what `consensus.py` blends; `projected_points` remains the honest expectation for ranking a real roster.

**2. Components.** `weighted_ppg_ppr` carried 0.927 of permutation importance — a single scalar with no way to tell 17 PPG on nine targets from 17 PPG on four targets and triple the league's touchdown rate. `player_weighted_baselines` gained a recency-weighted volume/role/efficiency block plus `weighted_td_regressed_ppg` (points with the player's own touchdowns swapped for what his yardage would have produced at league-average rate). That last column **displaced `weighted_ppg_ppr` as the top feature**, 0.402 to 0.125.

**3. Target-season role.** Every feature described the season *before* the one being projected, so a career backup with a starter-like per-game history was projected like a starter. Added `target_is_starter`/`changed_team` from the projected season's own week-1 depth chart — published before a snap is played, so not leakage — which also repoints the OL/skill grades at the team a player is *joining*. Landed third by importance.

**4. Unproven players.** Players with no `player_weighted_baselines` row had no projection at all — 150 that ESPN covered and this warehouse didn't. A second, deliberately small model covers them: draft capital, landing spot, week-1 job, and an unweighted career rate that's NULL for a true rookie and so doubles as the group indicator. **Coverage gap 108 → 12 skill players.**

**5. Availability.** Its label counted box-score appearances, so a player who was in the league and never took a snap read as unobserved rather than as a zero (~90-110 a season). Anchored on roster membership instead: **MAE 3.96 vs 5.01 naive**, a gap four times what it was.

## Corrections made along the way

Phase 1 concluded "the sites project 17 games for everyone." That was over-generalised from the aggregate — they discount backups via per-game points — and it made `projected_points_full` throw away the role signal, so Browning briefly got *worse* (143 → 185). Phase 3 caught it; the claim is corrected in both module docstrings and the README, and Browning now lands at 45.

## Also

- `scripts/build_warehouse.sh` was missing `fantasyfootballcalculator` and six gold modules, and was already broken for a from-scratch rebuild before this branch. Now runs all thirteen in three dependency tiers.
- `schedules`, `depth_chart_snapshots` and `rosters` describe a season before it's played, so they're fetched a year further forward than the stats feeds. Draft capital reads from `rosters.draft_number`, not `players.draft_pick` — the latter lags by months and had no 2026 class at all during the 2026 preseason.

## Known limits, documented in the code

- Ty Simpson (#13-pick QB behind Stafford) projects 129 vs ESPN's 10. The model can't see *who is ahead of a player* beyond the binary starter flag.
- Unproven players still run above the external median (QB +17, RB +15, TE +14, WR +10).
- The scoring walk-forward is structurally blind to availability work — its 6-game floor excludes exactly the affected players — so availability is scored on its own population.

## Verification

Full gold chain rebuilds clean; `inhouse_projections` is bit-identical across back-to-back runs (the reproducibility guarantee from `7052ae8` survives).

🤖 Generated with [Claude Code](https://claude.com/claude-code)