### PR TITLE
feat: resolve every draft board row to a Sleeper ID

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -72,6 +72,13 @@ Every draftable player for one league, priced in that league's scoring basis and
 you read on draft night.
 _Avoid_: rankings, cheat sheet, big board
 
+**Draftable**:
+Priced by the market (has a **consensus ADP**) *or* ranked inside the league's starter depth at
+the position. The second arm is not redundant: a rookie can have no ADP at all and still be the
+5th kicker on a board where 14 get rostered, and an ADP-only rule would drop him. Below this cut
+sit third-string quarterbacks and camp-body kickers, whom a build counts rather than names.
+_Avoid_: rosterable, relevant, in range
+
 **ADP**:
 Average draft position — the mean pick at which a player actually went, across many real drafts in
 a stated format. A market price, never a projection or an opinion.

--- a/src/gold/draft_board.py
+++ b/src/gold/draft_board.py
@@ -105,6 +105,7 @@ import pandas as pd
 
 from src import console
 from src.gold.points_over_replacement import _SKILL_POSITIONS, _build_league_season
+from src.gold.sleeper_ids import report_unmapped, resolve_sleeper_ids
 from src.silver.teams import normalize_team
 
 WAREHOUSE_PATH = Path("data/warehouse.duckdb")
@@ -129,7 +130,8 @@ _STARTER_WEEKS_FOR_ROLE = 4
 _SCORING_BASES = {1.0: "ppr", 0.5: "half_ppr"}
 
 _OUTPUT_COLUMNS = [
-    "league_key", "season", "format", "scoring", "player_id", "player_name", "position", "team",
+    "league_key", "season", "format", "scoring", "player_id", "sleeper_id", "player_name",
+    "position", "team",
     "ol_grade", "ol_tier",
     "projected_points", "projected_points_adjusted", "projected_floor", "projected_ceiling",
     "availability", "availability_source",
@@ -343,6 +345,19 @@ def _adp(con: duckdb.DuckDBPyConnection, season: int, adp_format: str) -> pd.Dat
     return pd.concat([players, defenses], ignore_index=True)
 
 
+def _sleeper_crosswalk(con: duckdb.DuckDBPyConnection) -> pd.DataFrame:
+    """nflverse's player crosswalk, cut to the Sleeper mapping — see `sleeper_ids` for why this
+    and not Sleeper's own `gsis_id` field, which is null for most of the board."""
+    return con.execute(
+        "SELECT gsis_id, sleeper_id FROM ids WHERE gsis_id IS NOT NULL AND sleeper_id IS NOT NULL"
+    ).df()
+
+
+def _sleeper_defenses(con: duckdb.DuckDBPyConnection) -> pd.DataFrame:
+    """Sleeper's own DEF rows, which key a defense on its team rather than on any player ID."""
+    return con.execute("SELECT player_id FROM sleeper_players WHERE position = 'DEF'").df()
+
+
 def _team_context(con: duckdb.DuckDBPyConnection, season: int) -> pd.DataFrame:
     """Each player's team and the line he runs behind, graded before the season starts.
 
@@ -416,6 +431,12 @@ def _build_league(con: duckdb.DuckDBPyConnection, league: pd.Series, season: int
     df["season"] = season
     df["format"] = adp_format
     df["scoring"] = scoring
+
+    # Resolved per league, not once for the whole board: a player holds one row per league, so a
+    # board-wide uniqueness check would report every player as colliding with himself.
+    df = resolve_sleeper_ids(df, _sleeper_crosswalk(con), _sleeper_defenses(con))
+    report_unmapped(df, league["league_key"])
+
     return df[_OUTPUT_COLUMNS].sort_values("points_over_replacement", ascending=False)
 
 

--- a/src/gold/sleeper_ids.py
+++ b/src/gold/sleeper_ids.py
@@ -61,12 +61,16 @@ from src.silver.teams import normalize_team
 # Every entry below is the same story — a rookie who has a crosswalk row and a Sleeper row, but
 # whose `ids.sleeper_id` nflverse has not filled in yet. Expect to prune these as the crosswalk
 # catches up; the build will tell you when one no longer matches anybody.
+#
+# Deliberately only the draftable ones. Three more rookie kickers (Drew Stevens, Charlie Smyth,
+# Ben Sauls) have the identical gap and were left out on purpose: they sit below the draftable
+# cut, so mapping them buys nothing a draft can use, while each entry is one more thing that
+# fails the build once the player leaves the board. If one of them wins a job, he crosses the cut
+# and the build will name him — which is the signal to add him, rather than carrying him against
+# the possibility.
 SLEEPER_ID_OVERRIDES = {
     "00-0041145": ("13833", "Dominic Zvada"),
     "00-0040899": ("13545", "Trey Smack"),
-    "00-0041182": ("13968", "Drew Stevens"),
-    "00-0039229": ("11653", "Charlie Smyth"),
-    "00-0040530": ("13066", "Ben Sauls"),
 }
 
 

--- a/src/gold/sleeper_ids.py
+++ b/src/gold/sleeper_ids.py
@@ -1,0 +1,216 @@
+"""Resolve every draft board row to the identifier a Sleeper pick will arrive carrying.
+
+During a live draft the only thing that changes is who has been taken, and Sleeper reports that as
+a player ID. Matching those picks by name is the failure mode this module exists to prevent: a
+board that quietly shows a drafted player as still available costs a pick, which is worse than
+having no tool at all. So identity is resolved here, days before the draft, by a build that says
+out loud which players it could not map.
+
+## The route in, and the one that looks right and isn't
+
+Sleeper's own player export carries a `gsis_id` field, which appears to be exactly the join this
+needs — the warehouse keys players on `gsis_id` throughout. It is a trap. That field is null for
+most of Sleeper's player list, and joining the board through it matches **98 of 655 rows, 15%**.
+Nothing about the failure is loud: the join succeeds, returns a board where six players in seven
+have no ID, and the shortfall only turns up on draft night.
+
+The mapping goes through nflverse's `ids` crosswalk instead, which covers the skill positions
+completely — every running back, receiver and tight end on the board, and every quarterback anyone
+would draft.
+
+## Three routes, in precedence order
+
+1. **Overrides.** A hand-maintained table, consulted first, for players the crosswalk has not
+   caught up with. Every entry must name a player who is actually on the board; an override for
+   someone who has since left it fails the build rather than sitting there mapping nothing.
+2. **Defenses, by team abbreviation.** A team defense has no crosswalk row anywhere — it is not a
+   player — so it resolves on its team instead. Both sides go through `normalize_team` first
+   because the two conventions genuinely disagree: the board says `LA` for the Rams, following
+   nfl_data_py, and Sleeper says `LAR`. What comes back is Sleeper's spelling, since that is what
+   a pick will carry.
+3. **The crosswalk**, for everyone else.
+
+## Identifiers are strings, deliberately
+
+`ids.sleeper_id` is stored as a DOUBLE, so the crosswalk hands back `4034.0` where Sleeper's API
+sends `"4034"`. Compared as strings those are not equal, and the mismatch is invisible in any
+printed frame. Every ID leaving this module has the float scraped off it and is a string, which is
+also the only representation that can hold a defense's `LAR`.
+
+## What "draftable" means
+
+A player is draftable if the market has priced him (`consensus_adp`) **or** he ranks inside the
+league's starter depth at his position (`position_rank <= starters_at_position`). The second arm
+is not redundant: a promising rookie can have no ADP at all and still be the 5th kicker on a board
+where 14 get rostered, and an ADP-only rule would drop him. Below that cut sit third-string
+quarterbacks and camp-body kickers, who are counted rather than named, because a warning printed
+every build about players nobody drafts is a warning that stops being read.
+"""
+
+import pandas as pd
+
+from src import console
+from src.silver.teams import normalize_team
+
+# gsis_id -> (sleeper_id, player_name), consulted before the crosswalk.
+#
+# The name is carried here rather than looked up on the board because it is needed exactly when
+# the board no longer has the player: an override that has gone stale fails the build, and
+# "00-0041145 is not on the board" is not something anyone can act on at speed.
+#
+# Every entry below is the same story — a rookie who has a crosswalk row and a Sleeper row, but
+# whose `ids.sleeper_id` nflverse has not filled in yet. Expect to prune these as the crosswalk
+# catches up; the build will tell you when one no longer matches anybody.
+SLEEPER_ID_OVERRIDES = {
+    "00-0041145": ("13833", "Dominic Zvada"),
+    "00-0040899": ("13545", "Trey Smack"),
+    "00-0041182": ("13968", "Drew Stevens"),
+    "00-0039229": ("11653", "Charlie Smyth"),
+    "00-0040530": ("13066", "Ben Sauls"),
+}
+
+
+def _as_sleeper_id(value) -> str | None:
+    """One identifier as a string, with the crosswalk's float representation removed.
+
+    `4034.0` and `"4034.0"` both become `"4034"`; `"LAR"` is left exactly as it is. Only a value
+    that is already numeric, or spelled as a number with nothing but zeros after the point, is
+    touched — so an ID that merely looks numeric keeps whatever shape it arrived in.
+    """
+    if value is None or pd.isna(value):
+        return None
+    if isinstance(value, float):
+        return str(int(value))
+    text = str(value).strip()
+    if not text:
+        return None
+    whole, separator, fraction = text.partition(".")
+    if separator and whole.isdigit() and set(fraction) <= {"0"}:
+        return whole
+    return text
+
+
+def _crosswalk_ids(crosswalk: pd.DataFrame) -> dict[str, str]:
+    """gsis_id -> Sleeper ID, for the crosswalk rows that carry one.
+
+    A handful of gsis_ids appear on more than one crosswalk row. Taking the first that carries a
+    Sleeper ID is enough here — where two rows disagree the collision check downstream is what
+    catches it, rather than this quietly picking a winner.
+    """
+    ids = {}
+    for gsis_id, sleeper_id in zip(crosswalk["gsis_id"], crosswalk["sleeper_id"]):
+        resolved = _as_sleeper_id(sleeper_id)
+        if resolved is not None and gsis_id not in ids:
+            ids[gsis_id] = resolved
+    return ids
+
+
+def _defense_ids(defenses: pd.DataFrame) -> dict[str, str]:
+    """Canonical team abbreviation -> the identifier Sleeper uses for that defense.
+
+    Keyed on the normalized abbreviation so a board saying `LA` finds the row Sleeper files under
+    `LAR`, and valued at Sleeper's own spelling so what comes back matches a live pick.
+    """
+    return {
+        normalize_team(str(player_id)): _as_sleeper_id(player_id)
+        for player_id in defenses["player_id"]
+    }
+
+
+def _check_overrides(board: pd.DataFrame, overrides: dict[str, tuple[str, str]]) -> None:
+    """Fail loudly on an override for a player the board no longer carries."""
+    on_board = set(board["player_id"])
+    missing = [
+        f"{name} ({player_id})"
+        for player_id, (_, name) in overrides.items()
+        if player_id not in on_board
+    ]
+    if missing:
+        raise ValueError(
+            "SLEEPER_ID_OVERRIDES names players who are not on the board: "
+            + ", ".join(missing)
+            + ". Remove the entry, or find out why the player left the board."
+        )
+
+
+def _check_for_collisions(board: pd.DataFrame) -> None:
+    """Fail loudly if two board rows claim one identifier.
+
+    This is the failure the whole module is built to prevent. Two rows sharing an ID means a
+    single pick would strike the wrong player off the board — or leave a drafted one on it — and
+    the drafter would have no way to see that from the screen.
+    """
+    mapped = board[board["sleeper_id"].notna()]
+    collisions = mapped[mapped.duplicated("sleeper_id", keep=False)]
+    if collisions.empty:
+        return
+
+    described = [
+        f"{sleeper_id} is claimed by " + " and ".join(rows["player_name"])
+        for sleeper_id, rows in collisions.groupby("sleeper_id")
+    ]
+    raise ValueError("Sleeper IDs must identify one board row each, but " + "; ".join(described))
+
+
+def resolve_sleeper_ids(
+    board: pd.DataFrame,
+    crosswalk: pd.DataFrame,
+    defenses: pd.DataFrame,
+    overrides: dict[str, tuple[str, str]] = SLEEPER_ID_OVERRIDES,
+) -> pd.DataFrame:
+    """The board with a `sleeper_id` column, resolved override-first and returned as strings.
+
+    One league's board at a time: the same player holds a row per league, so a whole-board
+    collision check would report every player as a collision with himself.
+    """
+    _check_overrides(board, overrides)
+
+    from_crosswalk = _crosswalk_ids(crosswalk)
+    from_defenses = _defense_ids(defenses)
+
+    def resolve(player_id: str, position: str) -> str | None:
+        if player_id in overrides:
+            return _as_sleeper_id(overrides[player_id][0])
+        if position == "DST":
+            return from_defenses.get(normalize_team(str(player_id)))
+        return from_crosswalk.get(player_id)
+
+    resolved = board.assign(
+        sleeper_id=[
+            resolve(player_id, position)
+            for player_id, position in zip(board["player_id"], board["position"])
+        ]
+    )
+    _check_for_collisions(resolved)
+    return resolved
+
+
+def _draftable(board: pd.DataFrame) -> pd.Series:
+    """Whether each row is someone this league might actually draft — see the module docstring."""
+    return board["consensus_adp"].notna() | (
+        board["position_rank"] <= board["starters_at_position"]
+    )
+
+
+def unmapped_draftable(board: pd.DataFrame) -> pd.DataFrame:
+    """The draftable rows with no Sleeper ID — the gaps that would cost a pick."""
+    return board[_draftable(board) & board["sleeper_id"].isna()]
+
+
+def report_unmapped(board: pd.DataFrame, league_key: str) -> None:
+    """Name every draftable player left unmapped, and count the rest.
+
+    Deliberately not `@console.analysis`: this is the one thing the build knows that a drafter
+    needs days of warning about, so it survives a quiet build like any other note.
+    """
+    gaps = unmapped_draftable(board)
+    for _, row in gaps.iterrows():
+        priced = "unpriced" if pd.isna(row["consensus_adp"]) else f"ADP {row['consensus_adp']:.1f}"
+        console.note(
+            f"{league_key}: no Sleeper ID for {row['player_name']} "
+            f"({row['position']}{int(row['position_rank'])}, {priced})"
+        )
+
+    below_cut = int((~_draftable(board) & board["sleeper_id"].isna()).sum())
+    if below_cut:
+        console.note(f"{league_key}: {below_cut} more unmapped below the draftable cut")

--- a/tests/test_sleeper_ids.py
+++ b/tests/test_sleeper_ids.py
@@ -1,0 +1,229 @@
+"""Spec cases 1-9 from the live draft assistant's identity-resolution ticket.
+
+Every fixture here is hand-written and small enough to reason about by eye, which is the point:
+these assert what comes *out* of resolution for a given board and crosswalk, never how the
+resolution is done. The shapes are not invented, though — each one reproduces something measured
+in the real warehouse:
+
+- `4034.0` is what `ids.sleeper_id` actually holds, a DOUBLE, so every ID needs the float scraped
+  off it before a pick can be matched by string equality.
+- `LA` against Sleeper's `LAR` is the one genuine abbreviation disagreement between the board's
+  nfl_data_py convention and Sleeper's, and it is a defense, so it has no crosswalk row to fall
+  back on.
+- The rookie kickers are on the board and in Sleeper's player list but carry a null `sleeper_id`
+  in nflverse's crosswalk, which is the entire reason an override table exists.
+"""
+
+import pandas as pd
+import pytest
+
+from src.gold.sleeper_ids import (
+    report_unmapped,
+    resolve_sleeper_ids,
+    unmapped_draftable,
+)
+
+
+def board(*rows: dict) -> pd.DataFrame:
+    """A draft board with only the columns resolution reads, defaulted to a draftable player."""
+    defaults = {
+        "player_id": "00-0000001",
+        "player_name": "A Player",
+        "position": "RB",
+        "position_rank": 1,
+        "starters_at_position": 14,
+        "consensus_adp": None,
+    }
+    return pd.DataFrame([{**defaults, **row} for row in rows])
+
+
+def crosswalk(**gsis_to_sleeper) -> pd.DataFrame:
+    """nflverse's `ids`, cut to the two columns that matter, with its float `sleeper_id`."""
+    return pd.DataFrame(
+        [{"gsis_id": gsis, "sleeper_id": sleeper} for gsis, sleeper in gsis_to_sleeper.items()],
+        # Named explicitly so an empty crosswalk still has the columns a real query returns —
+        # a bare DataFrame([]) has no columns at all, which is a shape the warehouse never hands
+        # back and so not one worth making the code under test tolerate.
+        columns=["gsis_id", "sleeper_id"],
+    )
+
+
+def defenses(*sleeper_ids: str) -> pd.DataFrame:
+    """Sleeper's own DEF rows, which key a defense on its team abbreviation."""
+    return pd.DataFrame({"player_id": list(sleeper_ids)})
+
+
+NO_DEFENSES = defenses()
+NO_OVERRIDES: dict[str, tuple[str, str]] = {}
+
+
+# 1. Every running back, receiver and tight end on the board resolves to a Sleeper ID.
+def test_skill_positions_resolve_through_the_crosswalk():
+    resolved = resolve_sleeper_ids(
+        board(
+            {"player_id": "00-0000001", "player_name": "A Back", "position": "RB"},
+            {"player_id": "00-0000002", "player_name": "A Receiver", "position": "WR"},
+            {"player_id": "00-0000003", "player_name": "An End", "position": "TE"},
+        ),
+        crosswalk(**{"00-0000001": 4034.0, "00-0000002": 5849.0, "00-0000003": 7564.0}),
+        NO_DEFENSES,
+        NO_OVERRIDES,
+    )
+
+    assert resolved["sleeper_id"].tolist() == ["4034", "5849", "7564"]
+
+
+# 2. Every quarterback within the draftable range resolves to a Sleeper ID.
+def test_draftable_quarterback_resolves_and_a_deeper_one_is_neither_resolved_nor_reported():
+    resolved = resolve_sleeper_ids(
+        board(
+            {
+                "player_id": "00-0000010",
+                "player_name": "A Starter",
+                "position": "QB",
+                "position_rank": 12,
+                "starters_at_position": 28,
+            },
+            {
+                "player_id": "00-0000011",
+                "player_name": "A Third Stringer",
+                "position": "QB",
+                "position_rank": 57,
+                "starters_at_position": 28,
+            },
+        ),
+        crosswalk(**{"00-0000010": 4034.0}),
+        NO_DEFENSES,
+        NO_OVERRIDES,
+    )
+
+    by_name = resolved.set_index("player_name")["sleeper_id"]
+    assert by_name["A Starter"] == "4034"
+    assert by_name["A Third Stringer"] is None
+
+    # Outside the draftable cut on both arms — no ADP, ranked past the league's starter depth —
+    # so his absence is a fact about a player nobody drafts, not a gap worth a warning.
+    assert unmapped_draftable(resolved)["player_name"].tolist() == []
+
+
+# 3. Every team defense resolves via its team abbreviation.
+def test_defenses_resolve_on_their_team_abbreviation():
+    resolved = resolve_sleeper_ids(
+        board({"player_id": "PHI", "player_name": "PHI", "position": "DST"}),
+        crosswalk(),
+        defenses("PHI"),
+        NO_OVERRIDES,
+    )
+
+    assert resolved["sleeper_id"].tolist() == ["PHI"]
+
+
+# 4. A board team abbreviation that differs from Sleeper's normalizes correctly before matching.
+def test_a_defense_whose_abbreviation_sleeper_spells_differently_still_matches():
+    resolved = resolve_sleeper_ids(
+        board({"player_id": "LA", "player_name": "LA", "position": "DST"}),
+        crosswalk(),
+        defenses("LAR"),
+        NO_OVERRIDES,
+    )
+
+    # The board says LA and Sleeper says LAR for the same franchise. What comes back is the
+    # identifier a pick will actually arrive carrying, which is Sleeper's.
+    assert resolved["sleeper_id"].tolist() == ["LAR"]
+
+
+# 5. Resolved IDs are strings with no floating-point residue.
+def test_ids_come_back_as_strings_without_the_crosswalks_float():
+    resolved = resolve_sleeper_ids(
+        board({"player_id": "00-0000001"}),
+        crosswalk(**{"00-0000001": 4034.0}),
+        NO_DEFENSES,
+        NO_OVERRIDES,
+    )
+
+    (sleeper_id,) = resolved["sleeper_id"]
+    assert sleeper_id == "4034"
+    assert isinstance(sleeper_id, str)
+
+
+# 6. No two board rows resolve to the same Sleeper ID.
+def test_two_board_rows_resolving_to_one_id_fails_loudly():
+    with pytest.raises(ValueError) as error:
+        resolve_sleeper_ids(
+            board(
+                {"player_id": "00-0000001", "player_name": "A Back"},
+                {"player_id": "00-0000002", "player_name": "Another Back"},
+            ),
+            crosswalk(**{"00-0000001": 4034.0, "00-0000002": 4034.0}),
+            NO_DEFENSES,
+            NO_OVERRIDES,
+        )
+
+    assert "4034" in str(error.value)
+    assert "A Back" in str(error.value)
+    assert "Another Back" in str(error.value)
+
+
+# 7. A hand-written override takes precedence over the crosswalk for the same player.
+def test_an_override_beats_the_crosswalk():
+    resolved = resolve_sleeper_ids(
+        board({"player_id": "00-0000001", "player_name": "A Kicker", "position": "K"}),
+        crosswalk(**{"00-0000001": 4034.0}),
+        NO_DEFENSES,
+        {"00-0000001": ("13833", "A Kicker")},
+    )
+
+    assert resolved["sleeper_id"].tolist() == ["13833"]
+
+
+# 8. An override naming a player absent from the board fails the build loudly.
+def test_an_override_for_a_player_who_is_not_on_the_board_fails_loudly():
+    with pytest.raises(ValueError) as error:
+        resolve_sleeper_ids(
+            board({"player_id": "00-0000001", "player_name": "A Kicker"}),
+            crosswalk(**{"00-0000001": 4034.0}),
+            NO_DEFENSES,
+            {"00-0000099": ("13833", "A Departed Kicker")},
+        )
+
+    assert "A Departed Kicker" in str(error.value)
+
+
+# 9. The build reports every draftable player left unmapped, naming each one.
+def test_the_report_names_every_draftable_player_left_unmapped(capsys):
+    resolved = resolve_sleeper_ids(
+        board(
+            {
+                "player_id": "00-0000020",
+                "player_name": "A Priced Kicker",
+                "position": "K",
+                "position_rank": 21,
+                "consensus_adp": 162.4,
+            },
+            {
+                "player_id": "00-0000021",
+                "player_name": "A Top Kicker",
+                "position": "K",
+                "position_rank": 5,
+            },
+            {
+                "player_id": "00-0000022",
+                "player_name": "A Camp Body",
+                "position": "K",
+                "position_rank": 34,
+            },
+        ),
+        crosswalk(),
+        NO_DEFENSES,
+        NO_OVERRIDES,
+    )
+
+    report_unmapped(resolved, "sleeper")
+    printed = capsys.readouterr().out
+
+    # Priced by the market, so draftable however deep his position rank.
+    assert "A Priced Kicker" in printed
+    # No ADP at all, but inside the league's starter depth — the rookie case the cut exists for.
+    assert "A Top Kicker" in printed
+    # Ranked past anyone's bench, unpriced: counted, but not named at every build.
+    assert "A Camp Body" not in printed


### PR DESCRIPTION
Closes #31. Part of #29.

Adds a `sleeper_id` column to `draft_board`, so a pick arriving during a live draft can be matched
by identifier rather than by name — and reports the gaps at build time, days beforehand, rather
than on draft night.

## The join that looks right and isn't

Sleeper's player export carries its own `gsis_id` field, which appears to be exactly the join this
needs. It is a trap: that field is null for most of Sleeper's player list, and joining the board
through it matches **98 of 655 rows (15%)**. Nothing about the failure is loud — the join
succeeds and returns a board where six players in seven have no ID. The mapping goes through
nflverse's `ids` crosswalk instead.

## Three routes, in precedence order

1. **Overrides** — a hand-maintained table, consulted first, for players the crosswalk hasn't
   caught up with. An entry naming a player who has left the board fails the build.
2. **Defenses, by team abbreviation** — a defense has no crosswalk row anywhere. Both sides go
   through `normalize_team`, because the conventions genuinely disagree: the board says `LA` for
   the Rams and Sleeper says `LAR`. Only the *lookup key* is normalized; the value returned is
   Sleeper's own spelling, since that's what a pick will carry.
3. **The crosswalk**, for everyone else.

## Identifiers are strings

`ids.sleeper_id` is a DOUBLE, so the crosswalk hands back `4034.0` where the API sends `"4034"`.
Every ID leaving the module has the float scraped off it. This matters beyond tidiness: one null
in a picks payload types the whole column `float64`, DuckDB stores it `DOUBLE`, and a join against
the board silently returns **zero rows**. `_as_sleeper_id` is deliberately in its own module rather
than inside the board builder so the live tool can share the one rule instead of reinventing it.

## What "draftable" means

Priced by the market (`consensus_adp`) **or** ranked inside the league's starter depth
(`position_rank <= starters_at_position`). The second arm isn't redundant — a rookie can have no
ADP at all and still be the 5th kicker on a board where 14 get rostered. Below the cut, unmapped
rows are counted rather than named, so a warning nobody drafts against doesn't train people to
ignore the warning line. Added to `CONTEXT.md`, since `Board`'s own definition leans on the word.

## Result, from a real build

| | sleeper | espn |
|---|---|---|
| RB / WR / TE | 136/136, 200/200, 123/123 | 100% |
| QB | 113/120 — the 7 are QB49–65, unpriced | 100% of draftable |
| K | 41/44 | 41/44 |
| DST | 32/32 | 32/32 |
| **Draftable unmapped** | **0** | **0** |
| ID collisions | 0 | 0 |

Column type is `VARCHAR`; Josh Allen is `"4984"`, the Rams defense is `"LAR"`. The build's entire
gap output is two counted lines.

Overrides carry only the two draftable rookie kickers. Three more (Stevens, Smyth, Sauls) have the
identical crosswalk gap but sit below the cut on both boards, so mapping them buys nothing a draft
can use while each entry is one more thing that fails the build when a player leaves. If one wins
a job he crosses the cut and the build names him.

## Testing

Spec cases 1–9 from #31, written and failing before the module existed, in
`tests/test_sleeper_ids.py`. Fixtures are hand-written frames whose shapes reproduce things
measured in the warehouse — the `4034.0` float, the `LA`/`LAR` disagreement, the rookie kickers
with a null `sleeper_id`. No warehouse access, per `tests/conftest.py`. Suite is 21 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)