### PR TITLE
Carry each player's bye week onto the draft board

### DIFF
--- a/src/gold/draft_board.py
+++ b/src/gold/draft_board.py
@@ -131,7 +131,7 @@ _SCORING_BASES = {1.0: "ppr", 0.5: "half_ppr"}
 
 _OUTPUT_COLUMNS = [
     "league_key", "season", "format", "scoring", "player_id", "sleeper_id", "player_name",
-    "position", "team",
+    "position", "team", "bye_week",
     "ol_grade", "ol_tier",
     "projected_points", "projected_points_adjusted", "projected_floor", "projected_ceiling",
     "availability", "availability_source",
@@ -402,6 +402,104 @@ def _team_context(con: duckdb.DuckDBPyConnection, season: int) -> pd.DataFrame:
     return df[["player_id", "team", "ol_grade", "ol_tier"]]
 
 
+def _schedule(con: duckdb.DuckDBPyConnection, season: int) -> pd.DataFrame:
+    """Every regular-season game of one season, which is the only thing a bye week is readable from."""
+    return con.execute(
+        "SELECT week, home_team, away_team FROM schedules WHERE season = ? AND game_type = 'REG'",
+        [season],
+    ).df()
+
+
+def _canonical_team(team) -> str | None:
+    """One team abbreviation folded to canonical, or None where a row has no team to fold."""
+    if not isinstance(team, str) or not team.strip():
+        return None
+    return normalize_team(team)
+
+
+def bye_weeks(schedule: pd.DataFrame) -> pd.DataFrame:
+    """One row per team: the week of the season in which it has no game.
+
+    Takes a frame of `week`, `home_team` and `away_team` and reads both sides, because a team that
+    happens to be away every week it plays is still a team. Abbreviations come back canonical, so
+    the caller joins against one spelling rather than the several the sources use.
+
+    Raises where any team's answer is not exactly one week. Two byes means games are missing from
+    the frame; none means games are duplicated in it. Either way the season handed in is not a real
+    one, and a bye week is worth exactly as much as the schedule it was read from — so this stops
+    rather than picking a week, which is the failure mode that would put a wrong number on a board
+    nobody would think to re-check.
+    """
+    weeks = sorted(set(schedule["week"]))
+
+    played: dict[str, set] = {}
+    for side in ("home_team", "away_team"):
+        for team, week in zip(schedule[side], schedule["week"]):
+            played.setdefault(normalize_team(team), set()).add(week)
+
+    byes = {
+        team: [week for week in weeks if week not in weeks_played]
+        for team, weeks_played in played.items()
+    }
+
+    broken = {team: found for team, found in byes.items() if len(found) != 1}
+    if broken:
+        raise ValueError(
+            "The schedule does not give every team exactly one bye week: "
+            + "; ".join(
+                f"{team} plays every week"
+                if not found
+                else f"{team} is missing weeks {', '.join(str(week) for week in found)}"
+                for team, found in sorted(broken.items())
+            )
+            + ". That means the schedule is incomplete, so no bye week read from it can be trusted."
+        )
+
+    return pd.DataFrame(
+        [{"team": team, "bye_week": found[0]} for team, found in sorted(byes.items())]
+    )
+
+
+def add_bye_weeks(board: pd.DataFrame, schedule: pd.DataFrame) -> pd.DataFrame:
+    """The board with each player's bye week beside his team, as a copy.
+
+    A bye week is a property of a *team*, so it joins team-to-team and no name matching happens
+    anywhere. `fantasypros_adp` and `ffc_adp` both publish a `bye` column and both are the wrong
+    source: they are keyed on player names, and FantasyPros' own is missing for 5-20% of recent
+    rows, so taking a team fact through a name would be strictly worse than reading the schedule.
+
+    Both sides are folded to canonical abbreviations first. That is not a formality — the board
+    genuinely holds two spellings of Arizona at once, AZ for the players it reads from `rosters`
+    and ARI for the defense it reads from Sleeper.
+
+    A player whose team is unknown, or whose team the schedule does not cover, gets a null rather
+    than a guess. There is no sensible default for a bye week and a wrong one would quietly pile a
+    drafter's starters into the same empty week.
+    """
+    byes = bye_weeks(schedule)
+    by_team = dict(zip(byes["team"], byes["bye_week"]))
+
+    board = board.copy()
+    board["bye_week"] = pd.to_numeric(
+        board["team"].map(_canonical_team).map(by_team)
+    ).astype("Int64")
+    return board
+
+
+def _report_missing_byes(board: pd.DataFrame, league_key: str) -> None:
+    """Count the rows the schedule could not date, so a gap is a build line rather than a surprise.
+
+    Deliberately not `@console.analysis`, for the same reason `report_unmapped` isn't: a quiet
+    build is still the last place this can be noticed before a draft.
+    """
+    missing = int(board["bye_week"].isna().sum())
+    if missing:
+        console.note(
+            f"{league_key}: no bye week for {missing} rows — no team, or a team the schedule "
+            "does not cover"
+        )
+
+
 def _build_league(con: duckdb.DuckDBPyConnection, league: pd.Series, season: int) -> pd.DataFrame:
     scoring = _scoring_basis(league)
     adp_format = _league_format(league)
@@ -432,6 +530,8 @@ def _build_league(con: duckdb.DuckDBPyConnection, league: pd.Series, season: int
     df["ol_tier"] = df["ol_tier"].where(df["position"] == "RB")
     # Defenses are keyed on their own team abbreviation, so they name themselves.
     df["team"] = df["team"].fillna(df["player_id"].where(df["position"] == "DST"))
+    df = add_bye_weeks(df, _schedule(con, season))
+    _report_missing_byes(df, league["league_key"])
     df["league_key"] = league["league_key"]
     df["season"] = season
     df["format"] = adp_format

--- a/src/gold/draft_board.py
+++ b/src/gold/draft_board.py
@@ -368,7 +368,12 @@ def _team_context(con: duckdb.DuckDBPyConnection, season: int) -> pd.DataFrame:
     df = con.execute(
         """
         WITH rostered AS (
-            SELECT player_id, mode(team) AS team FROM rosters WHERE season = ? GROUP BY player_id
+            -- Normalized here rather than raw, because `rosters` does not spell a club the same
+            -- way in every season: 2026 writes Arizona as AZ where 2025 writes ARI, and this
+            -- joins one season's roster to the previous season's grades. Left raw, every Arizona
+            -- player silently loses the offensive-line tier the board exists to warn him with.
+            SELECT player_id, mode(normalize_team(team)) AS team
+            FROM rosters WHERE season = ? GROUP BY player_id
         ),
         -- Cut on the grade's own value, not on row position: ntile() would split the four teams
         -- that share a grade of exactly 66.1 across two different tiers depending on row order,

--- a/src/silver/teams.py
+++ b/src/silver/teams.py
@@ -22,7 +22,7 @@ NICKNAME_TO_ABBR = {
 ABBR_ALIASES = {
     "LAR": "LA", "JAC": "JAX", "WSH": "WAS", "GNB": "GB", "NOR": "NO",
     "SFO": "SF", "TAM": "TB", "NWE": "NE", "KAN": "KC", "LVR": "LV",
-    "ARZ": "ARI", "BLT": "BAL", "CLV": "CLE", "HST": "HOU",
+    "ARZ": "ARI", "AZ": "ARI", "BLT": "BAL", "CLV": "CLE", "HST": "HOU",
     # Relocations, mapped to the franchise's current abbreviation so a team joins to itself across
     # its move: a 2018 "OAK" row is the same O-line/roster lineage as a 2024 "LV" one. Sources
     # disagree about which era's code to use for old seasons (PFR's advstats_pass says "OAK" for

--- a/tests/test_bye_weeks.py
+++ b/tests/test_bye_weeks.py
@@ -1,0 +1,160 @@
+"""A player's bye week, derived from the schedule rather than read off an ADP source.
+
+Every case here is agreed before the implementation, per the repo's testing rule, and asserts what
+comes *out* of the two functions for a given schedule and board — never how either gets there.
+
+The fixture is a four-team, three-week season rather than a slice of the real one, because a bye
+week is only checkable by hand if the whole season is small enough to hold in your head. In `FULL`
+below, KC and LA rest in week 3 and SF and BUF rest in week 2, which can be read straight off the
+four games.
+"""
+
+import pandas as pd
+import pytest
+
+from src.gold.draft_board import add_bye_weeks, bye_weeks
+
+
+def schedule(*games: tuple[int, str, str]) -> pd.DataFrame:
+    """A schedule frame as `(week, home, away)` triples, in the columns the derivation reads."""
+    return pd.DataFrame(
+        [{"week": week, "home_team": home, "away_team": away} for week, home, away in games],
+        # Named explicitly so an empty frame still has the shape the warehouse hands back, the way
+        # the ingestion and ranking suites build theirs.
+        columns=["week", "home_team", "away_team"],
+    )
+
+
+# Three weeks, four teams, one bye each: KC and LA sit out week 3, SF and BUF sit out week 2. BUF
+# is away in both of its games, which is case 2 — it exists in this fixture on purpose.
+FULL = schedule(
+    (1, "KC", "SF"),
+    (1, "LA", "BUF"),
+    (2, "KC", "LA"),
+    (3, "SF", "BUF"),
+)
+
+# The same season spelled the way the sources actually spell it: the schedule says ARI and LA,
+# while the board carries AZ from `rosters` and LAR from anything that follows Sleeper.
+DIVERGENT = schedule(
+    (1, "ARI", "LA"),
+    (1, "KC", "SF"),
+    (2, "ARI", "KC"),
+    (3, "LA", "SF"),
+)
+
+
+def board(*rows: dict) -> pd.DataFrame:
+    """A board with the column the join reads, plus one it must carry through untouched."""
+    defaults = {
+        "player_id": "00-0000001",
+        "player_name": "A Back",
+        "position": "RB",
+        "team": "KC",
+        "points_over_replacement": 100.0,
+    }
+    return pd.DataFrame([{**defaults, **row} for row in rows], columns=list(defaults))
+
+
+def byes(frame: pd.DataFrame) -> dict:
+    """A bye frame as a plain dict, so an expectation reads as one line."""
+    return dict(zip(frame["team"], frame["bye_week"]))
+
+
+# 1. A team that plays every week but one gets that week as its bye.
+def test_the_week_a_team_has_no_game_is_its_bye():
+    assert byes(bye_weeks(FULL)) == {"KC": 3, "SF": 2, "LA": 3, "BUF": 2}
+
+
+# 2. A team appearing only as an away team is still covered.
+def test_a_team_that_is_never_at_home_still_gets_a_bye():
+    # BUF is the away side of both its games, so a derivation reading only `home_team` would not
+    # know it exists at all.
+    assert byes(bye_weeks(FULL))["BUF"] == 2
+
+
+# 3. A team missing two weeks fails loudly, naming the team and both weeks.
+def test_a_team_with_two_byes_fails_naming_the_team_and_the_weeks():
+    incomplete = schedule((1, "KC", "SF"), (2, "KC", "SF"), (3, "LA", "BUF"))
+
+    with pytest.raises(ValueError) as failure:
+        bye_weeks(incomplete)
+
+    message = str(failure.value)
+    assert "LA" in message and "BUF" in message
+    assert "1" in message and "2" in message
+
+
+# 4. A team missing no week fails the same way.
+def test_a_team_that_plays_every_week_fails_too():
+    # Not what the acceptance criteria asked for, and agreed anyway: a team with no bye at all
+    # means the same thing a team with two byes means — the schedule is not a real season — and
+    # returning a frame with that team silently absent would be worse than stopping.
+    every_week = schedule((1, "KC", "SF"), (2, "KC", "SF"))
+
+    with pytest.raises(ValueError) as failure:
+        bye_weeks(every_week)
+
+    assert "KC" in str(failure.value)
+
+
+# 5. Every board row for a team in the schedule carries that team's bye week.
+def test_every_board_row_carries_its_team_bye_week():
+    priced = board({"team": "KC"}, {"team": "SF"}, {"team": "LA"}, {"team": "BUF"})
+
+    assert list(add_bye_weeks(priced, FULL)["bye_week"]) == [3, 2, 3, 2]
+
+
+# 6. A board row spelled AZ and one spelled LAR both still find their bye.
+def test_a_divergent_abbreviation_still_finds_its_bye():
+    # The board holds both spellings of Arizona at once — twenty players arrive from `rosters` as
+    # AZ and the defense arrives from Sleeper as ARI — so this is a live collision, not a
+    # hypothetical one.
+    priced = board({"team": "AZ"}, {"team": "ARI"}, {"team": "LAR"}, {"team": "LA"})
+
+    assert list(add_bye_weeks(priced, DIVERGENT)["bye_week"]) == [3, 3, 2, 2]
+
+
+# 7. A team defense gets the same bye as that team's players.
+def test_a_defense_gets_its_team_bye_week():
+    priced = board(
+        {"player_id": "00-0000009", "position": "RB", "team": "SF"},
+        {"player_id": "SF", "player_name": "SF", "position": "DST", "team": "SF"},
+    )
+
+    assert list(add_bye_weeks(priced, FULL)["bye_week"]) == [2, 2]
+
+
+# 8. A board row whose team has no schedule rows gets a null bye, not a wrong one.
+def test_a_team_absent_from_the_schedule_gets_no_bye():
+    priced = board({"team": "MIA"}, {"team": "KC"})
+
+    with_byes = add_bye_weeks(priced, FULL)
+
+    assert pd.isna(with_byes["bye_week"][0])
+    assert with_byes["bye_week"][1] == 3
+
+
+# 9. A board row with no team at all gets a null bye and does not raise.
+def test_a_player_with_no_team_gets_no_bye():
+    # Free agents, mostly: twenty-two players on the real board were on a 2025 roster and no 2026
+    # one. They cannot have a bye because they do not have a team.
+    priced = board({"team": None}, {"team": "KC"})
+
+    with_byes = add_bye_weeks(priced, FULL)
+
+    assert pd.isna(with_byes["bye_week"][0])
+    assert with_byes["bye_week"][1] == 3
+
+
+# 10. The input board is not mutated and keeps its other columns.
+def test_the_board_handed_in_is_left_alone():
+    priced = board({"team": "KC"})
+    before = priced.copy()
+
+    with_byes = add_bye_weeks(priced, FULL)
+
+    pd.testing.assert_frame_equal(priced, before)
+    assert "bye_week" not in priced.columns
+    assert list(with_byes.columns) == [*before.columns, "bye_week"]
+    assert with_byes["points_over_replacement"][0] == 100.0

--- a/tests/test_teams.py
+++ b/tests/test_teams.py
@@ -19,6 +19,13 @@ def test_divergent_abbreviation_folds_to_canonical():
     assert normalize_team("WSH") == "WAS"
 
 
+def test_arizona_folds_to_the_canonical_abbreviation():
+    # The draft board carries both spellings at once: `rosters` writes AZ for every Arizona player
+    # while Sleeper writes ARI for the defense, so without this the same club joins to itself as
+    # two different teams and half of it goes missing.
+    assert normalize_team("AZ") == "ARI"
+
+
 def test_relocated_franchise_folds_to_its_current_abbreviation():
     assert normalize_team("OAK") == "LV"
     assert normalize_team("SD") == "LAC"


### PR DESCRIPTION
Closes #44.

## What this does

`draft_board` priced every draftable player but carried no bye week, so no surface built on it could show one. This adds it, derived from `schedules` — a bye week is the week a team has no game, which makes it a property of a *team* and a join that needs no name matching anywhere.

Two pure functions in `src/gold/draft_board.py`:

- `bye_weeks(schedule)` — a schedule frame in, one row per team out. Raises where any team's answer is not exactly one week.
- `add_bye_weeks(board, schedule)` — normalizes both sides, joins, returns a copy.

`build_draft_board` reports how many rows it could not date. On the Sleeper board that is 23, every one of them a free agent who was on a 2025 roster and no 2026 one.

## The AZ fix, in its own commit

`rosters` writes Arizona as **AZ** in 2026 and **ARI** in 2025, and `normalize_team` had no alias for it. That is the same collision AC3 names, already live and doing damage beyond bye weeks: `_team_context` joins a season's roster to the previous season's offensive-line grades, so **every Arizona player was arriving with no `ol_grade`, and four Arizona running backs with no `ol_tier`** — the board's one warning about backs behind a bad line. Arizona was the only team on the board with zero graded rows.

Fixed in two places, because the fix needs both: an `AZ -> ARI` alias in `normalize_team`, and normalization of the roster side of that join.

## Why not an ADP source

`fantasypros_adp` and `ffc_adp` both carry a `bye` column and both are wrong here. They are name-keyed rather than ID-keyed, and FantasyPros' parsing already notes the field is missing for ~90% of 2015 rows and 5-20% by the mid-2020s. Taking a team fact through a player name would be strictly worse than reading the schedule.

## Verification

Rebuilt against the warehouse: 632 of 655 Sleeper board rows carry a bye, 32 teams resolve to exactly one bye each, and the values match the ticket's spot-check (ARI 14, ATL 11, BAL 13, BUF 7, CAR 5, CHI 10, CIN 6, CLE 11). Arizona now has one spelling, 20 of 21 rows graded, all 21 on bye 14. The only running backs still without an `ol_tier` are the three with no team at all.

11 new cases, written before the implementation and agreed case by case first: 4 on the derivation and its two failure modes, 6 on the join, 1 on the normalizer. Suite is 51 passing.

## Not in this PR

- Rendering it. The ticket scopes that to whichever surface displays a candidate.
- **Mike Washington Jr.** — a 2026 rookie RB with an ADP of 158.1, on LV in both `players` and `sleeper_players` but absent from `rosters`, which is the only place the board reads `team` from. He gets a null bye here, correctly. The gap is in team sourcing rather than in bye weeks and wants its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)