### PR TITLE
feat: render the live draft board once from the terminal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,11 +33,13 @@ Dependencies are pinned in `requirements.txt` — keep it in sync when adding ne
   - `src/gold/<model>.py` — proprietary/derived models built on top of already-loaded silver
     tables (e.g. `consensus.py`). Pure SQL/Python over the warehouse — no fetch step, no network.
   - `src/draft/` — the live draft assistant, and the one part of `src/` that is not a medallion
-    layer. It is neither: it opens no connection and reads no raw file, but takes already-built
-    frames and a live API payload and returns frames. Everything about a player's value is fixed
-    by the warehouse rebuild days beforehand; nothing here recomputes any of it. New modules for
-    this feature go here rather than under `gold/`, which is documented as warehouse-to-warehouse
-    and would be a lie about what these do.
+    layer. It is neither: it reads no raw file and writes nothing at all. `src/draft/live.py` is
+    the runnable edge and the only module here that touches the world — GETs to Sleeper, and the
+    warehouse read through `src/query.py`, which opens read-only and closes per call. Every other
+    module is pure: already-built frames and a live API payload in, frames and strings out.
+    Everything about a player's value is fixed by the warehouse rebuild days beforehand; nothing
+    here recomputes any of it. New modules for this feature go here rather than under `gold/`,
+    which is documented as warehouse-to-warehouse and would be a lie about what these do.
 - `if __name__ == "__main__":` in each source module runs the full fetch→load sequence for that
   source end to end.
 - Console output goes through `src/console.py`, never a bare `print`:

--- a/README.md
+++ b/README.md
@@ -412,6 +412,17 @@ sequence:
 ./scripts/build_warehouse.sh
 ```
 
+On draft night, render the Sleeper board once and exit:
+
+```bash
+python -m src.draft.live              # the top 30 still available
+python -m src.draft.live --limit 50
+```
+
+It resolves the seat from the draft order, subtracts the picks already made, and shows the roster
+so far and the next overall pick number. It reads the warehouse read-only, refuses to run against
+a build more than a day old, and has no code path that could submit a pick.
+
 Query the warehouse with the DuckDB CLI or Python:
 
 ```bash

--- a/src/draft/live.py
+++ b/src/draft/live.py
@@ -1,0 +1,208 @@
+"""Render the live draft board once, from the terminal, and exit.
+
+    python -m src.draft.live
+    python -m src.draft.live --limit 50
+
+The first thing here that can be pointed at a real draft. It resolves my seat from the draft
+order, reads the picks made so far, subtracts them from the board the warehouse built days ago,
+and prints what is left. Then it stops — refreshing as picks come in is the next ticket.
+
+## This module is the edge, and the only part of `src/draft/` that is
+
+`picks`, `candidates`, `seat` and `render` are all pure: frames and payloads in, frames and
+strings out. Everything that touches the world is here, in one file, so that "does this tool
+write anything" is a question answered by reading one module rather than four.
+
+What it touches, exhaustively:
+
+- Four HTTP **GET**s to Sleeper — the user, the league's drafts, the draft, the picks. There is no
+  POST anywhere in this package, which is what "never makes a pick" means in practice: the tool
+  has no code path that could submit one, rather than a flag saying it shouldn't.
+- One read of `data/warehouse.duckdb` through `src.query.q`, which opens read-only and closes
+  before it returns. A draft-night process cannot corrupt what the pipeline built, and cannot hold
+  the file lock against a rebuild either.
+
+## Nothing is typed in
+
+The league ID and season come from `src.silver.sleeper`, so the repo holds one league ID rather
+than two that can disagree. Everything else — seat, roster, team count, rounds, starting slots —
+is read out of the draft record. The one configured name is the Sleeper username below, which is
+resolved to a user ID against the API and then to a seat against the draft order.
+
+## Why it refuses to run against an old warehouse
+
+Every number on screen was computed by a warehouse rebuild and is exactly as current as that
+rebuild. A board built a week ago still prices a player who has since been ruled out for the
+season, and prices him with the same confidence as everyone else — there is nothing on the screen
+to suggest the file is old. So staleness is a refusal, not a warning, and the tool reports the
+build time it found so the answer to "how old?" comes from the tool rather than from `ls -l`.
+
+Console output goes through a plain `print` here rather than `src.console`, for the same reason
+`src.summary` does: those helpers format build progress — a table name and a row count — and this
+is a screen being drawn.
+"""
+
+import argparse
+from datetime import datetime, timedelta
+
+import pandas as pd
+import requests
+
+from src.draft.candidates import rank_candidates
+from src.draft.picks import ingest_picks
+from src.draft.render import render_board
+from src.draft.seat import resolve_seat
+from src.query import WAREHOUSE_PATH, q
+from src.silver.sleeper import LEAGUE_ID, SEASON
+
+BASE_URL = "https://api.sleeper.app/v1"
+
+# Which board to read: `draft_board` holds a row per player *per league*, priced in that league's
+# scoring and slots, so the key picks out the superflex league's prices rather than the ESPN one's.
+LEAGUE_KEY = "sleeper"
+
+# The one thing configured by hand. A username rather than a user ID because it is the string
+# that can be checked by eye against the app; it is resolved to an ID before anything uses it.
+USERNAME = "commonfox"
+
+# How old a warehouse may be and still be drafted off. A day means the board was built with the
+# last of the preseason news in it — the window in which starters are named and seasons end.
+MAX_WAREHOUSE_AGE = timedelta(hours=24)
+
+# About a screenful. The count above the table always names the total, so a cut list never reads
+# as a short one, and `--limit` is there for looking deeper.
+DEFAULT_LIMIT = 30
+
+# A draft night has a pick clock. A request that hangs is worse than one that fails, because a
+# failure can be retried by pressing up-enter and a hang cannot be anything.
+TIMEOUT_SECONDS = 10
+
+
+def _get(path: str):
+    response = requests.get(f"{BASE_URL}{path}", timeout=TIMEOUT_SECONDS)
+    response.raise_for_status()
+    return response.json()
+
+
+def check_recency(
+    built_at: datetime, now: datetime, max_age: timedelta = MAX_WAREHOUSE_AGE
+) -> None:
+    """Refuse to draft off a warehouse older than `max_age`, saying when it was built.
+
+    Pure, so the rule is checkable without a clock or a file. The build time is in the message
+    because "the warehouse is stale" is not actionable and "the warehouse is from last Tuesday"
+    is.
+    """
+    age = now - built_at
+    if age <= max_age:
+        return
+    raise RuntimeError(
+        f"The warehouse was last built {built_at:%Y-%m-%d %H:%M}, "
+        f"{age.total_seconds() / 3600:.0f}h ago — older than the "
+        f"{max_age.total_seconds() / 3600:.0f}h this tool will draft off. Every value it would "
+        "show was computed by that build. Run scripts/build_warehouse.sh and start again."
+    )
+
+
+def warehouse_built_at() -> datetime:
+    """When the warehouse was last written, which is when its numbers were computed."""
+    if not WAREHOUSE_PATH.exists():
+        raise RuntimeError(
+            f"{WAREHOUSE_PATH} does not exist — run scripts/build_warehouse.sh before drafting."
+        )
+    return datetime.fromtimestamp(WAREHOUSE_PATH.stat().st_mtime)
+
+
+def user_id(username: str) -> str:
+    """The Sleeper ID behind a username, which is what the draft order is keyed on."""
+    user = _get(f"/user/{username}")
+    if not user or not user.get("user_id"):
+        raise RuntimeError(f"Sleeper has no user called {username!r}.")
+    return user["user_id"]
+
+
+def find_draft(league_id: str, season: int) -> dict:
+    """This season's draft for one league, fetched whole.
+
+    Two calls, deliberately. The league's draft list carries the draft order but *not*
+    `slot_to_roster_id`, so the record has to be fetched by ID to learn which roster a seat's
+    picks land on — and without that, my own picks cannot be told from anyone else's.
+    """
+    drafts = [
+        draft for draft in _get(f"/league/{league_id}/drafts")
+        if str(draft.get("season")) == str(season)
+    ]
+    if not drafts:
+        raise RuntimeError(f"League {league_id} has no {season} draft.")
+
+    # Newest first, for the case where a league has a redrafted or restarted draft on record.
+    newest = max(drafts, key=lambda draft: draft.get("created") or 0)
+    return _get(f"/draft/{newest['draft_id']}")
+
+
+def load_board(league_key: str = LEAGUE_KEY) -> pd.DataFrame:
+    """One league's priced board, read-only, exactly as the last rebuild left it.
+
+    Only the columns the draft night needs: enough to recognise a pick (`sleeper_id`), to rank
+    what is left (`points_over_replacement`) and to show it (the rest).
+    """
+    board = q(
+        """
+        SELECT player_id, sleeper_id, player_name, position, team,
+               points_over_replacement, bye_week
+        FROM draft_board
+        WHERE league_key = ?
+        """,
+        [league_key],
+    )
+    if board.empty:
+        raise RuntimeError(
+            f"draft_board holds no rows for league {league_key!r} — the warehouse has been built "
+            "without it. Run scripts/build_warehouse.sh."
+        )
+    return board
+
+
+def render_once(limit: int = DEFAULT_LIMIT) -> str:
+    """Everything, once: fetch, resolve, subtract, rank, and give back the screen."""
+    board = load_board()
+    draft = find_draft(LEAGUE_ID, SEASON)
+    league = resolve_seat(draft, user_id(USERNAME))
+    result = ingest_picks(_get(f"/draft/{draft['draft_id']}/picks"), board, league)
+
+    # The bye week is joined back on by ID rather than carried through the ranking: what
+    # `rank_candidates` returns is a fixed contract, and a display column is not the ranking's
+    # business. Joining on `player_id` is the same identity the whole feature runs on.
+    candidates = rank_candidates(board, result["taken"]).merge(
+        board[["player_id", "bye_week"]], on="player_id", how="left"
+    )
+    return render_board(candidates, result, league, limit)
+
+
+def main(limit: int = DEFAULT_LIMIT) -> None:
+    built_at = warehouse_built_at()
+    check_recency(built_at, datetime.now())
+    print(render_once(limit))
+    print(f"\nboard built {built_at:%Y-%m-%d %H:%M} — read-only, no pick is ever submitted")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Show what is still on the board in the live Sleeper draft."
+    )
+    parser.add_argument(
+        "--limit", type=int, default=DEFAULT_LIMIT,
+        help=f"how many candidates to show (default {DEFAULT_LIMIT})",
+    )
+    arguments = parser.parse_args()
+
+    try:
+        main(arguments.limit)
+    except RuntimeError as error:
+        # A stale or missing warehouse is a thing the drafter has to fix, not a bug — a traceback
+        # in front of a pick clock buries the one sentence that says what to do.
+        print(f"\n{error}\n")
+        raise SystemExit(1)
+    except requests.RequestException as error:
+        print(f"\nSleeper did not answer: {error}\n")
+        raise SystemExit(1)

--- a/src/draft/render.py
+++ b/src/draft/render.py
@@ -1,0 +1,137 @@
+"""Turn what the seam returned into the screen the drafter reads.
+
+Pure in the same way the two halves above it are: frames and dicts in, one string out. Nothing
+here queries, fetches or prints, which is what makes the screen itself testable rather than
+something that has to be eyeballed on a draft night to know whether it is right.
+
+## What goes where, and why in that order
+
+    seat, picks made, next pick        one line, because it is the thing checked against the app
+    unmatched picks                    loud, and above everything else
+    my roster                          short, and answers "what do I still need"
+    best available                     the long list, last
+
+The order is the only real decision here, and it is decided by what a wrong screen costs. An
+unmatched pick means a player may have been drafted and still be sitting on this board looking
+available — the exact failure the feature exists to prevent — so it goes where it cannot be
+scrolled past, above the board rather than under thirty rows of it. Everything else is ordered by
+how often it is read, which puts the candidate list at the bottom where the eye lands.
+
+## Missing values print as gaps, never as values
+
+A player with no bye week gets a dash. Pandas renders a missing nullable integer as `<NA>` and a
+missing float as `nan`, and either one in a column of week numbers reads as a number that happens
+to look odd rather than as an absence. The same rule applies to a missing team. Nothing here
+substitutes a plausible value for a missing one — a guessed bye week would quietly pile a
+drafter's starters into the same empty week, which is worse than an obvious blank.
+"""
+
+import pandas as pd
+
+# Wide enough for the longest name a board actually carries (`Amon-Ra St. Brown`, `Marvin Harrison
+# Jr.`) without wrapping, which would break the column alignment the eye is using to scan.
+_NAME_WIDTH = 24
+
+# How a value that is not there is written. One character, in a column of numbers, so that it
+# cannot be misread as one.
+_MISSING = "-"
+
+
+def _text(value) -> str:
+    """One cell, with pandas' spellings of absence turned into a visible gap."""
+    if value is None or pd.isna(value):
+        return _MISSING
+    return str(value)
+
+
+def _bye(value) -> str:
+    """A bye week as a plain week number — the board stores it as a nullable integer."""
+    if value is None or pd.isna(value):
+        return _MISSING
+    return str(int(value))
+
+
+def _header(picks: dict, league: dict) -> str:
+    """Seat, progress and next turn: the line that gets checked against the Sleeper app."""
+    next_pick = picks["next_pick"]
+    turn = f"next pick #{next_pick}" if next_pick is not None else "draft complete"
+    return (
+        f"seat {league['seat']} of {league['team_count']}"
+        f"  ·  {picks['picks_made']} picks made"
+        f"  ·  {turn}"
+    )
+
+
+def _unmatched(unmatched: list[dict]) -> list[str]:
+    """The warning, or nothing at all when there is nothing wrong.
+
+    Named rather than counted: "3 picks could not be matched" tells a drafter that something is
+    wrong without telling him which player to distrust, and the name is the only part he can act
+    on in the ninety seconds he has.
+    """
+    if not unmatched:
+        return []
+
+    lines = [
+        "",
+        f"!! {len(unmatched)} UNMATCHED "
+        f"{'PICK' if len(unmatched) == 1 else 'PICKS'} — this board may be showing a drafted "
+        "player as available",
+    ]
+    for pick in unmatched:
+        number = pick.get("pick_no")
+        where = f"pick {number}" if number is not None else "hand-marked"
+        lines.append(
+            f"!!   {where:<14}{_text(pick.get('player_name'))} "
+            f"({_text(pick.get('position'))}, Sleeper {_text(pick.get('sleeper_id'))})"
+        )
+    return lines
+
+
+def _roster(roster: pd.DataFrame, league: dict) -> list[str]:
+    """My lineup, one row per slot the league starts, filled against how many it starts."""
+    lines = ["", f"My roster — roster {league['roster_id']}"]
+    for row in roster.itertuples():
+        players = ", ".join(row.players) if row.players else _MISSING
+        # The bench has no target to fill, so it is counted rather than scored out of anything.
+        count = f"{row.filled:>3}" if row.starts == 0 else f"{row.filled}/{row.starts}"
+        lines.append(f"  {row.slot:<12}{count:<5}{players}")
+    return lines
+
+
+def _candidates(candidates: pd.DataFrame, limit: int) -> list[str]:
+    """The board that is left, best first, cut to what fits on a screen."""
+    shown = candidates.head(limit)
+    lines = [
+        "",
+        f"Best available — {len(shown)} of {len(candidates)}",
+        f"  {'#':>3}  {'POS':<5}{'PLAYER':<{_NAME_WIDTH}}{'TM':<5}{'BYE':>3}{'PoR':>9}",
+    ]
+    if shown.empty:
+        lines.append("  nobody left on the board")
+        return lines
+
+    for rank, row in enumerate(shown.itertuples(), start=1):
+        lines.append(
+            f"  {rank:>3}  {_text(row.position):<5}{_text(row.player_name):<{_NAME_WIDTH}}"
+            f"{_text(row.team):<5}{_bye(row.bye_week):>3}"
+            f"{row.points_over_replacement:>9.1f}"
+        )
+    return lines
+
+
+def render_board(
+    candidates: pd.DataFrame, picks: dict, league: dict, limit: int = 30
+) -> str:
+    """The whole screen as one string.
+
+    `candidates` is what `rank_candidates` returned with the board's `bye_week` joined on,
+    `picks` is what `ingest_picks` returned, and `league` is the shape `resolve_seat` read out
+    of the draft record. `limit` is how much of the board to show; the count above the table
+    always names the total, so a cut list never reads as a short one.
+    """
+    lines = [_header(picks, league)]
+    lines += _unmatched(picks["unmatched"])
+    lines += _roster(picks["roster"], league)
+    lines += _candidates(candidates, limit)
+    return "\n".join(lines)

--- a/src/draft/seat.py
+++ b/src/draft/seat.py
@@ -1,0 +1,104 @@
+"""Work out which seat is mine, and what shape the draft is, from the draft record itself.
+
+Sleeper's `GET /draft/<id>` already knows everything the pick arithmetic needs — where I sit, how
+many teams there are, how many rounds, and which lineup slots the league starts. So none of it is
+typed in. That is worth more than tidiness: the one thing a drafter would have to type is the
+number that silently corrupts every pick estimate if it is off by one, and it would be typed in
+the thirty seconds before a draft starts.
+
+## Two maps, and they are not the same map
+
+The record carries both `draft_order` and `slot_to_roster_id`, and the temptation is to read one
+and assume the other:
+
+- `draft_order` maps a **user** to a **seat** — where in the snake that manager picks.
+- `slot_to_roster_id` maps a **seat** to a **roster** — which roster that seat's picks land on.
+
+In this league seat 1 is roster 6, so the two disagree for almost everybody. The seat drives the
+pick arithmetic and the roster ID is how a pick is recognised as *mine*, which means confusing
+them does not fail loudly: it fills my lineup with somebody else's players while my own picks come
+back as another manager's, and the board keeps looking plausible throughout.
+
+## What it refuses
+
+A draft that is not a snake, and a draft whose order has not been drawn yet. Both are refusals
+rather than defaults because the alternative is a pick number that is wrong without looking wrong
+— `next_pick_number` reverses every even round, so against a linear draft it is right in round one
+and wrong from round two onwards, which is the worst shape an error can have on a draft night.
+"""
+
+# Sleeper's own settings keys, mapped onto the slot names `picks.SLOT_ELIGIBILITY` uses. `slots_bn`
+# is left out: the bench is whoever does not fit a starting slot, not a slot players are assigned
+# to. `slots_p` has never been seen on a Sleeper league — the punter is the ESPN league's oddity —
+# and is carried anyway so that a league which does start one is described rather than silently
+# short a slot.
+SLOT_SETTINGS = {
+    "QB": "slots_qb",
+    "RB": "slots_rb",
+    "WR": "slots_wr",
+    "TE": "slots_te",
+    "FLEX": "slots_flex",
+    "SUPER_FLEX": "slots_super_flex",
+    "K": "slots_k",
+    "P": "slots_p",
+    "DST": "slots_def",
+}
+
+
+def _slots(settings: dict) -> dict[str, int]:
+    """The starting lineup, keeping only the slots this league actually starts.
+
+    A slot the league does not use is absent rather than zero, so the one-quarterback league's
+    lineup never shows an empty superflex row and this league's never shows a punter.
+    """
+    return {
+        slot: int(settings[key])
+        for slot, key in SLOT_SETTINGS.items()
+        if int(settings.get(key) or 0) > 0
+    }
+
+
+def resolve_seat(draft: dict, user_id: str) -> dict:
+    """The league shape `ingest_picks` takes, read out of one draft record.
+
+    Returns `seat` and `roster_id` for the drafter, `team_count` and `rounds` for the snake, and
+    `slots` for the lineup — the exact dict the ingestion seam expects, so nothing between here
+    and there has to know Sleeper's spelling of anything.
+    """
+    if draft.get("type") != "snake":
+        raise ValueError(
+            f"This draft is a {draft.get('type')!r} draft, and every pick number this tool "
+            "reports assumes a snake. Refusing rather than reporting pick numbers that would be "
+            "right in round one and wrong from round two."
+        )
+
+    order = draft.get("draft_order") or {}
+    if not order:
+        raise ValueError(
+            "This draft has no draft order yet — Sleeper populates it when the order is drawn. "
+            "Until then there is no seat to resolve, and no honest way to guess one."
+        )
+
+    seat = order.get(str(user_id))
+    if seat is None:
+        raise ValueError(
+            f"User {user_id} holds no seat in this draft, which has {len(order)}. Check the "
+            "configured username against the league you are drafting in."
+        )
+    seat = int(seat)
+
+    roster_id = (draft.get("slot_to_roster_id") or {}).get(str(seat))
+    if roster_id is None:
+        raise ValueError(
+            f"Seat {seat} maps to no roster in this draft. Without that, a pick of mine cannot "
+            "be told apart from anyone else's."
+        )
+
+    settings = draft.get("settings") or {}
+    return {
+        "seat": seat,
+        "roster_id": int(roster_id),
+        "team_count": int(settings["teams"]),
+        "rounds": int(settings["rounds"]),
+        "slots": _slots(settings),
+    }

--- a/tests/test_draft_recency.py
+++ b/tests/test_draft_recency.py
@@ -1,0 +1,42 @@
+"""The guard that stops the tool drafting off a stale board.
+
+Cases 8 and 9 of the terminal render ticket, plus the boundary that defines "older than".
+
+Every number the assistant shows was computed by a warehouse rebuild, so the board is exactly as
+current as that rebuild and no more. A board built before the last week of preseason still shows a
+player who has since been ruled out for the year, and it shows him with the same confident value
+as everyone else — there is nothing on screen to suggest the file is old. So the check is a refusal
+rather than a warning, and it reports the build time it found so the answer to "how stale?" comes
+from the tool rather than from `ls -l`.
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from src.draft.live import MAX_WAREHOUSE_AGE, check_recency
+
+NOW = datetime(2026, 9, 3, 18, 30)
+
+
+# 8. A warehouse inside the window passes.
+def test_a_warehouse_built_today_is_accepted():
+    check_recency(NOW - timedelta(hours=3), NOW)
+
+
+# 9. An older one raises, and the message carries the build time it found.
+def test_a_stale_warehouse_refuses_and_reports_when_it_was_built():
+    built = NOW - timedelta(days=6)
+    with pytest.raises(RuntimeError) as caught:
+        check_recency(built, NOW)
+    message = str(caught.value)
+    assert built.strftime("%Y-%m-%d") in message
+    assert built.strftime("%H:%M") in message
+
+
+def test_the_window_is_the_configured_one_and_its_edge_is_not_stale():
+    # Exactly at the limit still runs; a minute past it does not. Stated as a case because
+    # "older than 24 hours" has to mean something exact at 6pm on a draft night.
+    check_recency(NOW - MAX_WAREHOUSE_AGE, NOW)
+    with pytest.raises(RuntimeError):
+        check_recency(NOW - MAX_WAREHOUSE_AGE - timedelta(minutes=1), NOW)

--- a/tests/test_draft_render.py
+++ b/tests/test_draft_render.py
@@ -1,0 +1,229 @@
+"""What the drafter actually sees, for a given board and a given set of picks.
+
+Cases 10-17 of the terminal render ticket. `render_board` is pure — frames in, one string out —
+so these assert the screen itself rather than capturing stdout, and none of them reaches into how
+the string is assembled.
+
+Two things are asserted harder than the rest, because they are the ones that cost a pick:
+
+- An unmatched pick is named *and* appears above the candidate list. A warning printed below
+  thirty rows of board is a warning nobody reads at pick eleven.
+- A player with no bye week shows a dash. `nan` and `<NA>` are what pandas prints for a missing
+  Int64, and either one on a draft card reads as data rather than as a gap.
+"""
+
+import pandas as pd
+
+from src.draft.candidates import rank_candidates
+from src.draft.picks import ingest_picks
+from src.draft.render import render_board
+
+SLOTS = {"QB": 1, "RB": 2, "WR": 2, "TE": 1, "FLEX": 1, "SUPER_FLEX": 1, "K": 1, "DST": 1}
+
+LEAGUE = {"seat": 1, "roster_id": 6, "team_count": 14, "rounds": 15, "slots": SLOTS}
+
+
+def candidates(*rows: dict) -> pd.DataFrame:
+    """The frame the ranking hands over, with the bye week joined on beside it."""
+    defaults = {
+        "player_id": "00-0000001",
+        "player_name": "A Back",
+        "position": "RB",
+        "team": "SF",
+        "points_over_replacement": 100.0,
+        "bye_week": 9,
+    }
+    frame = pd.DataFrame(
+        [{**defaults, **row} for row in rows], columns=list(defaults)
+    )
+    # The board carries the bye as a nullable integer, which is the type that prints `<NA>`.
+    frame["bye_week"] = frame["bye_week"].astype("Int64")
+    return frame
+
+
+def roster(*rows: tuple) -> pd.DataFrame:
+    """A lineup as `ingest_picks` reports it: one row per slot the league actually starts."""
+    return pd.DataFrame(
+        [
+            {
+                "slot": slot,
+                "starts": starts,
+                "filled": len(players),
+                "open": max(starts - len(players), 0),
+                "players": list(players),
+            }
+            for slot, starts, players in rows
+        ]
+    )
+
+
+def ingested(**overrides) -> dict:
+    """What the ingestion seam returns, defaulted to a quiet draft with nothing wrong."""
+    return {
+        "taken": set(),
+        "roster": roster(("QB", 1, []), ("RB", 2, []), ("SUPER_FLEX", 1, [])),
+        "unmatched": [],
+        "next_pick": 29,
+        "picks_made": 28,
+        **overrides,
+    }
+
+
+def line_naming(out: str, text: str) -> str:
+    """The one rendered line that mentions something, so a claim is about that row alone."""
+    matches = [line for line in out.splitlines() if text in line]
+    assert len(matches) == 1, f"expected exactly one line naming {text!r}, got {matches}"
+    return matches[0]
+
+
+def section(out: str, title: str) -> list[str]:
+    """The indented rows under one section heading — headings start at the left margin."""
+    lines = out.splitlines()
+    start = next(index for index, line in enumerate(lines) if line.startswith(title))
+    rows = []
+    for line in lines[start + 1:]:
+        if line and not line.startswith(" "):
+            break
+        if line.strip():
+            rows.append(line)
+    return rows
+
+
+# 10. Each candidate line carries value, position, team and bye week.
+def test_a_candidate_is_shown_with_his_value_position_team_and_bye():
+    out = render_board(
+        candidates({"player_name": "Bijan Robinson", "position": "RB", "team": "ATL",
+                    "bye_week": 11, "points_over_replacement": 178.4}),
+        ingested(),
+        LEAGUE,
+    )
+    row = line_naming(out, "Bijan Robinson")
+    assert "RB" in row
+    assert "ATL" in row
+    assert "11" in row
+    assert "178.4" in row
+
+
+# 11. A missing bye week renders blank, never `nan` and never a guessed week.
+def test_a_player_with_no_bye_week_shows_a_gap_rather_than_a_number():
+    out = render_board(
+        candidates({"player_name": "No Schedule", "bye_week": None}), ingested(), LEAGUE
+    )
+    row = line_naming(out, "No Schedule")
+    assert "nan" not in row.lower()
+    assert "<NA>" not in row
+    assert "-" in row
+
+
+# 12. The next overall pick number and the picks-made count appear.
+def test_the_next_pick_number_and_the_picks_made_are_shown():
+    out = render_board(candidates({}), ingested(next_pick=29, picks_made=28), LEAGUE)
+    header = out.splitlines()[0]
+    assert "#29" in header
+    assert "28" in header
+
+
+# 13. The roster is shown slot by slot, superflex included, with open slots visible.
+def test_the_roster_is_shown_by_slot_including_the_superflex():
+    out = render_board(
+        candidates({}),
+        ingested(
+            roster=roster(
+                ("QB", 1, ["Josh Allen"]),
+                ("RB", 2, []),
+                ("SUPER_FLEX", 1, ["Jayden Daniels"]),
+            )
+        ),
+        LEAGUE,
+    )
+    rows = section(out, "My roster")
+    assert any("QB" in row and "Josh Allen" in row for row in rows)
+    assert any("SUPER_FLEX" in row and "Jayden Daniels" in row for row in rows)
+    # Two backs still to find, which is the whole reason to look at this block mid-draft.
+    assert any(row.strip().startswith("RB") and "0/2" in row for row in rows)
+
+
+# 14. An unmatched pick becomes a prominent warning naming the player; several all appear.
+def test_an_unmatched_pick_is_a_warning_naming_the_player_above_the_board():
+    out = render_board(
+        candidates({"player_name": "Bijan Robinson"}),
+        ingested(unmatched=[
+            {"sleeper_id": "12345", "player_name": "Someone Unknown", "position": "WR",
+             "pick_no": 14},
+        ]),
+        LEAGUE,
+    )
+    assert "UNMATCHED" in out
+    warning = line_naming(out, "Someone Unknown")
+    assert out.index(warning) < out.index(line_naming(out, "Bijan Robinson"))
+
+
+def test_every_unmatched_pick_is_named():
+    out = render_board(
+        candidates({}),
+        ingested(unmatched=[
+            {"sleeper_id": "1", "player_name": "First Unknown", "position": "WR", "pick_no": 3},
+            {"sleeper_id": "2", "player_name": "Second Unknown", "position": "TE", "pick_no": 9},
+        ]),
+        LEAGUE,
+    )
+    assert "First Unknown" in out
+    assert "Second Unknown" in out
+
+
+# 15. With nothing unmatched there is no warning block at all.
+def test_a_clean_draft_shows_no_warning():
+    out = render_board(candidates({}), ingested(), LEAGUE)
+    assert "UNMATCHED" not in out
+
+
+# 16. A finished draft says so instead of printing `None` for the next pick.
+def test_a_finished_draft_says_so_rather_than_printing_none():
+    out = render_board(candidates({}), ingested(next_pick=None, picks_made=210), LEAGUE)
+    header = out.splitlines()[0]
+    assert "None" not in header
+    assert "complete" in header.lower()
+
+
+# 17. An empty candidate list renders without raising.
+def test_a_board_with_nobody_left_still_renders():
+    empty = candidates().iloc[0:0]
+    out = render_board(empty, ingested(), LEAGUE)
+    assert "My roster" in out
+
+
+def test_only_the_asked_for_number_of_candidates_are_shown():
+    many = candidates(*[
+        {"player_id": f"00-000000{index}", "player_name": f"Player {index}",
+         "points_over_replacement": 100.0 - index}
+        for index in range(10)
+    ])
+    out = render_board(many, ingested(), LEAGUE, limit=3)
+    assert "Player 2" in out
+    assert "Player 3" not in out
+
+
+def test_the_three_halves_join_on_a_real_payload():
+    """Ingestion, ranking and rendering run together, so the joins are checked not assumed."""
+    board = pd.DataFrame([
+        {"player_id": "00-0000001", "sleeper_id": "4034", "player_name": "A Back",
+         "position": "RB", "team": "SF", "points_over_replacement": 120.0, "bye_week": 9},
+        {"player_id": "00-0000002", "sleeper_id": "4035", "player_name": "A Receiver",
+         "position": "WR", "team": "KC", "points_over_replacement": 80.0, "bye_week": 6},
+    ])
+    board["bye_week"] = board["bye_week"].astype("Int64")
+
+    picks = [{
+        "player_id": "4034", "roster_id": 6, "pick_no": 1,
+        "metadata": {"first_name": "A", "last_name": "Back", "position": "RB"},
+    }]
+    result = ingest_picks(picks, board, LEAGUE)
+    ranked = rank_candidates(board, result["taken"]).merge(
+        board[["player_id", "bye_week"]], on="player_id", how="left"
+    )
+
+    out = render_board(ranked, result, LEAGUE)
+    assert "A Receiver" in out
+    # Drafted, by me: off the board and onto the roster, not both and not neither.
+    assert any("A Back" in row for row in section(out, "My roster"))
+    assert not any("A Back" in row for row in section(out, "Best available"))

--- a/tests/test_draft_seat.py
+++ b/tests/test_draft_seat.py
@@ -1,0 +1,114 @@
+"""Which seat is mine, read from the draft record rather than typed in.
+
+Cases 1-7 of the terminal render ticket. Every one asserts what comes *out* of `resolve_seat`
+for a draft record shaped the way Sleeper's own `GET /draft/<id>` returns it — string keys,
+integer values, slots spelled `slots_super_flex`.
+
+The fixture below is this league's real draft in miniature, and the one number in it worth
+saying out loud is that **seat 1 holds roster 6**. Sleeper hands back two separate maps for a
+reason: `draft_order` places a user in the snake, `slot_to_roster_id` says which roster that
+seat's picks land on. A tool that assumed they were the same would put another manager's picks
+on my roster and lose mine, and would do it silently. So they differ here in every fixture.
+"""
+
+import pytest
+
+from src.draft.seat import resolve_seat
+
+ME = "1154199555601219584"
+SOMEONE_ELSE = "1263304885919551488"
+
+
+def draft(**overrides) -> dict:
+    """One draft record, as Sleeper returns it, with this league's real shape."""
+    record = {
+        "draft_id": "1390836962482487296",
+        "type": "snake",
+        "status": "pre_draft",
+        "season": "2026",
+        # Sleeper keys this on the user and values it with the seat, both as they arrive: the
+        # user IDs are strings and the seats are bare integers.
+        "draft_order": {ME: 1, SOMEONE_ELSE: 2},
+        # And keys this one on the seat *as a string*, valued with the roster. Seat 1 is roster
+        # 6 in the real draft, so nothing here can pass by treating the two as interchangeable.
+        "slot_to_roster_id": {"1": 6, "2": 7},
+        "settings": {
+            "teams": 14,
+            "rounds": 15,
+            "slots_qb": 1,
+            "slots_rb": 2,
+            "slots_wr": 2,
+            "slots_te": 1,
+            "slots_flex": 1,
+            "slots_super_flex": 1,
+            "slots_k": 1,
+            "slots_def": 1,
+            "slots_bn": 5,
+        },
+    }
+    return {**record, **overrides}
+
+
+# 1. The seat is read from the draft order for the drafter's user ID.
+def test_the_seat_comes_from_the_draft_order():
+    assert resolve_seat(draft(), ME)["seat"] == 1
+    assert resolve_seat(draft(), SOMEONE_ELSE)["seat"] == 2
+
+
+# 2. The roster ID is read from slot_to_roster_id for that seat, which is not the seat.
+def test_the_roster_id_comes_from_the_seat_to_roster_map():
+    resolved = resolve_seat(draft(), ME)
+    assert resolved["seat"] == 1
+    assert resolved["roster_id"] == 6
+
+
+# 3. Team count and rounds come from the draft's own settings.
+def test_the_snake_shape_comes_from_the_drafts_settings():
+    resolved = resolve_seat(draft(), ME)
+    assert resolved["team_count"] == 14
+    assert resolved["rounds"] == 15
+
+
+# 4. Starting slots come from the settings, superflex included, in the shape ingestion wants.
+def test_the_starting_slots_come_from_the_drafts_settings():
+    slots = resolve_seat(draft(), ME)["slots"]
+    assert slots["QB"] == 1
+    assert slots["RB"] == 2
+    assert slots["WR"] == 2
+    assert slots["TE"] == 1
+    assert slots["FLEX"] == 1
+    # The slot that makes this league draft differently from the other one.
+    assert slots["SUPER_FLEX"] == 1
+    assert slots["K"] == 1
+    assert slots["DST"] == 1
+
+
+def test_a_slot_the_league_does_not_start_is_not_reported_as_one():
+    # Sleeper leagues have no punter slot; the ESPN one does. A zero must not become a row in
+    # the drafter's lineup, or the table describes a league nobody is in.
+    slots = resolve_seat(draft(), ME)["slots"]
+    assert slots.get("P", 0) == 0
+
+
+# 5. A user absent from the draft order raises, naming him.
+def test_a_user_who_is_not_in_this_draft_raises_and_names_him():
+    stranger = "9999999999999999999"
+    with pytest.raises(ValueError) as caught:
+        resolve_seat(draft(), stranger)
+    assert stranger in str(caught.value)
+
+
+# 6. A draft whose order has not been drawn yet raises and says so.
+def test_an_undrawn_draft_order_raises_rather_than_guessing_a_seat():
+    with pytest.raises(ValueError) as caught:
+        resolve_seat(draft(draft_order=None), ME)
+    assert "order" in str(caught.value).lower()
+
+
+# 7. A non-snake draft refuses rather than computing snake pick numbers.
+def test_a_draft_that_is_not_a_snake_refuses():
+    # Every pick number this feature reports assumes rounds alternate direction. Against a
+    # linear draft that arithmetic is wrong from round two, and wrong quietly.
+    with pytest.raises(ValueError) as caught:
+        resolve_seat(draft(type="linear"), ME)
+    assert "snake" in str(caught.value).lower()


### PR DESCRIPTION
Closes #34.

The first piece of the live assistant that can be pointed at a real draft: resolve my seat from
the draft order, read the picks made so far, subtract them from the board the warehouse built,
print what is left, exit. Refreshing as picks come in is #35.

```
seat 1 of 14  ·  29 picks made  ·  next pick #56

!! 1 UNMATCHED PICK — this board may be showing a drafted player as available
!!   pick 29       Ghost Rookie (K, Sleeper 9999999)

My roster — roster 6
  QB          0/1  -
  RB          2/2  Bijan Robinson, Jeremiyah Love
  ...

Best available — 8 of 627
    #  POS  PLAYER                  TM   BYE      PoR
    1  RB   Josh Jacobs             GB    11     80.8
    2  QB   Justin Herbert          LAC    7     79.7
```

## Three modules, split by what they touch

- `src/draft/seat.py` — a draft record in, the league shape `ingest_picks` already takes out. It
  reads `draft_order` and `slot_to_roster_id` as the two different maps they are: seat 1 is
  roster 6 in this league, and conflating them fills my lineup with another manager's players
  while my own picks come back as his, with the board looking plausible throughout. Refuses a
  non-snake draft and an undrawn order rather than reporting pick numbers that are right in
  round one and wrong from round two.
- `src/draft/render.py` — frames in, one string out, so the screen is testable rather than
  eyeballed on the night. Missing values print as a dash; `<NA>` in a column of week numbers
  reads as data rather than as a gap.
- `src/draft/live.py` — the only module in the package that touches the world. Four GETs and one
  read-only warehouse read through `src.query.q`. There is no POST anywhere in `src/draft/`,
  which is what "never makes a pick" means here.

## Acceptance criteria

- Runs as a module, like `src.summary` — `python -m src.draft.live [--limit N]`
- Seat resolved from the draft order, never typed in; league ID and season come from
  `src.silver.sleeper` so the repo holds one of each
- Candidates carry value, position, team and bye week — the bye joined back on by `player_id`,
  leaving `rank_candidates`' contract from #33 untouched
- Roster shown against the league's own starting slots, superflex included, plus the next
  overall pick number
- Unmatched picks named, and printed above the board rather than under thirty rows of it
- Refuses a warehouse older than 24h, and the refusal carries the build time it found
- Read-only via `src.query.q`, which opens read-only and closes per call, so it cannot hold the
  file lock against a rebuild either

## Tests

Seventeen cases, enumerated and committed before the implementation (d58eeae is red on purpose,
2398f5a turns it green). Suite is 73 passing.

## Verification

Against the real league: seat 1, roster 6, next pick #1 with the draft in `pre_draft`. Against a
simulated 29-pick payload on the real board: roster filled with my picks at 1 and 28, next pick
#56 off the snake reversal, 627 of 655 still available, and a deliberately unknown Sleeper ID
reported by name having removed nobody.

## Doc changes

`CLAUDE.md`'s description of `src/draft/` said the package opens no connection, which stops being
true with `live.py` — it now says the pure modules are pure and names `live.py` as the one edge.
README gains the draft-night command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
