### PR TITLE
feat: turn a raw picks payload into taken players, roster, unmatched picks and next pick

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,12 @@ Dependencies are pinned in `requirements.txt` — keep it in sync when adding ne
       alone.
   - `src/gold/<model>.py` — proprietary/derived models built on top of already-loaded silver
     tables (e.g. `consensus.py`). Pure SQL/Python over the warehouse — no fetch step, no network.
+  - `src/draft/` — the live draft assistant, and the one part of `src/` that is not a medallion
+    layer. It is neither: it opens no connection and reads no raw file, but takes already-built
+    frames and a live API payload and returns frames. Everything about a player's value is fixed
+    by the warehouse rebuild days beforehand; nothing here recomputes any of it. New modules for
+    this feature go here rather than under `gold/`, which is documented as warehouse-to-warehouse
+    and would be a lie about what these do.
 - `if __name__ == "__main__":` in each source module runs the full fetch→load sequence for that
   source end to end.
 - Console output goes through `src/console.py`, never a bare `print`:

--- a/src/draft/picks.py
+++ b/src/draft/picks.py
@@ -1,0 +1,236 @@
+"""Turn a live Sleeper picks payload into who is gone, who is mine, and when I pick next.
+
+This is the first half of the live draft assistant's single seam, and it is pure: no network, no
+warehouse connection, no printing, no mutation of anything handed in. It takes the payload
+*exactly* as Sleeper's API returns it rather than something pre-parsed, which is deliberate —
+every awkward thing a payload can do is then handled inside a boundary that tests can reach.
+
+## Why the payload needs defending against at all
+
+`GET /draft/<id>/picks` returns the whole draft from pick one, every single poll. Never a delta.
+So the obvious worries are the wrong ones: the list is complete and sorted when it arrives.
+
+The disorder comes from above. The tool unions hand-marked players in with the API's picks so a
+drafter can keep going with no network, and a hand-marked player has no pick number and no place
+in the ordering. The moment the API catches up with a hand-mark, that player is in the list twice.
+Both of those must not double-fill a roster slot or double-count against the next pick, and
+neither is a hypothetical.
+
+## Unmatched picks are the whole point of the module
+
+A pick arrives carrying Sleeper's player ID. If no board row has that ID in `sleeper_id`, two very
+different things could be true and there is no way to tell them apart from here:
+
+- some deep flyer nobody was going to draft, who was never on the board; or
+- somebody who *is* on the board but whose ID resolution failed upstream — meaning he has just
+  been drafted and the board still shows him available.
+
+The second is exactly the failure the whole feature exists to prevent, and it costs a pick. So an
+unmatched pick is never dropped, never guessed at, and is returned named so the renderer can put
+it on screen. `sleeper_ids.report_unmapped` is the same instinct applied days earlier.
+
+## Snake arithmetic
+
+Rounds alternate direction, so a seat's pick number depends on the round's parity:
+
+    odd  round r, seat s  ->  (r - 1) * team_count + s
+    even round r, seat s  ->  (r - 1) * team_count + (team_count - s + 1)
+
+Seat 1 in a 14-team draft therefore picks 1, 28, 29, 56, 57 — the back-to-back pairs the glossary
+describes — and a version that forgot the reversal would give 1, 15, 29 and be wrong from round two
+onwards. Picks made is read from the highest pick number seen rather than from the length of the
+list, so a hand-marked player (no pick number) cannot push the next turn a pick further away.
+
+## Filling slots
+
+A quarterback can start at QB or in the superflex; a back can start at RB, in the flex, or in the
+superflex. So "which slots are still open" is not a count, it is an assignment, and the assignment
+order changes the answer. The order here is fixed and dull on purpose — dedicated slot, then flex,
+then superflex, then bench — so that what lands where can be worked out by eye at pick five rather
+than trusted. Within a slot, players are taken in the order they were drafted.
+"""
+
+import pandas as pd
+
+# Which positions may start in each slot. FLEX and SUPER_FLEX are the only ones that overlap with
+# anything, and the superflex slot is the reason this league drafts differently to the other one.
+SLOT_ELIGIBILITY = {
+    "QB": {"QB"},
+    "RB": {"RB"},
+    "WR": {"WR"},
+    "TE": {"TE"},
+    "K": {"K"},
+    "P": {"P"},
+    "DST": {"DST"},
+    "FLEX": {"RB", "WR", "TE"},
+    "SUPER_FLEX": {"QB", "RB", "WR", "TE"},
+}
+
+# Dedicated slots first, so a back only reaches the flex once the RB slots are full, and the
+# superflex is only reached once the flex is too. Everyone left over is bench.
+FILL_ORDER = ["QB", "RB", "WR", "TE", "K", "P", "DST", "FLEX", "SUPER_FLEX"]
+
+# How a lineup reads on screen, which is not how it fills: the superflex sits with the flex rather
+# than after the defense, because that is where a drafter looks for it.
+SLOT_ORDER = ["QB", "RB", "WR", "TE", "FLEX", "SUPER_FLEX", "K", "P", "DST", "BENCH"]
+
+BENCH = "BENCH"
+
+
+def _unique_picks(picks: list[dict]) -> list[dict]:
+    """The payload's picks, deduplicated on player and put in draft order.
+
+    Deduplication is on the player rather than on the pick number, because the duplicate this
+    guards against is a hand-marked player meeting his own API pick — same player, one of them
+    with no pick number at all. Sorting last means an out-of-order payload and an in-order one
+    reduce to the same list before anything is decided from it.
+    """
+    first_seen = {}
+    for entry in picks:
+        player = entry.get("player_id")
+        if player is None or player in first_seen:
+            continue
+        first_seen[player] = entry
+
+    # Hand-marked entries carry no pick number; they sort after everything the API has reported,
+    # which is where they belong — they are known to have happened, but not known when.
+    return sorted(first_seen.values(), key=lambda entry: (entry.get("pick_no") or float("inf")))
+
+
+def _picked_name(entry: dict) -> str | None:
+    """The name Sleeper attached to a pick, for a player the board could not identify."""
+    metadata = entry.get("metadata") or {}
+    parts = [metadata.get("first_name"), metadata.get("last_name")]
+    return " ".join(part for part in parts if part) or None
+
+
+def _picks_made(picks: list[dict]) -> int:
+    """How far the draft has actually got, read from pick numbers rather than list length.
+
+    A hand-marked player is a pick that happened but has no number; counting the list would
+    treat him as an extra selection and push the seat's next turn one pick too far away.
+    """
+    numbered = [entry["pick_no"] for entry in picks if entry.get("pick_no") is not None]
+    return max(numbered, default=0)
+
+
+def next_pick_number(picks_made: int, seat: int, team_count: int, rounds: int) -> int | None:
+    """The overall number of the seat's next turn, or None once the draft is over.
+
+    Walks the seat's own pick numbers in round order and returns the first one still ahead. A
+    closed form would need the same parity branch and be harder to check by eye against the
+    Sleeper app, which is the thing this number exists to be verified against.
+    """
+    for round_number in range(1, rounds + 1):
+        within_round = (
+            seat if round_number % 2 == 1 else team_count - seat + 1
+        )
+        overall = (round_number - 1) * team_count + within_round
+        if overall > picks_made:
+            return overall
+    return None
+
+
+def _assign_to_slots(drafted: list[dict], slots: dict[str, int]) -> dict[str, list[str]]:
+    """Each of my players placed in one slot, dedicated first, then flex, then superflex.
+
+    `drafted` is in draft order, so the first back taken holds RB1 and the third falls to the
+    flex — which is what a drafter expects to see and what makes the table checkable by hand.
+    """
+    placed = {slot: [] for slot in [*SLOT_ORDER, BENCH]}
+    remaining = list(drafted)
+
+    for slot in FILL_ORDER:
+        eligible = SLOT_ELIGIBILITY[slot]
+        openings = slots.get(slot, 0)
+        still_open = []
+        for player in remaining:
+            if openings > 0 and player["position"] in eligible:
+                placed[slot].append(player["player_name"])
+                openings -= 1
+            else:
+                still_open.append(player)
+        remaining = still_open
+
+    placed[BENCH] = [player["player_name"] for player in remaining]
+    return placed
+
+
+def _roster_frame(placed: dict[str, list[str]], slots: dict[str, int]) -> pd.DataFrame:
+    """One row per starting slot the league actually uses, plus the bench.
+
+    Slots the league does not start are left out entirely rather than shown as zero, so the
+    one-quarterback league's table never mentions a superflex it does not have.
+    """
+    shown = [slot for slot in SLOT_ORDER if slots.get(slot, 0) > 0 or placed[slot]]
+    return pd.DataFrame(
+        [
+            {
+                "slot": slot,
+                "starts": slots.get(slot, 0),
+                "filled": len(placed[slot]),
+                "open": max(slots.get(slot, 0) - len(placed[slot]), 0),
+                "players": placed[slot],
+            }
+            for slot in shown
+        ]
+    )
+
+
+def ingest_picks(picks: list[dict], board: pd.DataFrame, league: dict) -> dict:
+    """Read a raw Sleeper picks payload against one league's board.
+
+    `league` carries the shape the payload cannot supply: `seat` and `roster_id` for the drafter,
+    `team_count` and `rounds` for the snake, and `slots` mapping each starting slot to how many of
+    it the league starts.
+
+    Returns a dict of:
+
+    - `taken` — the board's own player IDs for everyone drafted, mine and everyone else's.
+    - `roster` — my lineup so far, a frame of one row per starting slot.
+    - `unmatched` — every pick whose player the board could not identify, named, in draft order.
+    - `next_pick` — the overall number of my next turn, or None once the draft is over.
+    - `picks_made` — how far the draft has got, so a caller need not re-parse the payload for it.
+    """
+    ordered = _unique_picks(picks)
+
+    # Sleeper's ID -> the board row it identifies. Built once rather than per pick, and keyed on
+    # the string form because that is what a pick carries and what `sleeper_ids` guarantees.
+    by_sleeper_id = {
+        str(sleeper_id): {"player_id": player_id, "player_name": name, "position": position}
+        for sleeper_id, player_id, name, position in zip(
+            board["sleeper_id"], board["player_id"], board["player_name"], board["position"]
+        )
+        if pd.notna(sleeper_id)
+    }
+
+    taken = set()
+    mine = []
+    unmatched = []
+
+    for entry in ordered:
+        row = by_sleeper_id.get(str(entry["player_id"]))
+        if row is None:
+            metadata = entry.get("metadata") or {}
+            unmatched.append({
+                "sleeper_id": entry["player_id"],
+                "player_name": _picked_name(entry),
+                "position": metadata.get("position"),
+                "pick_no": entry.get("pick_no"),
+            })
+            continue
+
+        taken.add(row["player_id"])
+        if entry.get("roster_id") == league["roster_id"]:
+            mine.append(row)
+
+    picks_made = _picks_made(ordered)
+    return {
+        "taken": taken,
+        "roster": _roster_frame(_assign_to_slots(mine, league["slots"]), league["slots"]),
+        "unmatched": unmatched,
+        "next_pick": next_pick_number(
+            picks_made, league["seat"], league["team_count"], league["rounds"]
+        ),
+        "picks_made": picks_made,
+    }

--- a/tests/test_draft_picks.py
+++ b/tests/test_draft_picks.py
@@ -254,3 +254,54 @@ def test_the_roster_is_reported_against_the_leagues_real_starting_slots():
     ])
 
     pd.testing.assert_frame_equal(result["roster"], expected)
+
+
+# The two cases below are not from the ticket's numbered list. They were agreed in conversation
+# after the implementation, because the payload defences above exist for a situation Sleeper's own
+# API cannot create: it refuses to draft an already-drafted player, so a duplicate never arrives
+# from the network. Both duplicates and unnumbered picks arrive from #36's hand-marking, where the
+# drafter's own entry is unioned into the same list the API returns. Without these, the two rules
+# that handle that are untested for the reason they were written.
+
+
+# A hand-marked entry carries no pick number: the drafter knows the player is gone, not when.
+HAND_MARKED = {"player_id": "4034", "roster_id": MY_ROSTER, "pick_no": None, "metadata": {}}
+
+ONE_BACK = {"player_id": "00-0000001", "sleeper_id": "4034", "player_name": "My Back"}
+
+
+# A. A hand-marked player and his own API pick are one player.
+#
+# Two claims, because the two ways of getting this wrong fail in opposite directions and a test
+# making only one of them would sleep through the other. Keying identity on the pick number drops
+# the hand-mark, because its number is None — the player silently returns to the board after the
+# drafter has said he is gone. Not deduplicating at all keeps both copies, and he fills two slots.
+def test_a_hand_marked_player_is_taken_before_the_api_reports_him():
+    result = ingest_picks([HAND_MARKED], board(ONE_BACK), league())
+
+    assert result["taken"] == {"00-0000001"}
+    assert players_in(result["roster"], "RB") == ["My Back"]
+
+
+def test_a_hand_marked_player_and_his_api_pick_are_one_player():
+    from_the_api = pick("4034", pick_no=12, roster_id=MY_ROSTER)
+
+    result = ingest_picks([HAND_MARKED, from_the_api], board(ONE_BACK), league())
+
+    # Two RB slots, so a player counted twice would fill both and report the position as done.
+    assert players_in(result["roster"], "RB") == ["My Back"]
+    assert result["roster"].loc[result["roster"]["slot"] == "RB", "open"].iloc[0] == 1
+
+
+# B. A hand-marked player does not advance the draft.
+def test_a_hand_marked_player_does_not_advance_the_draft():
+    api = [pick(str(9000 + n), pick_no=n) for n in range(1, 24)]
+    hand_marked = {"player_id": "4034", "roster_id": ANOTHER_ROSTER, "pick_no": None,
+                   "metadata": {}}
+
+    result = ingest_picks([*api, hand_marked], board(), league(seat=5))
+
+    # 23 selections have happened. Counting the list would make it 24, and seat 5's turn would
+    # read as pick 33 — nine away — at the exact moment the drafter is on the clock at pick 24.
+    assert result["picks_made"] == 23
+    assert result["next_pick"] == 24

--- a/tests/test_draft_picks.py
+++ b/tests/test_draft_picks.py
@@ -1,0 +1,256 @@
+"""Spec cases 11, 12, 13, 16, 17, 18, 19 and 28 from the live draft assistant's ingestion ticket.
+
+These assert what comes *out* of `ingest_picks` for a given payload, board and league shape —
+never how it gets there. Every fixture is small enough to work out by hand, which is the only
+kind that stays true across a warehouse rebuild.
+
+The payload shapes are Sleeper's own, not invented:
+
+- A pick keys its player on `player_id`, which is Sleeper's identifier — the string the board
+  now carries in `sleeper_id`, and never a name.
+- Ownership is `roster_id`. The drafter's seat is a separate thing, used only for pick arithmetic.
+- `pick_no` is the overall pick number, 1-indexed across the whole draft.
+- `metadata` carries the player's name, which is the only thing that makes an *unmatched* pick
+  reportable: if the ID resolves to nothing, the name is all there is to put on screen.
+"""
+
+import pandas as pd
+
+from src.draft.picks import ingest_picks
+
+TEAM_COUNT = 14
+ROUNDS = 15
+
+MY_ROSTER = 1
+ANOTHER_ROSTER = 7
+
+# This league's real starting lineup, superflex included — the shape spec case 28 is about.
+SUPERFLEX_SLOTS = {
+    "QB": 1, "RB": 2, "WR": 3, "TE": 1,
+    "FLEX": 1, "SUPER_FLEX": 1,
+    "K": 1, "DST": 1, "BENCH": 6,
+}
+
+
+def board(*rows: dict) -> pd.DataFrame:
+    """A board with only the columns ingestion reads, defaulted to one findable running back."""
+    defaults = {
+        "player_id": "00-0000001",
+        "sleeper_id": "4034",
+        "player_name": "A Back",
+        "position": "RB",
+    }
+    return pd.DataFrame(
+        [{**defaults, **row} for row in rows],
+        # Named explicitly for the same reason the identity suite names them: a bare
+        # DataFrame([]) has no columns at all, which is not a shape the warehouse can hand back,
+        # so it is not one worth making the code under test tolerate.
+        columns=list(defaults),
+    )
+
+
+def pick(sleeper_id: str, pick_no: int, roster_id: int = ANOTHER_ROSTER, **metadata) -> dict:
+    """One pick as Sleeper hands it back."""
+    named = {"first_name": "Some", "last_name": "Player", "position": "RB", **metadata}
+    return {
+        "player_id": sleeper_id,
+        "roster_id": roster_id,
+        "pick_no": pick_no,
+        "round": (pick_no - 1) // TEAM_COUNT + 1,
+        "metadata": named,
+    }
+
+
+def league(**overrides) -> dict:
+    """The league's shape: which seat is mine, how big the draft is, what a lineup requires."""
+    return {
+        "seat": 1,
+        "roster_id": MY_ROSTER,
+        "team_count": TEAM_COUNT,
+        "rounds": ROUNDS,
+        "slots": SUPERFLEX_SLOTS,
+        **overrides,
+    }
+
+
+def players_in(roster: pd.DataFrame, slot: str) -> list[str]:
+    """The names sitting in one slot of a returned roster."""
+    return roster.loc[roster["slot"] == slot, "players"].iloc[0]
+
+
+def assert_same_result(left: dict, right: dict) -> None:
+    """Every part of two results agrees — used where the claim is about order-independence."""
+    assert left["taken"] == right["taken"]
+    assert left["unmatched"] == right["unmatched"]
+    assert left["next_pick"] == right["next_pick"]
+    assert left["picks_made"] == right["picks_made"]
+    pd.testing.assert_frame_equal(left["roster"], right["roster"])
+
+
+# 11. A pick whose player ID matches nothing is returned in the unmatched list.
+def test_a_pick_matching_no_board_row_is_returned_as_unmatched():
+    result = ingest_picks(
+        [pick("9999", pick_no=1, first_name="Ghost", last_name="Runner", position="WR")],
+        board({"sleeper_id": "4034", "player_name": "A Back"}),
+        league(),
+    )
+
+    assert result["unmatched"] == [
+        {"sleeper_id": "9999", "player_name": "Ghost Runner", "position": "WR", "pick_no": 1}
+    ]
+
+
+# 12. An unmatched pick removes nobody from the board and leaves the rest of the result intact.
+def test_an_unmatched_pick_removes_nobody_and_leaves_the_rest_intact():
+    result = ingest_picks(
+        [
+            pick("9999", pick_no=1, first_name="Ghost", last_name="Runner"),
+            pick("4034", pick_no=2, roster_id=ANOTHER_ROSTER),
+        ],
+        board(
+            {"player_id": "00-0000001", "sleeper_id": "4034", "player_name": "A Back"},
+            {"player_id": "00-0000002", "sleeper_id": "5849", "player_name": "A Receiver",
+             "position": "WR"},
+        ),
+        league(seat=5),
+    )
+
+    # Only the pick that matched takes anybody off the board. The ghost removes nobody, and in
+    # particular does not remove the row it sorts next to.
+    assert result["taken"] == {"00-0000001"}
+    assert len(result["unmatched"]) == 1
+    # Both picks still happened, so both still count against the seat's next turn.
+    assert result["picks_made"] == 2
+    assert result["next_pick"] == 5
+    assert result["roster"]["filled"].sum() == 0
+
+
+# 13. A pick belonging to the drafter's own roster ID appears in the roster and is also removed
+#     from the board.
+def test_a_pick_on_the_drafters_roster_fills_a_slot_and_is_also_taken():
+    result = ingest_picks(
+        [
+            pick("4034", pick_no=1, roster_id=MY_ROSTER),
+            pick("5849", pick_no=2, roster_id=ANOTHER_ROSTER),
+        ],
+        board(
+            {"player_id": "00-0000001", "sleeper_id": "4034", "player_name": "My Back"},
+            {"player_id": "00-0000002", "sleeper_id": "5849", "player_name": "Their Receiver",
+             "position": "WR"},
+        ),
+        league(),
+    )
+
+    assert result["taken"] == {"00-0000001", "00-0000002"}
+    assert players_in(result["roster"], "RB") == ["My Back"]
+    # Somebody else's pick is off the board but is emphatically not on my roster.
+    assert players_in(result["roster"], "WR") == []
+
+
+# 16. The same pick appearing twice in a payload is counted once.
+def test_the_same_pick_twice_is_counted_once():
+    duplicated = pick("4034", pick_no=1, roster_id=MY_ROSTER)
+    unknown = pick("9999", pick_no=2, first_name="Ghost", last_name="Runner")
+
+    result = ingest_picks(
+        [duplicated, dict(duplicated), unknown, dict(unknown)],
+        board({"player_id": "00-0000001", "sleeper_id": "4034", "player_name": "My Back"}),
+        league(),
+    )
+
+    assert players_in(result["roster"], "RB") == ["My Back"]
+    assert result["roster"].loc[result["roster"]["slot"] == "RB", "filled"].iloc[0] == 1
+    assert len(result["unmatched"]) == 1
+    assert result["picks_made"] == 2
+
+
+# 17. Picks supplied out of order produce the same result as the same picks in order.
+def test_picks_out_of_order_give_the_same_result_as_picks_in_order():
+    in_order = [
+        pick("4034", pick_no=1, roster_id=MY_ROSTER),
+        pick("5849", pick_no=2, roster_id=ANOTHER_ROSTER),
+        pick("9999", pick_no=3, first_name="Ghost", last_name="Runner"),
+        pick("7564", pick_no=4, roster_id=MY_ROSTER),
+    ]
+    shuffled = [in_order[2], in_order[0], in_order[3], in_order[1]]
+
+    the_board = board(
+        {"player_id": "00-0000001", "sleeper_id": "4034", "player_name": "My Back"},
+        {"player_id": "00-0000002", "sleeper_id": "5849", "player_name": "Their Receiver",
+         "position": "WR"},
+        {"player_id": "00-0000003", "sleeper_id": "7564", "player_name": "My End",
+         "position": "TE"},
+    )
+
+    assert_same_result(
+        ingest_picks(shuffled, the_board, league()),
+        ingest_picks(in_order, the_board, league()),
+    )
+
+
+# 18. The next pick number is correct for a seat in an odd-numbered round.
+def test_the_next_pick_is_correct_in_an_odd_round():
+    # Round 1 runs 1-14 in seat order, so seat 5 is pick 5 before anything has happened.
+    assert ingest_picks([], board(), league(seat=5))["next_pick"] == 5
+
+    # Round 3 is odd too, so the order is seat order again: it runs 29-42 and seat 5 is pick 33.
+    made = [pick(str(9000 + n), pick_no=n) for n in range(1, 31)]
+    assert ingest_picks(made, board(), league(seat=5))["next_pick"] == 33
+
+
+# 19. The next pick number is correct for a seat in an even-numbered round, reflecting the snake
+#     reversal.
+def test_the_next_pick_is_correct_in_an_even_round_and_reverses():
+    # Round 2 runs 15-28 backwards, so seat 5 is 14 + (14 - 5 + 1) = pick 24, not pick 19.
+    made = [pick(str(9000 + n), pick_no=n) for n in range(1, 21)]
+    assert ingest_picks(made, board(), league(seat=5))["next_pick"] == 24
+
+    # Seat 1 is the extreme case: last in round 2, first in round 3, so picks 28 and 29 are
+    # back to back and the reversal is the whole reason for it.
+    assert ingest_picks(made, board(), league(seat=1))["next_pick"] == 28
+    made_through_28 = [pick(str(9000 + n), pick_no=n) for n in range(1, 29)]
+    assert ingest_picks(made_through_28, board(), league(seat=1))["next_pick"] == 29
+
+    # Past the last round there is no next pick, and that must not be a number.
+    whole_draft = [pick(str(9000 + n), pick_no=n) for n in range(1, TEAM_COUNT * ROUNDS + 1)]
+    assert ingest_picks(whole_draft, board(), league(seat=1))["next_pick"] is None
+
+
+# 28. A roster is reported against the league's actual starting slots, including the superflex
+#     slot.
+def test_the_roster_is_reported_against_the_leagues_real_starting_slots():
+    result = ingest_picks(
+        [
+            pick("1001", pick_no=1, roster_id=MY_ROSTER),
+            pick("1002", pick_no=28, roster_id=MY_ROSTER),
+            pick("1003", pick_no=29, roster_id=MY_ROSTER),
+            pick("1004", pick_no=56, roster_id=MY_ROSTER),
+        ],
+        board(
+            {"player_id": "00-0000001", "sleeper_id": "1001", "player_name": "First QB",
+             "position": "QB"},
+            {"player_id": "00-0000002", "sleeper_id": "1002", "player_name": "Second QB",
+             "position": "QB"},
+            {"player_id": "00-0000003", "sleeper_id": "1003", "player_name": "A Back",
+             "position": "RB"},
+            {"player_id": "00-0000004", "sleeper_id": "1004", "player_name": "A Receiver",
+             "position": "WR"},
+        ),
+        league(),
+    )
+
+    expected = pd.DataFrame([
+        # The second quarterback lands in the superflex slot, which is the slot that only exists
+        # because this league is superflex — in the ESPN league he would be a bench body.
+        {"slot": "QB", "starts": 1, "filled": 1, "open": 0, "players": ["First QB"]},
+        {"slot": "RB", "starts": 2, "filled": 1, "open": 1, "players": ["A Back"]},
+        {"slot": "WR", "starts": 3, "filled": 1, "open": 2, "players": ["A Receiver"]},
+        {"slot": "TE", "starts": 1, "filled": 0, "open": 1, "players": []},
+        {"slot": "FLEX", "starts": 1, "filled": 0, "open": 1, "players": []},
+        {"slot": "SUPER_FLEX", "starts": 1, "filled": 1, "open": 0, "players": ["Second QB"]},
+        {"slot": "K", "starts": 1, "filled": 0, "open": 1, "players": []},
+        {"slot": "DST", "starts": 1, "filled": 0, "open": 1, "players": []},
+        {"slot": "BENCH", "starts": 6, "filled": 0, "open": 6, "players": []},
+    ])
+
+    pd.testing.assert_frame_equal(result["roster"], expected)


### PR DESCRIPTION
Closes #32. First half of the single pure seam in #29; ranking the survivors is #33.

## What this does

`ingest_picks(picks, board, league)` in `src/draft/picks.py`. Given the payload exactly as
Sleeper returns it, it works out who is gone, which of them are mine, which picks could not be
matched, and what my next overall pick number is. No network, no warehouse connection, no
printing, and no mutation of the caller's frames.

Taking the raw payload rather than something pre-parsed is the spec's choice, and it is what puts
duplicates, out-of-order picks and unknown identifiers inside a boundary tests can reach.

Returns `taken`, `roster`, `unmatched`, `next_pick`, and `picks_made`. The last is beyond the four
the ticket names: #34 and #35 both need "how many picks have been made", and re-deriving it above
the seam would put payload handling back outside the tested boundary.

## Three things worth reviewing

**Unmatched picks are the point.** A pick whose Sleeper ID matches no board row could be a deep
flyer who was never on the board, or somebody who *is* on it whose ID resolution failed in #31 —
meaning he has just been drafted and the board still shows him available. Nothing here can tell
those apart, so an unmatched pick is never dropped and is returned named for the renderer.

**Identity is keyed on the player, not the pick number.** Sleeper refuses to draft an
already-drafted player, so a duplicate never arrives from the network. Both the duplicate and the
pick with no number come from #36's hand-marking, where the drafter's own entry is unioned into
the same list the API returns. Keying on the number instead would drop the hand-mark, because its
number is `None`, and the player would silently return to the board.

**`picks_made` reads the highest pick number, not the length of the list.** A hand-marked player
is a pick that happened but has no number. At seat 5 with 23 real picks and one hand-mark, the
length says 24 picks made and reports the next turn as pick 33 — nine away — at the moment the
drafter is actually on the clock at pick 24.

## Roster slots

A quarterback can start at QB or in the superflex; a back at RB, in the flex, or in the superflex.
So open slots are an assignment, not a count. The fill order is fixed and dull on purpose —
dedicated slot, then flex, then superflex, then bench — so what lands where can be checked by eye
at pick five rather than trusted. Slots the league does not start are left out entirely, so the
one-quarterback league's table never mentions a superflex it does not have.

## Tests

Spec cases 11, 12, 13, 16, 17, 18, 19 and 28, written before the implementation and driving it.

Three further cases were agreed in conversation and added, because the payload defences above
guard a situation Sleeper's own API cannot create, and were therefore untested for the reason they
exist. They are additions to the ticket's numbered list, not replacements for any of it.

Every test was then checked by breaking the code on purpose. Each named test caught its break:

| deliberate break | caught by |
| --- | --- |
| dedupe on the pick number | hand-marked player is taken before the API reports him |
| `picks_made = len(picks)` | hand-marked player does not advance the draft |
| no dedupe at all | case 16, and the hand-mark duplicate |
| forget the snake reversal | case 19 |
| drop unmatched picks | cases 11, 12, 16 |

That pass is also how the first version of the hand-mark case was found to be too weak: it
asserted only the duplicate direction and slept through the dropped hand-mark. It now asserts both.

32 tests pass. Additionally smoke-tested outside the suite against the real 655-row Sleeper board
and the league's actual settings, confirming the roster table matches the real starting lineup and
the input frame comes back untouched.

## Also here

`CLAUDE.md` gains `src/draft/` as the one part of `src/` that is not a medallion layer, so the
next module for this feature does not land in `gold/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)