### PR TITLE
feat: rank the remaining board by points over replacement

### DIFF
--- a/src/draft/candidates.py
+++ b/src/draft/candidates.py
@@ -1,0 +1,82 @@
+"""Subtract the players already taken from the board and rank what is left.
+
+The second half of the live draft assistant's single seam, and pure in the same way the first
+half is: no network, no warehouse connection, no printing, and nothing handed in is modified.
+`picks.ingest_picks` turns a payload into who is gone; this turns who is gone into who to take.
+
+## It is a filter and a sort, and that is the entire point
+
+Every number here was computed by the warehouse rebuild days before the draft. Nothing is
+recalculated on the night, and `points_over_replacement` in particular comes back exactly as
+the board priced it.
+
+That rule is worth stating because the tempting alternative is a *good* idea, not an obvious
+mistake. Replacement level genuinely moves during a draft — thirty backs go, so the best back
+still available is a worse player than he was at pick one — and the tool knows exactly who has
+gone, so recomputing against the survivors looks like free accuracy.
+
+It is not, for two reasons:
+
+- Replacement level means *freely available*, which is a season-long fact. By kickoff roughly
+  210 players are rostered in a 14-team league, and that end state is knowable before a single
+  pick is made — it is what the board is already computed against. The 47 players gone at pick
+  47 are a transient state that matches nothing. Recomputing would swap an accurate number for
+  a temporarily wrong one.
+- A number computed once, in memory, during a live draft cannot be checked against anything.
+  The board's value came from a pipeline that can be re-run and read; and when the tool and the
+  printed board disagree by seven points at pick eleven, the drafter has no way to tell which
+  is right and stops trusting both.
+
+The real version of that instinct — what a player is worth *to a roster whose slots are partly
+filled*, where a third back is worth less than a first — is a different question, is materially
+more machinery, and is deliberately out of scope for this feature.
+
+## Ranking, for now
+
+By points over replacement alone, highest first. Cost of waiting replaces this rule later and
+changes only the ordering: what comes back, and the promise that its values are the board's own,
+are fixed here.
+
+Ties break by name. The spec left them undecided, and left to itself a sort would order equal
+values however the board happened to arrive, which is not stable across a rebuild. Alphabetical
+is arbitrary but fixed, and because the values are on screen a reader can see that a tie is what
+it is rather than mistaking it for a judgement.
+"""
+
+import pandas as pd
+
+# What a candidate is, as far as every surface above here is concerned. The board carries thirty
+# or so columns; a candidate is the four that identify and price a player, and no more. The
+# `player_id` is not for display — it is how the survival probabilities join on when cost of
+# waiting arrives, and how anything downstream refers to a player without going through a name.
+CANDIDATE_COLUMNS = ["player_id", "player_name", "position", "team", "points_over_replacement"]
+
+
+def rank_candidates(
+    board: pd.DataFrame, taken: set[str], position: str | None = None
+) -> pd.DataFrame:
+    """The players still available, best first.
+
+    `taken` is the board's own player IDs, exactly as `ingest_picks` returns them — not the
+    picks payload, which has already been read once and should not be interpreted twice.
+    `position` narrows to one position when asked, and is matched exactly against the board's
+    own values rather than being normalized here, so that the pure function has no opinion a
+    caller has to know about.
+
+    Returns one row per available player with `CANDIDATE_COLUMNS`, in ranked order, always with
+    those columns even when nobody is left.
+    """
+    available = board.loc[~board["player_id"].isin(taken)]
+    if position is not None:
+        available = available.loc[available["position"] == position]
+
+    # `.loc` with a column list already copies, so the board itself is never touched by the
+    # sort; being explicit costs nothing and makes that guarantee readable rather than inferred.
+    return (
+        available[CANDIDATE_COLUMNS]
+        .copy()
+        .sort_values(
+            ["points_over_replacement", "player_name"], ascending=[False, True]
+        )
+        .reset_index(drop=True)
+    )

--- a/tests/test_draft_candidates.py
+++ b/tests/test_draft_candidates.py
@@ -1,0 +1,205 @@
+"""Spec cases 10, 14, 15, 25, 26 and 27 from the live draft assistant's ranking ticket.
+
+These assert what comes *out* of `rank_candidates` for a given board and set of taken players —
+never how it gets there. Fixtures are a handful of players with values chosen so the expected
+order can be worked out by eye, which is the only kind of expectation that survives a rebuild.
+
+The function takes the set of taken player IDs rather than the picks payload or the whole
+ingestion result. The payload has already been dealt with by `ingest_picks`, and a second
+function that re-read it would be a second place for duplicate and unmatched picks to be
+handled differently. One test at the bottom runs the two halves together, so the claim that
+they actually join on `player_id` is checked rather than assumed.
+"""
+
+import pandas as pd
+
+from src.draft.candidates import rank_candidates
+from src.draft.picks import ingest_picks
+
+CANDIDATE_COLUMNS = ["player_id", "player_name", "position", "team", "points_over_replacement"]
+
+
+def board(*rows: dict) -> pd.DataFrame:
+    """A board with the columns ranking reads, plus one it must leave behind."""
+    defaults = {
+        "player_id": "00-0000001",
+        "player_name": "A Back",
+        "position": "RB",
+        "team": "SF",
+        "points_over_replacement": 100.0,
+        # The real board carries thirty-odd columns. One of them is here so that "narrowed to
+        # the candidate columns" is a claim a test can fail rather than a description of a
+        # fixture that only ever had five columns to begin with.
+        "consensus_adp": 24.5,
+    }
+    return pd.DataFrame(
+        [{**defaults, **row} for row in rows],
+        # Named explicitly for the same reason the ingestion suite names them: a bare
+        # DataFrame([]) has no columns at all, which is not a shape the warehouse hands back.
+        columns=list(defaults),
+    )
+
+
+def player(player_id: str, name: str, por: float, position: str = "RB", **rest) -> dict:
+    """One board row, in the order the arguments read on the page."""
+    return {
+        "player_id": player_id,
+        "player_name": name,
+        "position": position,
+        "points_over_replacement": por,
+        **rest,
+    }
+
+
+def names(candidates: pd.DataFrame) -> list[str]:
+    """The candidate names in the order they came back."""
+    return list(candidates["player_name"])
+
+
+# 10. A player present in the picks payload never appears among the candidates.
+def test_a_taken_player_never_appears_among_the_candidates():
+    result = rank_candidates(
+        board(
+            player("00-0000001", "Taken Back", 150.0),
+            player("00-0000002", "Free Back", 120.0),
+            player("00-0000003", "Free Receiver", 90.0, position="WR"),
+        ),
+        taken={"00-0000001"},
+    )
+
+    assert names(result) == ["Free Back", "Free Receiver"]
+    # The whole feature exists to prevent a drafted player being shown as available, so the
+    # claim is his absence by ID, not merely that the list got shorter.
+    assert "00-0000001" not in set(result["player_id"])
+
+
+# 14. An empty payload returns the full board, ranked.
+def test_an_empty_payload_returns_the_whole_board_ranked():
+    result = rank_candidates(
+        board(
+            player("00-0000001", "Third Best", 90.0),
+            player("00-0000002", "Best", 150.0),
+            player("00-0000003", "Second Best", 120.0),
+        ),
+        taken=set(),
+    )
+
+    # Every row survives, and the board's own order is not what comes back — value order is.
+    assert names(result) == ["Best", "Second Best", "Third Best"]
+    assert list(result.columns) == CANDIDATE_COLUMNS
+
+
+# 15. A payload in which every player has been taken returns no candidates and does not raise.
+def test_a_fully_drafted_board_returns_no_candidates_without_raising():
+    the_board = board(
+        player("00-0000001", "A Back", 150.0),
+        player("00-0000002", "A Receiver", 120.0, position="WR"),
+    )
+
+    result = rank_candidates(the_board, taken={"00-0000001", "00-0000002"})
+
+    assert len(result) == 0
+    # An empty frame with no columns would break the renderer at the end of a draft, which is
+    # exactly when nobody wants to find out. The shape has to survive the emptiness.
+    assert list(result.columns) == CANDIDATE_COLUMNS
+
+
+# 25. Points over replacement is returned unchanged from the board and is never recomputed or
+#     rescaled.
+def test_points_over_replacement_comes_back_exactly_as_the_board_priced_it():
+    the_board = board(
+        player("00-0000001", "Gone One", 200.0),
+        player("00-0000002", "Gone Two", 180.0),
+        player("00-0000003", "Gone Three", 160.0),
+        player("00-0000004", "Still Here", 140.0),
+        # A negative value: replacement level is a real player, so someone ranked below him
+        # prices out under zero. A rescale or a floor-at-zero would quietly eat this.
+        player("00-0000005", "Below Replacement", -12.5, position="WR"),
+    )
+
+    # Most of the board is gone, which is the condition under which a recompute against the
+    # remaining players would move every surviving number. Under this rule none of them move.
+    result = rank_candidates(
+        the_board, taken={"00-0000001", "00-0000002", "00-0000003"}
+    )
+
+    assert list(result["points_over_replacement"]) == [140.0, -12.5]
+
+
+# 26. Neither input frame is mutated.
+def test_the_inputs_are_left_exactly_as_they_were_handed_in():
+    the_board = board(
+        player("00-0000001", "A Back", 150.0),
+        player("00-0000002", "A Receiver", 120.0, position="WR"),
+    )
+    board_before = the_board.copy(deep=True)
+    taken = {"00-0000001"}
+    taken_before = set(taken)
+
+    rank_candidates(the_board, taken=taken)
+
+    # The board is rebuilt days before the draft and is read by every other surface. Sorting or
+    # filtering it in place here would silently change what those surfaces see.
+    pd.testing.assert_frame_equal(the_board, board_before)
+    assert taken == taken_before
+
+
+# 27. Filtering to a single position returns only that position, ranked by the same rule.
+def test_filtering_to_one_position_returns_only_that_position_ranked_the_same_way():
+    the_board = board(
+        player("00-0000001", "Best Receiver", 150.0, position="WR"),
+        player("00-0000002", "Best Back", 190.0),
+        player("00-0000003", "Second Receiver", 130.0, position="WR"),
+        player("00-0000004", "Taken Receiver", 170.0, position="WR"),
+        player("00-0000005", "A Quarterback", 210.0, position="QB"),
+    )
+
+    result = rank_candidates(the_board, taken={"00-0000004"}, position="WR")
+
+    # Same two rules as the unfiltered ranking: taken players are gone, the rest are in value
+    # order. The higher-valued back and quarterback are excluded for position alone.
+    assert names(result) == ["Best Receiver", "Second Receiver"]
+    assert set(result["position"]) == {"WR"}
+
+
+# The case below is not from the ticket's numbered list. Ties were left undecided by the spec
+# and were agreed in conversation: order them by name, so that the ordering is stable across
+# runs and a reader can see from the equal values that it *is* a tie rather than a judgement.
+def test_players_of_equal_value_are_ordered_by_name():
+    result = rank_candidates(
+        board(
+            player("00-0000001", "Zeta Back", 120.0),
+            player("00-0000002", "Alpha Back", 120.0),
+            player("00-0000003", "Mid Back", 120.0),
+            player("00-0000004", "Clear Best", 200.0),
+        ),
+        taken=set(),
+    )
+
+    assert names(result) == ["Clear Best", "Alpha Back", "Mid Back", "Zeta Back"]
+    # The tie is visible in the output rather than resolved out of sight.
+    assert list(result["points_over_replacement"])[1:] == [120.0, 120.0, 120.0]
+
+
+# Also agreed in conversation rather than numbered: the two halves of the seam are written and
+# tested separately, so the one thing neither suite checks is that they join at all. They meet
+# on the board's `player_id`, and nothing else in either signature says so.
+def test_the_ingestion_result_feeds_the_ranking():
+    the_board = pd.DataFrame([
+        {"player_id": "00-0000001", "sleeper_id": "4034", "player_name": "Drafted Back",
+         "position": "RB", "team": "SF", "points_over_replacement": 150.0},
+        {"player_id": "00-0000002", "sleeper_id": "5849", "player_name": "Free Receiver",
+         "position": "WR", "team": "KC", "points_over_replacement": 120.0},
+    ])
+    payload = [{
+        "player_id": "4034", "roster_id": 7, "pick_no": 1,
+        "metadata": {"first_name": "Drafted", "last_name": "Back", "position": "RB"},
+    }]
+
+    ingested = ingest_picks(payload, the_board, {
+        "seat": 1, "roster_id": 1, "team_count": 14, "rounds": 15,
+        "slots": {"QB": 1, "RB": 2, "WR": 3, "TE": 1, "FLEX": 1, "SUPER_FLEX": 1,
+                  "K": 1, "DST": 1, "BENCH": 6},
+    })
+
+    assert names(rank_candidates(the_board, taken=ingested["taken"])) == ["Free Receiver"]


### PR DESCRIPTION
Closes #33.

Completes the live draft assistant's single seam. #32 gave us `ingest_picks` — payload in, who is
gone out. This adds `rank_candidates`: who is gone in, who to take out.

## What it does

`src/draft/candidates.py` filters the board to the players not yet taken, optionally narrows to one
position, and sorts by points over replacement. It is pure in the same way the ingestion half is:
no network, no warehouse connection, no printing, and neither input touched.

Cost of waiting (#37) replaces the *ordering* rule later. What comes back, and the promise that the
values are the board's own, are fixed here.

## Decisions worth reviewing

**It takes the taken set, not the payload or the ingestion result.** The payload has already been
read once by `ingest_picks`, and a second function that re-read it would be a second place for
duplicate and unmatched picks to be handled differently. Taking the set also keeps the two halves
independently testable.

**Points over replacement comes back exactly as the board priced it.** The module docstring records
why at some length, because the alternative is a *good* idea rather than an obvious mistake —
replacement level genuinely moves as a draft empties the pool, and the tool knows exactly who has
gone. It is still wrong: replacement level means *freely available*, which is a season-long fact,
and the board is already priced against the draft's knowable end state (~210 players rostered in a
14-team league). The 47 players gone at pick 47 are a transient state matching nothing. Separately,
a number computed in memory during a live draft can be checked against nothing when it disagrees
with the printed board at pick eleven. The genuinely better version of that instinct —
roster-conditional value, where a third back is worth less than a first — is already out of scope
in #29.

**Ties break by name.** The spec left them undecided; an unspecified sort orders equal values
however the board happened to arrive, which is not stable across a rebuild.

**Five columns out**, not the board's thirty-three. `player_id` earns its place not for display but
because #37 joins survival probabilities on it — by ID, never by name.

## Tests

Written before the implementation, and confirmed failing first. Spec cases 10, 14, 15, 25, 26 and
27, plus two agreed in conversation rather than numbered:

- **Ties order by name** — the case the spec left open.
- **The ingestion result feeds the ranking** — the only test that runs both halves together. Each
  suite otherwise proves its own side of the interface against its own hand-written fixture, so
  nothing executable connects them. That matters because `pandas.Series.isin` accepts sets,
  frozensets, lists and dicts alike and never raises: if `taken` ever drifted — most dangerously to
  Sleeper IDs, since both dicts in `ingest_picks` spell their key `player_id` one line apart — the
  board would silently never shrink, and a drafted player would show as available. #29 calls that
  outcome worse than having no tool.

Case 15 asserts the returned *shape* rather than just emptiness: `pd.DataFrame([])` has no columns
at all, so a future rewrite that builds rows in a list would crash the renderer at the end of a
draft, which is the worst possible moment to find out.

40 tests pass. Also verified against the real 655-row board: 5 columns out, taking the top 3 leaves
652, the QB filter gives 119, values identical to the board, board unmutated.

## Not in this PR

`draft_board` carries no bye week, so a candidate cannot show one (#29's user story 25). Filed as
#44 — it is derivable cleanly from `schedules` as a team fact, with no name matching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)