### PR TITLE
feat: measure booms absolutely, price players against ADP, and project a ceiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,22 @@ network access of their own.
   keeps the role discount the sites apply but drops the injury discount they don't, by measuring a
   player's expected games against a starter's at the same position and season. Season length is
   read from `schedules` rather than hardcoded to 17, since the warehouse still holds 16-game
-  seasons. Both totals depend on `expected_games`, whose label is anchored on the **roster** rather
+  seasons.
+
+  A floor and a ceiling come out alongside the expectation, from the same features and estimator
+  refit under the pinball loss: `ppg_p10`/`ppg_p90`, the season totals `projected_points_floor`/
+  `projected_points_ceiling`, and `upside` as the gap between ceiling and expectation. A conditional
+  mean cannot tell a season-long RB2 from a backup one injury away from a starter's workload, which
+  is exactly what "who might boom" is asking. Both are reported as measured: the ceiling is well
+  calibrated out-of-sample (89.9% of actual veteran seasons land under `ppg_p90` against a 90%
+  target, no crossed intervals) while the floor sits too high (15.4% under `ppg_p10` against 10%),
+  because the scoring label's games floor excludes short seasons so nothing teaches the model how
+  far down a bad one goes. `upside` earns its place modestly — holding the mean projection fixed
+  within quintiles, the high-upside half beats its own projection by 3+ PPG 15.5% of the time
+  against 11.9% (z=2.51, p=0.012, n=2416), positive in all five quintiles, dying by a 5-PPG
+  threshold. It tilts the odds; it is not a boom detector.
+
+  Both totals depend on `expected_games`, whose label is anchored on the **roster** rather
   than the box score: a player who was in the league all season and never took a snap has no
   `weekly_stats` row at all, so counting only those rows made him read as unobserved instead of as
   the zero he is (~90-110 players a season). Without those zeros the model can't answer below about
@@ -214,14 +229,47 @@ network access of their own.
   season automatically gets a deeper replacement level, with no hardcoded split. Pure SQL/Python
   over already-loaded tables — no fetch step, no network.
 - `src/gold/boom_bust.py` — builds `boom_bust`: classifies each skill-position player-season into
-  a preseason-ADP-relative outcome bucket (Boomed/Returned on ADP/Fine/Busted/Got Injured/No
-  Preseason ADP), by converting both `points_over_replacement` and `adp_consensus`'s
-  `consensus_adp` into percentiles within the same season-position pool of ADP-tracked players, so
-  the comparison is scoring-format- and league-size-independent rather than a fixed PPG number or
-  ADP-spot count. Boom/Bust/Fine/Returned split at symmetric +/-20-percentile-point bands around
-  "met expectation"; fewer than 12 games played overrides those bands as Got Injured, but only for
-  players who had preseason draft capital to begin with. Pure SQL over already-loaded tables — no
-  fetch step, no network.
+  an outcome bucket (League Winner/Delivered/Beat His Price/Met His Price/Fine/Busted/Got Injured/
+  Never Had The Job/No Preseason ADP), measured on an **absolute** scale rather than a relative
+  one. `finish_tier` buckets a positional finish into groups of `team_count` — the RB1/RB2/WR3
+  language, derived rather than hardcoded to 12 — `expected_tier` applies the same width to the
+  player's rank by preseason ADP, and `is_elite_finish` asks the uncensored question "was he a
+  top-`team_count` asset". `tier_delta` and the continuous `percentile_delta` keep the relative
+  "did he beat his price" read alongside, but no longer define the bucket.
+
+  That split is a deliberate correction. Defining a boom as a +20-percentile-point *move* made it
+  structurally unreachable from the top of the board — a first-round pick already sits near the
+  99th percentile — so the table reported a 0% boom rate for rounds 1-4 and ~25% for round 15
+  regardless of what those players did. On the absolute measure the rate falls 62.8% -> 6.4% from
+  round 1 to round 15, which is the real shape. The old single "Got Injured" bucket is likewise
+  split from "Never Had The Job", since conflating the fallen star with the career backup made
+  injuries look like they climbed 18% -> 30% with ADP round when late picks are simply backups who
+  were never going to play; splitting on whether a player started in the majority of the weeks he
+  actually appeared separates them cleanly (mean ADP 147 vs 276). Pure SQL over already-loaded
+  tables — no fetch step, no network.
+- `src/gold/draft_value.py` — builds `draft_value`: what each player returned (or is projected to
+  return) *over what he cost*, which is the question a draft actually turns on and which neither
+  `points_over_replacement` nor `adp_consensus` answers alone. `expected_value` is an isotonic
+  regression of realised value on `consensus_adp`, fit per league and position — isotonic because
+  the one thing known a priori is the shape (later picks return less, monotonically) — and fit
+  walk-forward, so no season is scored against a benchmark that had already seen it. Subtracting
+  gives `surplus_value` (backward-looking, the study column) and `projected_surplus` (forward-
+  looking, the draft board, from `inhouse_projections`).
+
+  Value is `points_over_replacement` **floored at zero**, because nobody is forced to start a
+  player worse than the waiver wire. That isn't cosmetic: on signed PoR the expected curve for a QB
+  at pick 235 sits near -139, so eight quarterbacks projected *below* replacement ranked in the top
+  25 of the 2026 board. They weren't beating their price, they were being less bad than a floor set
+  by how deep their position's replacement level is. Sorting past seasons into deciles by the
+  preseason call, the bottom decile realised -2.3 surplus and the top +16.6, with the share beating
+  their price rising 36% -> 54%; ADP is ~orthogonal to surplus by construction, so that is signal
+  genuinely additional to what the market prices. One measured caveat is recorded in the module:
+  the drafted pool's mean value swings ~6 points a season for reasons no preseason curve can see
+  and no training window removes, so surplus is a **within-season ranking** rather than a
+  calibrated point total — hence `surplus_rank`/`projected_surplus_rank` and `surplus_centered`.
+  `inhouse_projections`' full-PPR points are put on each league's scale by a through-origin
+  per-position coefficient (R2 0.996-1.000), and the projected replacement level reuses
+  `points_over_replacement`'s own `_replacement_levels` so the two definitions can't drift apart.
 - `src/gold/breakout_candidates.py` — builds `breakout_candidates`: ranks `inhouse_projections`'
   already-ADP-blind prediction into a position-relative percentile per target season and lines it
   up against `adp_consensus`'s preseason percentile, so a player the model likes that the real-world

--- a/src/gold/boom_bust.py
+++ b/src/gold/boom_bust.py
@@ -141,7 +141,8 @@ untracked AS (
     FROM points_over_replacement por
     WHERE NOT EXISTS (
         SELECT 1 FROM preseason pre
-        WHERE pre.gsis_id = por.player_id AND pre.season = por.season AND pre.position = por.position
+        WHERE pre.gsis_id = por.player_id AND pre.season = por.season
+            AND pre.position = por.position
     )
 ),
 combined AS (SELECT * FROM tracked UNION ALL SELECT * FROM untracked),

--- a/src/gold/boom_bust.py
+++ b/src/gold/boom_bust.py
@@ -1,42 +1,72 @@
 """Classify each player-season into a preseason-ADP-relative outcome bucket.
 
 Pure warehouse-to-warehouse SQL — no fetch step, no network. Built from `points_over_replacement`
-(already built by points_over_replacement.py) and `adp_consensus` (already built by
-adp_consensus.py).
+(already built by points_over_replacement.py), `adp_consensus` (already built by adp_consensus.py),
+`league_settings` (for each league's team count) and `player_depth_chart` (to tell a player who got
+hurt from one who never had the job).
 
-Step 3 of the "league-winning RB" idea: turns each player's replacement-level outcome and their
-preseason draft capital into percentiles within their season's position pool, so both are
-comparable across leagues (different team counts) and scoring formats without a hardcoded PPG or
-ADP-spot-count constant. `points_over_replacement` is ranked within (league_key, season, position)
-since replacement level is league-specific; `adp_consensus`'s `consensus_adp` is ranked within
-(season, position) only, since ADP reflects the real-world draft market rather than either
-league's scoring rules.
+Step 3 of the "league-winning RB" idea: line each player's actual season up against what his
+preseason draft capital implied, in units that survive a change of league size or scoring format.
 
-Both percentiles are computed over the *same* reference population: players with a preseason
-`consensus_adp` that season/position. `points_over_replacement` on its own is much deeper than the
-ADP-tracked pool (e.g. 135 RBs recorded a stat somewhere in the 2024 season vs. 93 that any ADP
-source tracked as draftable) — ranking the actual-outcome side against that full, scrub-padded
-pool while ranking the preseason side against the narrower ADP pool would systematically inflate
-everyone's percentile_delta upward (more players below you in a bigger pool isn't the same as
-actually outperforming your draft slot). Players with no preseason ADP are bucketed separately
-below rather than assigned a percentile at all.
+## Two questions, two measures — the absolute one is the point
 
-Outcome buckets mirror the five archetypes from the source idea, made format-agnostic by using
-percentile movement instead of a fixed PPG number or ADP-spot count:
-- No Preseason ADP: no `consensus_adp` that season, so there's no preseason expectation to compare
-  against (mostly waiver-wire adds no source tracked as draftable) — checked first, ahead of the
-  games-played bar below, since "Got Injured" is only a meaningful label for someone who was
-  actually expected to contribute; most sub-12-game players in this table are just replacement-
-  level scrubs who were never fantasy-relevant, not fallen stars.
-- Got Injured: had preseason ADP but played fewer than 12 games (this project's own bar for a
-  "full" season, reused from the source idea rather than inventing a new number) — overrides the
-  percentile-movement buckets below, since a shortened season explains the outcome rather than
-  reflecting a skill/value read.
-- Boomed / Returned on ADP / Fine / Busted: a symmetric +/-20-percentile-point band around "met
-  expectation" (delta 0), translating the source idea's "beat/lost by 10 ADP spots" into a
-  scoring-format- and league-size-independent unit. "Fine" (mild underperformance) and "Returned on
-  ADP" (met or modestly beat expectation) split at delta 0, mirroring the source idea's own
-  asymmetric shape ("lost 1-9 spots" vs. meeting-or-beating ADP).
+There are two different things people mean by "did he boom", and conflating them is how this table
+used to mislead:
+
+- *Was he great?* — an absolute question. `finish_tier` / `is_elite_finish` answer it. A top-12
+  finish at your position is a top-12 finish whether you cost the 3rd pick or went undrafted.
+- *Did he beat his price?* — a relative question. `tier_delta` (and the continuous
+  `percentile_delta`) answer it.
+
+The bucket below is built on the absolute measure first, then qualified by the relative one. This
+is a deliberate correction. An earlier version defined "Boomed" purely as a +20-percentile-point
+*move* from preseason percentile, which is structurally unreachable from the top of the board: a
+first-round pick already sits near the 99th percentile and has no room to gain 20 points, so the
+metric reported a 0% boom rate for rounds 1-4 and ~25% for round 15 no matter what the players
+actually did. That is a fact about the bounded scale, not about football. `is_elite_finish` is
+reachable from every draft slot, so rates computed on it are comparable across the board.
+
+## Tiers rather than percentiles
+
+`finish_tier` buckets a player's positional finish into groups of `team_count` — the "RB1 / RB2 /
+WR3" language commentators use, derived rather than hardcoded to 12, so a 10-team league gets
+10-wide tiers. `expected_tier` applies the same width to his rank *by preseason ADP* within the
+season's position pool, so "he was drafted as a mid-range RB2 and finished as an RB1" becomes
+`tier_delta = +1`. Both sides are ranks within the same reference population (players with a
+`consensus_adp` that season/position), for the same reason the percentile pair below is: the actual
+outcome pool is far deeper than the ADP-tracked pool (135 RBs recorded a stat in 2024 vs. 93 any
+ADP source tracked as draftable), and ranking one side against a scrub-padded pool would inflate
+everyone's delta upward.
+
+`preseason_percentile` / `actual_percentile` / `percentile_delta` are kept alongside as the
+continuous version of the same comparison — finer-grained than whole tiers, and still the right
+column to sort on. They are simply no longer what the bucket is computed from.
+
+## Outcome buckets
+
+- No Preseason ADP: no `consensus_adp` that season, so there is no preseason expectation to compare
+  against (mostly waiver adds no source tracked as draftable) — checked first, ahead of the
+  games-played bar, since a shortened season is only a meaningful label for someone who was
+  expected to contribute in the first place.
+- Got Injured / Never Had The Job: had preseason ADP but played fewer than `_MIN_GAMES_FOR_OUTCOME`
+  games. These two used to be one bucket, which conflated the fallen star with the career backup:
+  the old single label rose from 18% of round-1 picks to 30% of round-15 picks, which read as late
+  picks getting hurt more when it was really that late picks are mostly backups who were never
+  going to play. They are split on whether the player was listed as a starter in the majority of
+  the weeks he actually appeared in — "when he was on the field, was it his job?" — which separates
+  them cleanly: the injured half averages ADP 147, the never-had-the-job half averages ADP 276.
+  A player whose played weeks never overlap a depth chart at all (~7%, averaging 3.9 games and ADP
+  280) has no evidence of a role by any column available here and is grouped with the latter.
+- League Winner: finished inside the top `team_count` at his position *from outside* that
+  expectation. The archetype the whole idea is about — the pick that returns a starter's season
+  from a bench price.
+- Delivered: finished inside the top `team_count` and was drafted to. Not a lesser outcome, just
+  not a market-beating one; an early pick that delivers is exactly what it was bought for.
+- Beat / Met His Price: finished better than, or level with, the tier his ADP implied, without
+  reaching the elite tier.
+- Busted: finished `_BUST_TIERS` or more tiers below the one his ADP implied, having played a full
+  season — i.e. the failure is a performance read, not an availability one.
+- Fine: everything left over — mild underperformance inside the bust threshold.
 """
 
 from pathlib import Path
@@ -45,30 +75,53 @@ import duckdb
 
 WAREHOUSE_PATH = Path("data/warehouse.duckdb")
 
-# Percentile-points of preseason-vs-actual movement that counts as a genuine boom/bust rather than
-# year-to-year noise.
-_BOOM_BUST_THRESHOLD = 0.20
-
-# Reused from the source idea's own qualifier for a "full" season: fewer games than this is
-# "Got Injured" regardless of percentile movement.
+# Reused from the source idea's own qualifier for a "full" season: fewer games than this means the
+# season is an availability story, and gets an availability label rather than a value read.
 _MIN_GAMES_FOR_OUTCOME = 12
+
+# Share of his *played* weeks a player must have been listed as a starter for a short season to
+# read as "got hurt" rather than "was a backup". A majority, so the question is literally "when he
+# was on the field, was it his job?".
+_STARTER_SHARE_FOR_INJURY = 0.5
+
+# How many whole tiers below his ADP-implied tier counts as a bust rather than noise. One tier is
+# only `team_count` positional spots — well inside the year-to-year churn of any position — so a
+# single-tier slip is "Fine", not a failure.
+_BUST_TIERS = 2
 
 _BUILD_SQL = f"""
 CREATE OR REPLACE TABLE boom_bust AS
 WITH preseason AS (
     SELECT
         gsis_id, season, position, consensus_adp,
+        -- Rank drives the tier; percentile is kept as the continuous version of the same idea.
+        RANK() OVER (PARTITION BY season, position ORDER BY consensus_adp ASC) AS adp_rank,
         PERCENT_RANK() OVER (
             PARTITION BY season, position ORDER BY consensus_adp DESC
         ) AS preseason_percentile
     FROM adp_consensus
     WHERE consensus_adp IS NOT NULL
 ),
+-- "When he was on the field, was it his job?" — the depth chart restricted to the weeks he
+-- actually recorded a game, so a starter who is hurt from week 4 on isn't diluted by the weeks he
+-- spent listed behind his own replacement.
+played_role AS (
+    SELECT
+        d.season,
+        d.gsis_id,
+        AVG(CASE WHEN d.is_starter THEN 1.0 ELSE 0.0 END) AS started_when_available
+    FROM player_depth_chart d
+    JOIN weekly_stats w
+        ON w.player_id = d.gsis_id AND w.season = d.season AND w.week = d.week
+        AND w.season_type = 'REG' AND w.fantasy_points_ppr IS NOT NULL
+    GROUP BY d.season, d.gsis_id
+),
 tracked AS (
     SELECT
         por.league_key, por.season, por.player_id, por.player_name, por.position,
         por.games_played, por.points_over_replacement,
-        pre.consensus_adp, pre.preseason_percentile,
+        por.position_rank, por.starters_at_position,
+        pre.consensus_adp, pre.adp_rank, pre.preseason_percentile,
         PERCENT_RANK() OVER (
             PARTITION BY por.league_key, por.season, por.position
             ORDER BY por.points_over_replacement ASC
@@ -81,26 +134,54 @@ untracked AS (
     SELECT
         por.league_key, por.season, por.player_id, por.player_name, por.position,
         por.games_played, por.points_over_replacement,
-        CAST(NULL AS DOUBLE) AS consensus_adp, CAST(NULL AS DOUBLE) AS preseason_percentile,
+        por.position_rank, por.starters_at_position,
+        CAST(NULL AS DOUBLE) AS consensus_adp, CAST(NULL AS BIGINT) AS adp_rank,
+        CAST(NULL AS DOUBLE) AS preseason_percentile,
         CAST(NULL AS DOUBLE) AS actual_percentile
     FROM points_over_replacement por
     WHERE NOT EXISTS (
         SELECT 1 FROM preseason pre
         WHERE pre.gsis_id = por.player_id AND pre.season = por.season AND pre.position = por.position
     )
+),
+combined AS (SELECT * FROM tracked UNION ALL SELECT * FROM untracked),
+tiered AS (
+    SELECT
+        c.*,
+        ls.team_count,
+        r.started_when_available,
+        -- Tier width is the league's team count, not a hardcoded 12: "RB1" means "a top-12 RB"
+        -- only because leagues are usually 12-team, and this warehouse holds a 10-team one too.
+        CAST(CEIL(c.position_rank * 1.0 / ls.team_count) AS BIGINT) AS finish_tier,
+        CAST(CEIL(c.adp_rank * 1.0 / ls.team_count) AS BIGINT) AS expected_tier,
+        c.position_rank <= ls.team_count AS is_elite_finish,
+        c.position_rank <= c.starters_at_position AS is_startable_finish
+    FROM combined c
+    JOIN league_settings ls ON ls.league_key = c.league_key
+    LEFT JOIN played_role r ON r.gsis_id = c.player_id AND r.season = c.season
 )
 SELECT
-    *,
+    league_key, season, player_id, player_name, position, games_played,
+    points_over_replacement, position_rank, starters_at_position, team_count,
+    consensus_adp, preseason_percentile, actual_percentile,
     actual_percentile - preseason_percentile AS percentile_delta,
+    finish_tier, expected_tier,
+    expected_tier - finish_tier AS tier_delta,
+    is_elite_finish, is_startable_finish,
     CASE
         WHEN preseason_percentile IS NULL THEN 'No Preseason ADP'
-        WHEN games_played < {_MIN_GAMES_FOR_OUTCOME} THEN 'Got Injured'
-        WHEN actual_percentile - preseason_percentile >= {_BOOM_BUST_THRESHOLD} THEN 'Boomed'
-        WHEN actual_percentile - preseason_percentile <= -{_BOOM_BUST_THRESHOLD} THEN 'Busted'
-        WHEN actual_percentile - preseason_percentile < 0 THEN 'Fine'
-        ELSE 'Returned on ADP'
+        WHEN games_played < {_MIN_GAMES_FOR_OUTCOME}
+            AND COALESCE(started_when_available, 0) >= {_STARTER_SHARE_FOR_INJURY}
+            THEN 'Got Injured'
+        WHEN games_played < {_MIN_GAMES_FOR_OUTCOME} THEN 'Never Had The Job'
+        WHEN is_elite_finish AND expected_tier - finish_tier >= 1 THEN 'League Winner'
+        WHEN is_elite_finish THEN 'Delivered'
+        WHEN expected_tier - finish_tier >= 1 THEN 'Beat His Price'
+        WHEN expected_tier - finish_tier <= -{_BUST_TIERS} THEN 'Busted'
+        WHEN expected_tier = finish_tier THEN 'Met His Price'
+        ELSE 'Fine'
     END AS outcome_bucket
-FROM (SELECT * FROM tracked UNION ALL SELECT * FROM untracked)
+FROM tiered
 """
 
 

--- a/src/gold/draft_value.py
+++ b/src/gold/draft_value.py
@@ -1,0 +1,418 @@
+"""Price each player against what his draft slot historically returned: surplus over ADP.
+
+Pure warehouse-to-warehouse Python/SQL — no fetch step, no network. Built from
+`points_over_replacement`, `adp_consensus`, `inhouse_projections` and `league_settings`, all
+already loaded.
+
+`points_over_replacement` answers "how much was he worth". `adp_consensus` answers "what did he
+cost". Neither on its own answers the question a draft board actually turns on, which is whether
+he was worth *more than he cost* — the 3rd overall pick returning a top-3 season is a fair trade,
+not a win, while the same season out of the 9th round is what decides leagues. This table is that
+subtraction.
+
+## Value is points over replacement, floored at zero
+
+`points_over_replacement` runs negative — arbitrarily so, for a QB25 measured against a QB12
+replacement level. Draft value cannot: nobody is forced to start a player worse than the free agent
+pool, so the worst a pick can do is return nothing. `actual_value` / `projected_value` are
+therefore `points_over_replacement` floored at 0, and every curve and surplus below is built on
+them. The raw signed `actual_por` / `projected_por` are kept alongside for the roster questions
+where the size of a shortfall does matter.
+
+Flooring is not cosmetic here, it is what makes the table usable across positions. Fit on signed
+PoR, the expected curve for a QB drafted around pick 235 sits near -139, so any projection short of
+catastrophe scores a huge "surplus" — an early version of this board ranked Tua Tagovailoa (ADP
+235, projected PoR -46) as the single best value in 2026, along with seven other quarterbacks in
+the top 25, all of them projected below replacement. They were not beating their price; they were
+being less bad than a floor set by how deep their position's replacement level is. Positions with
+low floors generated fake surplus purely from having further to fall.
+
+## The ADP curve
+
+`expected_value` is what a pick at a given ADP has historically returned at that position: an
+isotonic regression of realised `actual_value` on `consensus_adp`, fit per
+(league_key, position). Isotonic rather than a polynomial or a linear fit because the one thing
+known a priori about this curve is its shape — later picks return less, monotonically — and
+isotonic regression is exactly the estimator that assumes that and nothing else. No knots to place,
+no degree to choose, no negative-slope-turning-positive at the tail.
+
+Fit per position, which preserves both comparisons worth making: within a position ("of the RBs
+going around pick 30, which ones beat the slot") the curve is the benchmark, and across positions
+("should this pick be an RB or a TE at all") the difference in the curves' *level* is itself the
+answer — a TE at pick 30 sits on a much lower curve than an RB at pick 30.
+
+Fit walk-forward, like `inhouse_projections`' backtest: the curve for season S is fit only on
+seasons before S, so no row's `surplus_value` is measured against a benchmark that had already seen
+it. `_MIN_CURVE_SEASONS` / `_MIN_CURVE_ROWS` leave the earliest seasons with a NULL curve rather
+than one fit on a handful of rows.
+
+## Two surpluses
+
+- `surplus_value` = `actual_value` - `expected_value`. Backward-looking, the study column: who
+  actually beat their price. NULL for a season that hasn't been played.
+- `projected_surplus` = `projected_value` - `expected_value`. Forward-looking, the draft-board
+  column: who this warehouse thinks *will* beat their price. Available for the live season, and —
+  because `inhouse_projections` stores its walk-forward folds alongside the live projection — for
+  past seasons too, so the question "did projected surplus predict actual surplus" can be asked of
+  the same table rather than taken on faith.
+
+## Surplus is a within-season ranking, not a calibrated point total
+
+A whole season's drafted pool does not average zero surplus, and no choice of training window makes
+it. The drafted pool's own mean PoR swings by season for reasons no preseason curve can anticipate
+— the league's scoring environment and its injury luck — running about -6 across 2015-2017 and
+about +6 across 2024-2025, with 2020 a -10 outlier. Fitting the curve on a rolling recent window
+instead of an expanding one moves the pooled offset from +5.5 to +3.9 and leaves the mean
+*per-season* offset at ~6 points either way, so the residual is a property of the seasons rather
+than of the estimator. The expanding window is kept: it has the most training data, matches
+`inhouse_projections`' walk-forward convention, and buys the alternative nothing real.
+
+So the raw `surplus_value` carries a season-level offset and should not be read as "points he beat
+his price by", nor compared across seasons as-is. Three columns exist to make the honest uses
+direct:
+- `surplus_rank` / `projected_surplus_rank` — position within that league-season's own draft pool,
+  1 = best. Immune to the offset, and the actual draft-board artifact: at any given pick, who
+  returns the most over what he costs.
+- `surplus_centered` — `surplus_value` minus that league-season's mean, which removes exactly the
+  measured offset and is the column for comparing players *across* seasons.
+
+## Two unit systems, reconciled
+
+`points_over_replacement` is in each league's own scoring; `inhouse_projections` is in nflverse's
+canned full-PPR points. `projected_por` needs the two on one scale, so league points are regressed
+on PPR points per (league_key, position) — a single through-origin coefficient, since the two
+differ only by the rulebook. It fits essentially exactly (R2 0.996-1.000, mean absolute residual
+0.2-3.0 points on season totals of 100-350): 1.000 for full-PPR ESPN, 0.81-0.90 for the half-PPR
+Sleeper receiving positions, 1.04 for Sleeper QBs, which is what the scoring rules say it should
+be. Fit on all seasons rather than walk-forward, deliberately: this coefficient is a property of a
+fixed rulebook, not an outcome being predicted, so there is nothing here to leak.
+
+The projected replacement level is then computed by handing those converted projections to
+`points_over_replacement`'s own `_replacement_levels` — the same combined-flex-pool VBD rule the
+realised side uses, imported rather than restated so the two definitions cannot drift apart.
+
+`projected_points` is the input rather than `projected_points_full`, because the benchmark it is
+being compared against is realised production, which already carries every game its players
+actually missed. `projected_points_full` deliberately strips the injury discount back out to stay
+comparable to the external sites (see `inhouse_projections`), which is the wrong frame here.
+
+## A drafted player who never played is a real zero
+
+A player with a preseason ADP and no `points_over_replacement` row scored nothing that season, and
+dropping him would bias the curve upward exactly where it matters — the expected return on a pick
+has to include its bust rate. Those seasons are therefore carried at zero league points (so
+`actual_por` is a full replacement level below zero) rather than skipped.
+
+Excluded from that treatment is a player with no `weekly_stats` row in his *entire career*, who is
+not a bust but an unresolved name: `adp_consensus` sometimes maps one ADP entry onto a gsis_id that
+never appears in the box scores (2026 carries both a "Marvin Harrison" and a "Marvin Harrison Jr."
+at different ADPs, and only one of them is a football player). Roughly 1-2% of recent drafted
+seasons, higher in 2015-2016. Counting those as zeros would invent busts that never happened.
+"""
+
+from pathlib import Path
+
+import duckdb
+import pandas as pd
+from sklearn.isotonic import IsotonicRegression
+
+from src.gold.points_over_replacement import _SKILL_POSITIONS, _replacement_levels
+
+WAREHOUSE_PATH = Path("data/warehouse.duckdb")
+
+# The ADP curve needs enough history behind it to be a benchmark rather than an echo of one or two
+# seasons' noise. Both bars must clear before a season gets a curve at all.
+_MIN_CURVE_SEASONS = 3
+_MIN_CURVE_ROWS = 60
+
+# Realised season totals per league and position, with a drafted-but-never-played season carried as
+# a genuine zero. The career-appearances guard separates that real zero from an ADP row whose
+# gsis_id was never a football player — see the module docstring.
+_ACTUAL_SQL = f"""
+WITH career_appearances AS (
+    SELECT player_id, COUNT(*) AS games
+    FROM weekly_stats
+    WHERE season_type = 'REG' AND fantasy_points_ppr IS NOT NULL
+    GROUP BY player_id
+),
+adp AS (
+    SELECT a.gsis_id, a.season, a.position, a.player_name, a.consensus_adp
+    FROM adp_consensus a
+    JOIN career_appearances c ON c.player_id = a.gsis_id
+    WHERE a.consensus_adp IS NOT NULL AND a.position IN {_SKILL_POSITIONS}
+),
+leagues AS (SELECT league_key FROM league_settings)
+SELECT
+    l.league_key,
+    adp.season,
+    adp.gsis_id AS player_id,
+    COALESCE(por.player_name, adp.player_name) AS player_name,
+    adp.position,
+    adp.consensus_adp,
+    -- A drafted player with no points_over_replacement row played no games at all. Zero league
+    -- points is the honest total; the replacement level below then makes his PoR properly negative
+    -- rather than merely absent.
+    COALESCE(por.league_points, 0.0) AS league_points,
+    por.player_id IS NULL AS never_played
+FROM adp
+CROSS JOIN leagues l
+LEFT JOIN points_over_replacement por
+    ON por.player_id = adp.gsis_id AND por.season = adp.season AND por.league_key = l.league_key
+-- Only seasons that have actually been played: the live season's ADP rows have no realised side at
+-- all, and carrying them here as zeros would label every 2026 first-rounder a total bust.
+WHERE adp.season <= (SELECT MAX(season) FROM weekly_stats)
+ORDER BY l.league_key, adp.season, adp.gsis_id
+"""
+
+# Replacement levels are recomputed here rather than read off points_over_replacement because the
+# zero-point seasons added above change the pool that the flex allocation is drawn from.
+_REPLACEMENT_SQL = """
+SELECT league_key, season, position, starters_at_position, replacement_level_points
+FROM points_over_replacement
+GROUP BY ALL
+"""
+
+# The scale factor's training data: every player-season where both unit systems are observed.
+_SCALE_SQL = """
+SELECT p.league_key, p.position, p.league_points, w.ppr_points
+FROM points_over_replacement p
+JOIN (
+    SELECT player_id, season, SUM(fantasy_points_ppr) AS ppr_points
+    FROM weekly_stats
+    WHERE season_type = 'REG' AND fantasy_points_ppr IS NOT NULL
+    GROUP BY player_id, season
+) w ON w.player_id = p.player_id AND w.season = p.season
+WHERE w.ppr_points > 0
+"""
+
+_PROJECTION_SQL = f"""
+SELECT
+    i.target_season AS season,
+    i.player_id,
+    i.player_name,
+    i.position,
+    i.projected_points
+FROM inhouse_projections i
+WHERE i.projected_points IS NOT NULL AND i.position IN {_SKILL_POSITIONS}
+"""
+
+_OUTPUT_COLUMNS = [
+    "league_key", "season", "player_id", "player_name", "position", "consensus_adp",
+    "expected_value", "actual_value", "surplus_value", "surplus_centered", "surplus_rank",
+    "projected_value", "projected_surplus", "projected_surplus_rank",
+    "actual_por", "projected_por", "never_played", "curve_train_seasons",
+]
+
+
+def _ppr_to_league_scale(scale_df: pd.DataFrame) -> pd.Series:
+    """One through-origin coefficient per (league_key, position) mapping PPR points to league
+    points. Through the origin because zero production is zero points under any rulebook, and a
+    free intercept would only fit noise at the bottom of the pool."""
+    df = scale_df.assign(
+        cross=scale_df["league_points"] * scale_df["ppr_points"],
+        square=scale_df["ppr_points"] ** 2,
+    )
+    totals = df.groupby(["league_key", "position"])[["cross", "square"]].sum()
+    return totals["cross"] / totals["square"]
+
+
+def _projected_por(
+    projections: pd.DataFrame, leagues: pd.DataFrame, scale: pd.Series
+) -> pd.DataFrame:
+    """Convert each season's projections into league points and subtract that season's projected
+    replacement level, using the same VBD rule the realised side uses."""
+    frames = []
+    for _, league in leagues.iterrows():
+        df = projections.copy()
+        df["league_key"] = league["league_key"]
+        key = pd.MultiIndex.from_arrays(
+            [df["league_key"], df["position"]], names=["league_key", "position"]
+        )
+        df["league_points"] = df["projected_points"] * scale.reindex(key).to_numpy()
+        for _, season_df in df.groupby("season"):
+            levels = _replacement_levels(season_df, league)
+            merged = season_df.merge(levels, on="position")
+            merged["projected_por"] = (
+                merged["league_points"] - merged["replacement_level_points"]
+            )
+            frames.append(merged[["league_key", "season", "player_id", "projected_por"]])
+    return pd.concat(frames, ignore_index=True)
+
+
+def _fit_curve(train: pd.DataFrame) -> IsotonicRegression:
+    """Later picks return less: the one thing known about this curve before fitting it, and the
+    only assumption isotonic regression makes."""
+    return IsotonicRegression(increasing=False, out_of_bounds="clip").fit(
+        train["consensus_adp"], train["actual_value"]
+    )
+
+
+def _expected_value(actual: pd.DataFrame) -> pd.DataFrame:
+    """Walk-forward isotonic curve of value on ADP, per (league_key, position, season).
+
+    Returns one row per (league_key, season, position, consensus_adp) rather than per player, so
+    the curve is a lookup both the realised and the projected side can join against.
+    """
+    rows = []
+    for (league_key, position), group in actual.groupby(["league_key", "position"]):
+        for season in sorted(group["season"].unique()):
+            train = group[group["season"] < season]
+            train_seasons = train["season"].nunique()
+            if train_seasons < _MIN_CURVE_SEASONS or len(train) < _MIN_CURVE_ROWS:
+                continue
+            fold = group[group["season"] == season]
+            rows.append(pd.DataFrame({
+                "league_key": league_key,
+                "position": position,
+                "season": season,
+                "consensus_adp": fold["consensus_adp"].to_numpy(),
+                "expected_value": _fit_curve(train).predict(fold["consensus_adp"]),
+                "curve_train_seasons": train_seasons,
+            }))
+    return pd.concat(rows, ignore_index=True).drop_duplicates(
+        subset=["league_key", "position", "season", "consensus_adp"]
+    )
+
+
+def _live_expected_value(
+    actual: pd.DataFrame, live_adp: pd.DataFrame, live_season: int
+) -> pd.DataFrame:
+    """The same curve for the season being drafted, whose realised side doesn't exist yet — fit on
+    every played season, which is the walk-forward rule applied to the live fold."""
+    rows = []
+    for (league_key, position), train in actual.groupby(["league_key", "position"]):
+        fold = live_adp[live_adp["position"] == position]
+        train_seasons = train["season"].nunique()
+        if fold.empty or train_seasons < _MIN_CURVE_SEASONS or len(train) < _MIN_CURVE_ROWS:
+            continue
+        rows.append(pd.DataFrame({
+            "league_key": league_key,
+            "position": position,
+            "season": live_season,
+            "consensus_adp": fold["consensus_adp"].to_numpy(),
+            "expected_value": _fit_curve(train).predict(fold["consensus_adp"]),
+            "curve_train_seasons": train_seasons,
+        }))
+    return pd.concat(rows, ignore_index=True).drop_duplicates(
+        subset=["league_key", "position", "season", "consensus_adp"]
+    )
+
+
+def _add_within_season_columns(result: pd.DataFrame) -> pd.DataFrame:
+    """Rank and centre each surplus inside its own league-season.
+
+    Both exist because the raw surplus carries a season-level offset the curve cannot anticipate
+    (see the module docstring) — ranking is immune to it, and centring subtracts it outright.
+    Ranked across positions rather than within one, because that is the question a draft pick
+    actually poses: at this cost, who returns the most, whatever he plays.
+    """
+    by_season = result.groupby(["league_key", "season"])
+    result["surplus_rank"] = by_season["surplus_value"].rank(ascending=False, method="min")
+    result["projected_surplus_rank"] = by_season["projected_surplus"].rank(
+        ascending=False, method="min"
+    )
+    result["surplus_centered"] = result["surplus_value"] - by_season["surplus_value"].transform(
+        "mean"
+    )
+    return result
+
+
+def _report(result: pd.DataFrame) -> None:
+    sleeper = result[
+        (result["league_key"] == "sleeper") & (result["consensus_adp"] <= 180)
+    ].copy()
+    scored = sleeper[sleeper["surplus_value"].notna()].copy()
+
+    print("\nSurplus over ADP — realised, by draft round (Sleeper, all curve-covered seasons):")
+    scored["adp_round"] = (scored["consensus_adp"] / 12).apply(lambda x: int(x) + 1)
+    print(f"  {'round':>5} {'n':>5} {'exp val':>8} {'act val':>8} {'surplus':>8} {'hit%':>6}")
+    for adp_round, group in scored.groupby("adp_round"):
+        print(f"  {adp_round:>5} {len(group):>5} {group['expected_value'].mean():>8.1f} "
+              f"{group['actual_value'].mean():>8.1f} {group['surplus_value'].mean():>8.1f} "
+              f"{100 * (group['surplus_value'] > 0).mean():>6.1f}")
+
+    # The accept/reject test for the forward-looking half: sorted into deciles by what the model
+    # said before the season, did realised surplus actually come out in that order?
+    both = scored[scored["projected_surplus"].notna()].copy()
+    if len(both) < _MIN_CURVE_ROWS:
+        return
+    both["decile"] = pd.qcut(both["projected_surplus"], 10, labels=False, duplicates="drop")
+    print("\nDoes projected surplus predict realised surplus? Deciles of the preseason call:")
+    print(f"  {'decile':>6} {'n':>5} {'proj surplus':>13} {'realised':>9} {'beat price %':>13}")
+    for decile, group in both.groupby("decile"):
+        print(f"  {decile + 1:>6} {len(group):>5} {group['projected_surplus'].mean():>13.1f} "
+              f"{group['surplus_value'].mean():>9.1f} "
+              f"{100 * (group['surplus_value'] > 0).mean():>13.1f}")
+    # ADP is near-orthogonal to surplus by construction — the curve is a function of it — so this
+    # is a check that the curve absorbed what ADP knows, not a benchmark the model is beating.
+    print(f"\n  Spearman(projected surplus, realised surplus) = "
+          f"{both['projected_surplus'].corr(both['surplus_value'], method='spearman'):.3f}  "
+          f"(n={len(both)}; ADP vs realised surplus = "
+          f"{both['consensus_adp'].corr(both['surplus_value'], method='spearman'):.3f}, "
+          f"~0 by construction)")
+
+
+def build_draft_value() -> None:
+    con = duckdb.connect(str(WAREHOUSE_PATH))
+    actual = con.execute(_ACTUAL_SQL).df()
+    replacement = con.execute(_REPLACEMENT_SQL).df()
+    scale_df = con.execute(_SCALE_SQL).df()
+    projections = con.execute(_PROJECTION_SQL).df()
+    leagues = con.execute("SELECT * FROM league_settings").df()
+    live_season = con.execute("SELECT MAX(season) FROM adp_consensus").fetchone()[0]
+    live_adp = con.execute(f"""
+        SELECT a.gsis_id AS player_id, a.player_name, a.position, a.consensus_adp
+        FROM adp_consensus a
+        WHERE a.season = {live_season} AND a.consensus_adp IS NOT NULL
+            AND a.position IN {_SKILL_POSITIONS}
+    """).df()
+    con.close()
+
+    actual = actual.merge(
+        replacement, on=["league_key", "season", "position"], how="left"
+    )
+    actual["actual_por"] = actual["league_points"] - actual["replacement_level_points"]
+    # Floored, because a player below replacement is worth what the waiver wire is worth, not a
+    # negative amount — see the module docstring on why the unfloored version breaks the board.
+    actual["actual_value"] = actual["actual_por"].clip(lower=0)
+
+    scale = _ppr_to_league_scale(scale_df)
+    projected = _projected_por(projections, leagues, scale)
+    projected["projected_value"] = projected["projected_por"].clip(lower=0)
+
+    curve = _expected_value(actual)
+    live_curve = _live_expected_value(actual, live_adp, live_season)
+
+    played = actual.merge(
+        curve, on=["league_key", "position", "season", "consensus_adp"], how="left"
+    )
+
+    # The live season has ADP and a projection but no realised side — built separately and
+    # concatenated, so one table serves both the study and the draft board.
+    live = live_adp.copy()
+    live["season"] = live_season
+    live = live.merge(leagues[["league_key"]], how="cross").merge(
+        live_curve, on=["league_key", "position", "season", "consensus_adp"], how="left"
+    )
+    for column in ("actual_por", "actual_value", "league_points"):
+        live[column] = float("nan")
+    live["never_played"] = False
+
+    result = pd.concat([played, live], ignore_index=True)
+    result = result.merge(projected, on=["league_key", "season", "player_id"], how="left")
+    result["surplus_value"] = result["actual_value"] - result["expected_value"]
+    result["projected_surplus"] = result["projected_value"] - result["expected_value"]
+    result = _add_within_season_columns(result)[_OUTPUT_COLUMNS]
+
+    _report(result)
+
+    con = duckdb.connect(str(WAREHOUSE_PATH))
+    con.execute("CREATE OR REPLACE TABLE draft_value AS SELECT * FROM result")
+    (count,) = con.execute("SELECT COUNT(*) FROM draft_value").fetchone()
+    con.close()
+
+    print(f"\nBuilt {count} rows into {WAREHOUSE_PATH} (table: draft_value)")
+
+
+if __name__ == "__main__":
+    build_draft_value()

--- a/src/gold/inhouse_projections.py
+++ b/src/gold/inhouse_projections.py
@@ -84,6 +84,26 @@ points per game across a full 17. Their product is what `projected_points_full` 
 comparable to, so it keeps the role discount and drops the injury one. `_role_games` does that by
 measuring a player's expected games against a starter's at the same position and season.
 
+A floor and a ceiling come out alongside the expectation, from the same features and estimator refit
+under the pinball loss: `ppg_p10` / `ppg_p90`, and the season totals `projected_points_floor` /
+`projected_points_ceiling` on the same games basis as `projected_points`. `upside` is the gap
+between the ceiling and the expectation — the "might he boom" score, which is not recoverable from
+`projected_points`, since two players can share a projection and not share a distribution.
+
+Both are reported as measured rather than assumed:
+- Calibration is checked out-of-sample on every walk-forward fold (`_print_quantile_report`). The
+  ceiling is honest — 89.9% of actual veteran seasons land under `ppg_p90` against a 90% target,
+  with no crossed intervals. The floor is not: 15.4% land under `ppg_p10` against a 10% target, so
+  it sits too high and should be read as optimistic. That is the scoring label's games floor showing
+  through — a season cut short is excluded from training, so nothing ever teaches the model how far
+  down a bad one goes, and the same censoring that makes the label trustworthy for a per-game rate
+  makes the low tail specifically unreliable.
+- `upside` does carry information beyond the mean projection, and not much. Splitting each quintile
+  of `predicted_ppg_ppr` at its median upside, the high-upside half beats its own projection by more
+  than 3 PPG 15.5% of the time against 11.9% for the low-upside half (+3.5pp, z=2.51, p=0.012, over
+  2,416 walk-forward player-seasons), with the lift positive in all five quintiles. It holds to a
+  4-PPG threshold and dies by 5 (p=0.11), so it is a genuine tilt in the odds, not a boom detector.
+
 Both arms' availability labels are anchored on the roster rather than the box score, because a
 player who was in the league all season and never took a snap has no `weekly_stats` row at all and
 would otherwise read as unobserved rather than as the zero he is — roughly 90-110 players a season
@@ -142,6 +162,18 @@ _GAMES_FEATURE_COLUMNS = [
 # per-leaf sample floor, and a gentle learning rate all guard against overfitting what little data
 # there is.
 _MODEL_PARAMS = dict(max_depth=3, min_samples_leaf=15, learning_rate=0.1, random_state=0)
+
+# The same estimator refit under the pinball loss, which asks it for a conditional quantile rather
+# than a conditional mean. Two players can share a projected PPG and be completely different draft
+# propositions — the season-long RB2 who will finish within a point of his number either way, and
+# the backup one injury away from a starter's workload — and a point estimate cannot tell them
+# apart. p90 is the ceiling that "which players might boom" is actually asking about; p10 is the
+# floor, which is the same question asked of a roster you already own.
+#
+# Deliberately additional to `predicted_ppg_ppr` rather than replacing it: the median is not the
+# mean, and consensus.py blends this model against external sites that publish means.
+_QUANTILE_LOW = 0.10
+_QUANTILE_HIGH = 0.90
 
 # offensive_line_grades needs target_season - 1 >= 2018 (PFR advanced stats' own floor) before it
 # has any non-null values at all. A walk-forward fold whose entire training slice sits below that
@@ -554,6 +586,21 @@ def _fit_generic(
     return model
 
 
+def _add_quantiles(
+    frame: pd.DataFrame, train: pd.DataFrame, feature_columns: list[str]
+) -> pd.DataFrame:
+    """Attach a floor and a ceiling PPG to `frame`, from models fit on `train` under the pinball
+    loss. Same features and hyperparameters as the mean model — the only thing changing is which
+    part of the conditional distribution is being asked for."""
+    for column, quantile in (("ppg_p10", _QUANTILE_LOW), ("ppg_p90", _QUANTILE_HIGH)):
+        model = HistGradientBoostingRegressor(
+            loss="quantile", quantile=quantile, **_MODEL_PARAMS
+        )
+        model.fit(train[feature_columns], train["actual_ppg_ppr"])
+        frame[column] = model.predict(frame[feature_columns])
+    return frame
+
+
 def _metrics(fold: pd.DataFrame, target_season: int, position: str) -> dict:
     """Score one fold (or one position within it) against every benchmark worth beating.
 
@@ -668,6 +715,7 @@ def _walk_forward_no_baseline(
         if not fold.empty:
             fold["predicted_ppg_ppr"] = scoring_model.predict(fold[_NO_BASELINE_FEATURE_COLUMNS])
             fold["expected_games"] = games_model.predict(fold[_NO_BASELINE_GAMES_FEATURE_COLUMNS])
+            fold = _add_quantiles(fold, train, _NO_BASELINE_FEATURE_COLUMNS)
             # Position means come from the training slice only — a benchmark computed on the fold
             # would have seen the answers the model is being graded against.
             position_means = train.groupby("position")["actual_ppg_ppr"].mean()
@@ -734,6 +782,7 @@ def _walk_forward(
         fold = labeled[labeled["target_season"] == season].copy()
         fold["predicted_ppg_ppr"] = _fit(train).predict(fold[_FEATURE_COLUMNS])
         fold["expected_games"] = games_model.predict(fold[_GAMES_FEATURE_COLUMNS])
+        fold = _add_quantiles(fold, train, _FEATURE_COLUMNS)
         predictions.append(fold)
 
         games_fold = labeled_games[labeled_games["target_season"] == season].copy()
@@ -768,6 +817,7 @@ def _print_no_baseline_report(
     print(f"  Games played, pooled over the whole cohort including true zeros "
           f"(n={games['games_n']}): MAE={games['games_mae']:.2f} vs {games['games_naive_mae']:.2f} "
           f"for always guessing the cohort mean")
+    _print_quantile_report(pooled, "unproven arm")
 
 
 def _games_metrics_no_baseline(games_fold: pd.DataFrame) -> dict:
@@ -818,6 +868,26 @@ def _print_backtest_report(
     print(f"\n  Games played, pooled over every player who appeared (n={games['games_n']}): "
           f"MAE={games['games_mae']:.2f} vs {games['games_naive_mae']:.2f} for the weighted "
           f"average it replaces")
+    _print_quantile_report(pooled, "veteran arm")
+
+
+def _print_quantile_report(pooled: pd.DataFrame, label: str) -> None:
+    """Are the floor and ceiling the quantiles they claim to be?
+
+    An interval is only worth reading if it covers what it says it covers, and a quantile model can
+    be badly calibrated while still scoring well on rank metrics. Empirical coverage is the direct
+    test: the share of actual seasons landing under `ppg_p90` should be about 90%, and under
+    `ppg_p10` about 10%. Reported out-of-sample, pooled over every walk-forward fold.
+    """
+    if "ppg_p90" not in pooled.columns or pooled["ppg_p90"].isna().all():
+        return
+    below_high = (pooled["actual_ppg_ppr"] <= pooled["ppg_p90"]).mean()
+    below_low = (pooled["actual_ppg_ppr"] <= pooled["ppg_p10"]).mean()
+    inverted = (pooled["ppg_p90"] < pooled["ppg_p10"]).sum()
+    print(f"\n  Quantile calibration, {label} (n={len(pooled)}): "
+          f"{100 * below_low:.1f}% of actual seasons under ppg_p10 (target "
+          f"{100 * _QUANTILE_LOW:.0f}%), {100 * below_high:.1f}% under ppg_p90 (target "
+          f"{100 * _QUANTILE_HIGH:.0f}%); {inverted} crossed intervals")
 
 
 def build_inhouse_projections() -> None:
@@ -889,9 +959,12 @@ def build_inhouse_projections() -> None:
         final_model = _fit(labeled)
         live["predicted_ppg_ppr"] = final_model.predict(live[_FEATURE_COLUMNS])
         live["expected_games"] = _fit_games(labeled_games).predict(live[_GAMES_FEATURE_COLUMNS])
+        live = _add_quantiles(live, labeled, _FEATURE_COLUMNS)
     else:
         live["predicted_ppg_ppr"] = float("nan")
         live["expected_games"] = float("nan")
+        live["ppg_p10"] = float("nan")
+        live["ppg_p90"] = float("nan")
         print("No labeled seasons available yet — live cohort predictions left null.")
     output_frames.append(live)
 
@@ -918,6 +991,9 @@ def build_inhouse_projections() -> None:
         live_unproven["expected_games"] = _fit_generic(
             unproven_cohort, _NO_BASELINE_GAMES_FEATURE_COLUMNS, "actual_games"
         ).predict(live_unproven[_NO_BASELINE_GAMES_FEATURE_COLUMNS])
+        live_unproven = _add_quantiles(
+            live_unproven, unproven_labeled, _NO_BASELINE_FEATURE_COLUMNS
+        )
         output_frames.append(live_unproven)
         print(f"\nUnproven arm: {len(live_unproven)} players with no qualifying prior season "
               f"projected for {live_season}, trained on {len(unproven_labeled)} labelled seasons.")
@@ -927,10 +1003,18 @@ def build_inhouse_projections() -> None:
     result["role_games"] = _role_games(result)
     result["projected_points"] = result["predicted_ppg_ppr"] * result["expected_games"]
     result["projected_points_full"] = result["predicted_ppg_ppr"] * result["role_games"]
+    # Season totals on the same games basis as `projected_points`, so floor/expectation/ceiling are
+    # three readings of one number rather than three different questions.
+    result["projected_points_floor"] = result["ppg_p10"] * result["expected_games"]
+    result["projected_points_ceiling"] = result["ppg_p90"] * result["expected_games"]
+    # How much room there is above the expectation, which is the actual "might he boom" score — and
+    # not recoverable from projected_points, since two players can share it and not share this.
+    result["upside"] = result["projected_points_ceiling"] - result["projected_points"]
     result = result[[
         "player_id", "player_name", "position", "target_season",
-        "predicted_ppg_ppr", "expected_games", "season_games", "role_games",
+        "predicted_ppg_ppr", "ppg_p10", "ppg_p90", "expected_games", "season_games", "role_games",
         "projected_points", "projected_points_full",
+        "projected_points_floor", "projected_points_ceiling", "upside",
     ]]
 
     con = duckdb.connect(str(WAREHOUSE_PATH))


### PR DESCRIPTION
Three related changes to how this warehouse answers "who is worth drafting": fixing a metric that was structurally incapable of measuring what it claimed, adding the missing join between what a player is worth and what he costs, and giving the projection a distribution instead of a point.

## 1. Booms measured on a scale the top of the board can reach

`boom_bust` defined "Boomed" as a +20-percentile-point *move* from preseason percentile. A first-round pick already sits near the 99th percentile and has no room to gain 20 points, so the metric reported a **0% boom rate for rounds 1-4 and ~25% for round 15** no matter what those players actually did. That is a fact about a bounded scale, not about football.

Booms are now absolute. `finish_tier` buckets a positional finish into groups of `team_count` (the RB1/RB2/WR3 language, derived rather than hardcoded to 12, since this warehouse holds a 10-team league too), `expected_tier` applies the same width to the player's rank by preseason ADP, and `is_elite_finish` asks the uncensored question. `tier_delta` and the continuous `percentile_delta` keep the relative "did he beat his price" read alongside, but no longer define the bucket.

| | round 1 | round 8 | round 15 |
|---|---|---|---|
| old "boom" rate | 0.0% | 6.7% | 24.8% |
| **new elite-finish rate** | **62.8%** | **18.3%** | **6.4%** |

The old `Got Injured` bucket is also split from a new `Never Had The Job`. Conflating the fallen star with the career backup made injuries appear to climb 18% -> 30% with ADP round, when late picks are simply backups who were never going to play. Splitting on whether a player started in the majority of the weeks he actually appeared separates them cleanly — the injured half averages ADP 147, the never-had-the-job half 276 — and leaves the injury rate flat at 14-24% across every round.

## 2. `draft_value` — what a player returns over what he costs

`points_over_replacement` says how much a player was worth. `adp_consensus` says what he cost. Nothing joined them, which is the only question a draft actually turns on: the 3rd overall pick returning a top-3 season is a fair trade, while the same season out of the 9th round decides leagues.

`expected_value` is an isotonic regression of realised value on ADP, fit per league and position — isotonic because the one thing known a priori is the shape (later picks return less, monotonically), so there are no knots to place and no degree to choose — and fit walk-forward, so no season is scored against a benchmark that had already seen it. Subtracting gives `surplus_value` (study) and `projected_surplus` (the draft board, from `inhouse_projections`).

Validation, sorting past seasons into deciles by the preseason call:

| decile | projected surplus | realised | beat their price |
|---|---|---|---|
| 1 | -34.4 | -2.3 | 36% |
| 10 | +35.9 | +16.6 | 54% |

ADP is ~orthogonal to surplus by construction (the curve is a function of it), so this is signal genuinely additional to what the market already prices.

**Value is floored at replacement, and that isn't cosmetic.** On signed PoR the expected curve for a QB at pick 235 sits near -139, so any projection short of catastrophe scores a huge "surplus" — an early version of this board ranked Tua Tagovailoa (ADP 235, projected PoR -46) as the single best value in 2026, with eight quarterbacks in the top 25 all projected *below* replacement. They weren't beating their price; they were being less bad than a floor set by how deep their position's replacement level is. Nobody is forced to start a player worse than the waiver wire.

**One measured limit is recorded rather than hidden.** The drafted pool's mean value swings ~6 points a season for reasons no preseason curve can anticipate, and no training window removes it — a rolling window moves the pooled offset from +5.5 to +3.9 and leaves the mean per-season offset at ~6 either way. So surplus is a within-season *ranking*, not a calibrated point total, and `surplus_rank` / `projected_surplus_rank` / `surplus_centered` exist to make the honest uses direct.

## 3. A ceiling, not just an expectation

`predicted_ppg_ppr` is a conditional mean. Two players can share one and be completely different draft propositions — the season-long RB2 who lands within a point of his number either way, and the backup one injury from a starter's workload. That distinction is exactly what "who might boom" turns on, and a point estimate cannot represent it.

The same estimator and features refit under the pinball loss give `ppg_p10` / `ppg_p90`, the season totals `projected_points_floor` / `projected_points_ceiling` on the same games basis as `projected_points`, and `upside` as the gap between ceiling and expectation. Both arms get them, including the unproven one, where variance matters most.

Both are reported as measured rather than assumed:

- **The ceiling is calibrated**: 89.9% of actual veteran seasons land under `ppg_p90` against a 90% target, with no crossed intervals.
- **The floor is not**: 15.4% land under `ppg_p10` against a 10% target, so it reads optimistic. That is the scoring label's games floor showing through — a season cut short is excluded from training, so nothing teaches the model how far down a bad one goes. Documented rather than quietly shipped.
- **`upside` earns its place, modestly.** Holding the mean projection fixed within quintiles, the high-upside half beats its own projection by 3+ PPG 15.5% of the time against 11.9% (+3.5pp, z=2.51, p=0.012, n=2416), positive in all five quintiles. It holds to a 4-PPG threshold and dies by 5 (p=0.11). It tilts the odds; it is not a boom detector, and shouldn't be used as a primary sort.

## Notes

- `consensus.py` and `breakout_candidates.py` both rebuild clean against the changed schemas; no existing column was removed.
- `draft_value` reuses `points_over_replacement`'s own `_replacement_levels` for the projected replacement level, so the two VBD definitions can't drift apart. `inhouse_projections`' full-PPR points are put on each league's scale by a through-origin per-position coefficient (R2 0.996-1.000).
- Worked around, not fixed: `adp_consensus` has a name-resolution wrinkle where one ADP entry can map to a gsis_id that never appears in the box scores (2026 carries both a "Marvin Harrison" and a "Marvin Harrison Jr." at different ADPs, only one of them a football player). `draft_value` guards on career appearances so those don't become invented busts. Worth its own branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)