### PR TITLE
chore: tell the engineering skills where issues and domain docs live

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,3 +65,20 @@ Dependencies are pinned in `requirements.txt` — keep it in sync when adding ne
 Implement changes directly — write and run the code yourself rather than coaching the user through
 writing it. Verify changes actually work (e.g. run the fetch/load pipeline, check row counts) before
 reporting a task done.
+
+## Agent skills
+
+### Issue tracker
+
+Issues live as GitHub issues on `CommonFox/going-deep`, driven via the `gh` CLI.
+See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+The five canonical triage roles, each label string equal to its name.
+See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context: `CONTEXT.md` and `docs/adr/` at the repo root.
+See `docs/agents/domain.md`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,35 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the
+codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root — the shared vocabulary for the models in `src/gold/`.
+  `format`, `scoring basis` and friends are defined there precisely because they are used loosely
+  elsewhere in the fantasy world.
+- **`docs/adr/`** — read the ADRs that touch the area you are about to work in. Currently:
+  `0001-roster-format-is-a-gold-concern.md`.
+
+This is a single-context repo: one `CONTEXT.md`, one `docs/adr/`, both at the root. There is no
+`CONTEXT-MAP.md` and no per-package context.
+
+If a file does not exist, **proceed silently**. Don't flag its absence; don't suggest creating it
+upfront. The `/domain-modeling` skill creates these lazily, when a term or a decision actually gets
+resolved.
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept — an issue title, a refactor proposal, a hypothesis, a test
+name — use the term as `CONTEXT.md` defines it. Don't drift to the synonyms it explicitly lists
+under _Avoid_.
+
+If the concept you need isn't in the glossary yet, that's a signal: either you're inventing language
+the project doesn't use (reconsider), or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding
+it:
+
+> _Contradicts ADR-0001 (roster format is a gold concern), but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,45 @@
+# Issue tracker: GitHub
+
+Issues and specs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v`; `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either: resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies**, the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only, the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me`, the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
## What this does

Scaffolds the per-repo config the mattpocock engineering skills assume. These files add no capability — the skills already know *how* to file a ticket or read a glossary. What they can't know is repo-local: **where** issues live and **what** the label strings are. Without this they guess, or interrupt to ask.

| File | Says |
|---|---|
| `docs/agents/issue-tracker.md` | Issues are GitHub issues on this repo, driven via the `gh` CLI. External PRs are *not* a request surface (flag is off). |
| `docs/agents/triage-labels.md` | The five canonical triage roles, keeping the default names: `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`. |
| `docs/agents/domain.md` | Single-context repo: one `CONTEXT.md` and one `docs/adr/`, both at the root. Use the glossary's vocabulary; surface ADR conflicts instead of silently overriding them. |

`CLAUDE.md` gains an `## Agent skills` block: three one-line summaries and three pointers.

## Why the split

`CLAUDE.md` is auto-loaded into context every session whether or not it's relevant, so it stays short. `docs/agents/*.md` cost nothing until something goes and reads them. Small always-on pointer, detailed on-demand payload.

## Note on ordering

`docs/agents/domain.md` names `CONTEXT.md` and `docs/adr/0001-roster-format-is-a-gold-concern.md`, which arrive on `main` with #27. Until that merges the references dangle — harmless, since the file's own rule is to proceed silently when a domain doc is missing.

## Labels

The five label strings are declared here but may not exist in the repo's GitHub labels yet. `/triage` will need to create them on first use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)