### PR TITLE
feat: rank the remaining board by cost of waiting

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -57,7 +57,8 @@ The share of a season a player is expected to be able to play, measured from his
 being on injured reserve. Distinct from **role**: availability is whether he *can* play, role is
 whether he *would* be played.
 _Avoid_: durability, health, expected games (that is one model's internal estimate, which conflates
-availability with role)
+availability with role), and never for draft supply — that is **survival probability**, which is a
+fact about a draft room rather than about a player
 
 **Role**:
 How much a player would be used if fit — starter, committee back, backup. Already priced into every
@@ -103,3 +104,18 @@ _Avoid_: draft order (that means **seat** ordering, not position ordering)
 The other teams in a simulated draft, and how they behave. A field drafting straight off ADP is the
 friendliest possible room, because the focal team is the only one deviating.
 _Avoid_: opponents, league mates
+
+**Survival probability**:
+How likely a player is to still be undrafted at a given pick. A fact about supply in a draft room,
+and nothing to do with **availability**, which is how much of a season he can play — the word is
+already spent, and the collision is why this term exists. `draft_availability` predates the
+distinction and still carries the older name; nothing a drafter reads does.
+_Avoid_: availability, p_available, still on the board (that is an observation, not a probability)
+
+**Cost of waiting**:
+The points over replacement expected to be lost by passing on a player at one turn and hoping he
+lasts to the seat's next one. Combines his **survival probability** with the drop-off to whoever
+would be left at his position, so a deep position is cheap to wait on even when the individual
+player is likely to go, and a cliff is expensive even when he will probably last. Zero at the
+turn, where the two picks are adjacent and there is no gap to survive.
+_Avoid_: urgency, opportunity cost, need (that is a roster question, not a supply one)

--- a/src/draft/live.py
+++ b/src/draft/live.py
@@ -18,9 +18,9 @@ What it touches, exhaustively:
 - Four HTTP **GET**s to Sleeper — the user, the league's drafts, the draft, the picks. There is no
   POST anywhere in this package, which is what "never makes a pick" means in practice: the tool
   has no code path that could submit one, rather than a flag saying it shouldn't.
-- One read of `data/warehouse.duckdb` through `src.query.q`, which opens read-only and closes
-  before it returns. A draft-night process cannot corrupt what the pipeline built, and cannot hold
-  the file lock against a rebuild either.
+- Two reads of `data/warehouse.duckdb` through `src.query.q`, which opens read-only and closes
+  before each returns. A draft-night process cannot corrupt what the pipeline built, and cannot
+  hold the file lock against a rebuild either.
 
 ## Nothing is typed in
 
@@ -48,10 +48,10 @@ from datetime import datetime, timedelta
 import pandas as pd
 import requests
 
-from src.draft.candidates import rank_candidates
 from src.draft.picks import ingest_picks
 from src.draft.render import render_board
 from src.draft.seat import resolve_seat
+from src.draft.waiting import rank_by_cost_of_waiting
 from src.query import WAREHOUSE_PATH, q
 from src.silver.sleeper import LEAGUE_ID, SEASON
 
@@ -163,20 +163,56 @@ def load_board(league_key: str = LEAGUE_KEY) -> pd.DataFrame:
     return board
 
 
+def load_survival(league_key: str = LEAGUE_KEY) -> pd.DataFrame:
+    """How likely each player is to still be there at each pick, as built days ago.
+
+    `draft_availability` is keyed by seat as well as by pick, but the probability itself is not:
+    it is a tail of the player's own ADP distribution and depends only on the overall pick number,
+    so the same (player, pick) pair carries the same number under every seat. `DISTINCT` collapses
+    that, and the frame then covers *every* overall pick rather than only this seat's — which the
+    conditional needs, because its denominator is read at the pick about to be made and that pick
+    usually belongs to somebody else.
+
+    The rename happens here, at the one place that touches the warehouse, so nothing above this
+    line has to know that the table spells it with the word the glossary has already spent.
+    """
+    survival = q(
+        """
+        SELECT DISTINCT player_id, overall_pick, p_available AS p_survives
+        FROM draft_availability
+        WHERE league_key = ?
+        """,
+        [league_key],
+    )
+    if survival.empty:
+        # Not a refusal: the board is still worth reading, and the ranking says on screen that it
+        # has fallen back to value alone. A draft is not worth losing to a missing table.
+        print(
+            f"\ndraft_availability holds no rows for league {league_key!r} — ranking by points "
+            "over replacement alone. Run scripts/build_warehouse.sh to price waiting.\n"
+        )
+    return survival
+
+
 def render_once(limit: int = DEFAULT_LIMIT) -> str:
     """Everything, once: fetch, resolve, subtract, rank, and give back the screen."""
     board = load_board()
+    survival = load_survival()
     draft = find_draft(LEAGUE_ID, SEASON)
     league = resolve_seat(draft, user_id(USERNAME))
     result = ingest_picks(_get(f"/draft/{draft['draft_id']}/picks"), board, league)
+    ranked = rank_by_cost_of_waiting(board, survival, result)
 
-    # The bye week is joined back on by ID rather than carried through the ranking: what
-    # `rank_candidates` returns is a fixed contract, and a display column is not the ranking's
-    # business. Joining on `player_id` is the same identity the whole feature runs on.
-    candidates = rank_candidates(board, result["taken"]).merge(
+    # The bye week is joined back on by ID rather than carried through the ranking: what the
+    # ranking returns is a fixed contract, and a display column is not the ranking's business.
+    # Joining on `player_id` is the same identity the whole feature runs on.
+    candidates = ranked["candidates"].merge(
         board[["player_id", "bye_week"]], on="player_id", how="left"
     )
-    return render_board(candidates, result, league, limit)
+    return render_board(
+        candidates, result, league, limit,
+        degraded=ranked["degraded"], covers_to=ranked["covers_to"],
+    )
 
 
 def main(limit: int = DEFAULT_LIMIT) -> None:

--- a/src/draft/picks.py
+++ b/src/draft/picks.py
@@ -41,6 +41,12 @@ describes — and a version that forgot the reversal would give 1, 15, 29 and be
 onwards. Picks made is read from the highest pick number seen rather than from the length of the
 list, so a hand-marked player (no pick number) cannot push the next turn a pick further away.
 
+Two of the seat's picks are reported, not one. `next_pick` is the turn being decided; the whole
+point of `pick_after_next` is the gap between them, which is what a player has to survive to still
+be there if he is passed on. At the turn those two are adjacent and the gap is empty, which is
+seat 1 being able to take both players at 28 and 29; from the middle of the board the same pair is
+14 picks apart. One number cannot say that, which is why both are returned.
+
 ## Filling slots
 
 A quarterback can start at QB or in the superflex; a back can start at RB, in the flex, or in the
@@ -190,6 +196,9 @@ def ingest_picks(picks: list[dict], board: pd.DataFrame, league: dict) -> dict:
     - `roster` — my lineup so far, a frame of one row per starting slot.
     - `unmatched` — every pick whose player the board could not identify, named, in draft order.
     - `next_pick` — the overall number of my next turn, or None once the draft is over.
+    - `pick_after_next` — the turn after that, or None when my next turn is my last. This is what
+      a player passed on at `next_pick` has to survive to, so it is the pick cost of waiting is
+      measured against.
     - `picks_made` — how far the draft has got, so a caller need not re-parse the payload for it.
     """
     ordered = _unique_picks(picks)
@@ -225,12 +234,22 @@ def ingest_picks(picks: list[dict], board: pd.DataFrame, league: dict) -> dict:
             mine.append(row)
 
     picks_made = _picks_made(ordered)
+    next_pick = next_pick_number(
+        picks_made, league["seat"], league["team_count"], league["rounds"]
+    )
     return {
         "taken": taken,
         "roster": _roster_frame(_assign_to_slots(mine, league["slots"]), league["slots"]),
         "unmatched": unmatched,
-        "next_pick": next_pick_number(
-            picks_made, league["seat"], league["team_count"], league["rounds"]
+        "next_pick": next_pick,
+        # The same walk, started from my next turn rather than from the draft: whatever I pass on
+        # there has to last until this one.
+        "pick_after_next": (
+            None
+            if next_pick is None
+            else next_pick_number(
+                next_pick, league["seat"], league["team_count"], league["rounds"]
+            )
         ),
         "picks_made": picks_made,
     }

--- a/src/draft/render.py
+++ b/src/draft/render.py
@@ -21,9 +21,27 @@ how often it is read, which puts the candidate list at the bottom where the eye 
 
 A player with no bye week gets a dash. Pandas renders a missing nullable integer as `<NA>` and a
 missing float as `nan`, and either one in a column of week numbers reads as a number that happens
-to look odd rather than as an absence. The same rule applies to a missing team. Nothing here
-substitutes a plausible value for a missing one — a guessed bye week would quietly pile a
+to look odd rather than as an absence. The same rule applies to a missing team, and to a player
+the survival model does not cover: no probability rather than a confident-looking zero. Nothing
+here substitutes a plausible value for a missing one — a guessed bye week would quietly pile a
 drafter's starters into the same empty week, which is worse than an obvious blank.
+
+## The screen has to say which rule it ranked by
+
+`rank_by_cost_of_waiting` falls back to points over replacement on its own, past the point the
+survival model covers, and the rows look identical either way. So the heading names the rule and
+the pick the probabilities are anchored to, and a fallback says on screen how far past the model
+the draft has got. A drafter who cannot tell the two rankings apart is reading a number he has no
+way to judge.
+
+Both numbers stay on the row beside the value they were computed from, for the same reason the
+repo keeps a blended metric's inputs individually visible: a ranking is auditable or it is obeyed.
+
+## Vocabulary
+
+*Survives* and *survival probability*, never *availability* — the glossary spends that word on how
+much of a season a player can play, and two meanings under one word on a screen read against a
+pick clock is how a supply number gets read as an injury number.
 """
 
 import pandas as pd
@@ -49,6 +67,24 @@ def _bye(value) -> str:
     if value is None or pd.isna(value):
         return _MISSING
     return str(int(value))
+
+
+def _percent(value) -> str:
+    """A survival probability, rounded to where it can actually be read.
+
+    Whole percent, because the third decimal place of a tail probability is not a thing anyone
+    should be deciding a pick on and a wider column costs a name its space.
+    """
+    if value is None or pd.isna(value):
+        return _MISSING
+    return f"{value * 100:.0f}%"
+
+
+def _cost(value) -> str:
+    """Cost of waiting, in the same units and to the same precision as the value beside it."""
+    if value is None or pd.isna(value):
+        return _MISSING
+    return f"{value:.1f}"
 
 
 def _header(picks: dict, league: dict) -> str:
@@ -99,13 +135,44 @@ def _roster(roster: pd.DataFrame, league: dict) -> list[str]:
     return lines
 
 
-def _candidates(candidates: pd.DataFrame, limit: int) -> list[str]:
-    """The board that is left, best first, cut to what fits on a screen."""
+def _ranking(picks: dict, degraded: bool, covers_to: int | None) -> list[str]:
+    """How the list below was ordered, and — when it is not the good rule — why not.
+
+    The pick named is `pick_after_next`, not the turn being decided: waiting means still being
+    there at the turn *after* this one, and a probability anchored to the pick in hand would be a
+    certainty dressed up as a forecast.
+    """
+    wait_to = picks["pick_after_next"]
+    if not degraded and wait_to is not None:
+        return [
+            f", ranked by cost of waiting to pick #{wait_to}",
+            "  SURV — survival probability, the chance he survives to that pick;"
+            " COST — what waiting gives up",
+        ]
+
+    heading = ", ranked by points over replacement"
+    if wait_to is None:
+        return [heading, "  no turn after this one, so there is nothing to wait for"]
+    if covers_to is None:
+        return [heading, "  no survival data was supplied, so nothing can be priced for waiting"]
+    return [
+        heading,
+        f"  pick #{wait_to} is past #{covers_to}, the last the survival model covers",
+    ]
+
+
+def _candidates(
+    candidates: pd.DataFrame, picks: dict, limit: int, degraded: bool, covers_to: int | None
+) -> list[str]:
+    """The board that is left, most expensive to pass on first, cut to what fits on a screen."""
     shown = candidates.head(limit)
+    rule, note = _ranking(picks, degraded, covers_to)
     lines = [
         "",
-        f"Best available — {len(shown)} of {len(candidates)}",
-        f"  {'#':>3}  {'POS':<5}{'PLAYER':<{_NAME_WIDTH}}{'TM':<5}{'BYE':>3}{'PoR':>9}",
+        f"Best available — {len(shown)} of {len(candidates)}{rule}",
+        note,
+        f"  {'#':>3}  {'POS':<5}{'PLAYER':<{_NAME_WIDTH}}{'TM':<5}{'BYE':>3}{'PoR':>9}"
+        f"{'SURV':>7}{'COST':>9}",
     ]
     if shown.empty:
         lines.append("  nobody left on the board")
@@ -116,22 +183,32 @@ def _candidates(candidates: pd.DataFrame, limit: int) -> list[str]:
             f"  {rank:>3}  {_text(row.position):<5}{_text(row.player_name):<{_NAME_WIDTH}}"
             f"{_text(row.team):<5}{_bye(row.bye_week):>3}"
             f"{row.points_over_replacement:>9.1f}"
+            f"{_percent(row.p_survives):>7}{_cost(row.cost_of_waiting):>9}"
         )
     return lines
 
 
 def render_board(
-    candidates: pd.DataFrame, picks: dict, league: dict, limit: int = 30
+    candidates: pd.DataFrame,
+    picks: dict,
+    league: dict,
+    limit: int = 30,
+    degraded: bool = False,
+    covers_to: int | None = None,
 ) -> str:
     """The whole screen as one string.
 
-    `candidates` is what `rank_candidates` returned with the board's `bye_week` joined on,
+    `candidates` is what `rank_by_cost_of_waiting` returned with the board's `bye_week` joined on,
     `picks` is what `ingest_picks` returned, and `league` is the shape `resolve_seat` read out
     of the draft record. `limit` is how much of the board to show; the count above the table
     always names the total, so a cut list never reads as a short one.
+
+    `degraded` and `covers_to` are the rest of what the ranking returned. They are separate
+    arguments rather than a dict because they change the words above the table and nothing else,
+    and a renderer that had to be handed a ranking result could not be pointed at anything else.
     """
     lines = [_header(picks, league)]
     lines += _unmatched(picks["unmatched"])
     lines += _roster(picks["roster"], league)
-    lines += _candidates(candidates, limit)
+    lines += _candidates(candidates, picks, limit, degraded, covers_to)
     return "\n".join(lines)

--- a/src/draft/waiting.py
+++ b/src/draft/waiting.py
@@ -1,0 +1,244 @@
+"""Rank what is left by what it costs to pass on it, rather than by what it is worth.
+
+The last pure step of the live draft assistant's seam. `picks.ingest_picks` turns a payload into
+who is gone; `candidates.rank_candidates` turns who is gone into who is left; this turns who is
+left into who to take. No network, no warehouse connection, no printing, and nothing handed in is
+modified.
+
+## Why value is only half a draft decision
+
+A player worth 180 points over replacement is worth nothing *at this pick* if he will still be
+sitting there 26 picks from now, and a player worth 120 is urgent if he will not. Cost of waiting
+is that second half: the points over replacement expected to be lost by passing on a player now
+and hoping he survives to the seat's next pick.
+
+It combines two things, and needs both. A deep position is cheap to wait on even when the
+individual player is likely to go, because someone almost as good is behind him. A cliff position
+is expensive even when the player will probably last, because nobody is. Neither the survival
+probability alone nor the drop-off alone says that.
+
+## The arithmetic, and why it is only arithmetic
+
+Every number that goes in was computed by the warehouse rebuild days before the draft. Nothing is
+refitted on the night — `points_over_replacement` comes back exactly as the board priced it, and
+the probabilities come back exactly as `draft_availability` computed them.
+
+Within one position, in value order, the expected best available at the next pick is a walk from
+the bottom up:
+
+    E(nobody left)  =  0
+    E(from player i) =  p_i . V_i  +  (1 - p_i) . E(from player i+1)
+    cost_i           =  V_i - E(from player i)
+
+which rearranges to `cost_i = (1 - p_i) . (V_i - E(from player i+1))` — the chance he is gone,
+times the drop to whoever is expected to be there instead. That is the sentence the ticket asks
+for, written as a recursion so it holds for every player at the position rather than only the top
+one.
+
+`E` is floored at zero. Points over replacement is measured against a freely available player, so
+a fallback cannot honestly be worth less than that: below the floor the drafter takes a different
+position, and does not take a below-replacement player because a model told him to.
+
+The known limitation is inherited from the table and stated in `draft_plan`: the probabilities are
+marginal, one player at a time, so they do not encode that exactly one player can be taken per
+pick. Multiplying them as though they were independent slightly overstates how often a whole
+position vanishes at once. Read a whole-position panic as a little softer than the number says.
+
+## Two picks, and the gap between them
+
+Waiting is a thing that happens between two of the seat's own turns, so both are needed.
+`next_pick` is the turn being decided; `pick_after_next` is where a player passed on has to still
+be for the decision to have cost nothing. Seat 1 of 14 deciding pick 1 is waiting until 28 — a gap
+of 26 picks by other people. Deciding 28 he is waiting until 29, and the gap is empty.
+
+Ranking against `next_pick` instead would be a tool that says nothing at the only moment it is
+read: on the clock, `next_pick` is the pick being made, so every player survives to it by
+definition and every cost is zero. That is the shape of a bug that looks like a working screen.
+
+## The probability is conditional, and that is the whole of user story 8
+
+`draft_availability` holds P(this player's draft position lands at or after pick k), computed from
+his ADP distribution. That is *unconditional*: it counts every pick from the top of the draft,
+including the ones already made and including my own. Availability is a monotone event — once a
+player is gone he stays gone — so the conditional this needs is an exact ratio of two numbers the
+table already holds, not a new model:
+
+    p_survives  =  p(pick after next) / p(next pick + 1)
+
+The denominator starts one past the turn being decided because that turn is *mine*, and I am the
+one passing: my own pick cannot be part of the hazard a player has to survive, or the tool charges
+me for the chance that I take him myself.
+
+At the turn the two picks are adjacent, numerator and denominator are the same pick, and the ratio
+is one: nothing costs anything to wait for, because there is no gap. Read off the raw column
+instead, De'Von Achane shows a 9% survival probability at pick 29 and a large cost of waiting from
+a seat that is about to pick twice in a row.
+
+## Three kinds of missing, and only one of them is missing
+
+The warehouse drops a row once the probability falls under its own 1% floor, and clips it to zero
+past the latest pick the player has ever actually lasted to. So absence in the frame is usually
+data, and reading it as ignorance would flag the most certain players on the board as the least
+certain. The three cases:
+
+- **No row at the pick I am waiting to, but rows elsewhere.** He is gone. `p_survives` is 0, and
+  waiting costs the full drop to whoever is behind him.
+- **No row at the pick the gap opens on.** The table already had him gone, and yet here he sits.
+  The conditional's denominator is zero, the model has been overtaken by events, and there is no
+  honest number to put in its place.
+- **No row anywhere.** No ADP, so no distribution, so nothing to say — the rookies and camp bodies
+  the board carries on its depth arm rather than its market arm.
+
+The last two are the same answer: `survival_known` is False, both numbers are missing rather than
+guessed, and he is ranked by value at the end of the list. A missing probability is never defaulted
+to a number, and never enters anyone else's fallback expectation either — a player who cannot be
+weighted cannot be counted on.
+
+## Vocabulary
+
+`p_survives`, never `p_available`. The glossary already spends *availability* on the share of a
+season a player can play, and the board carries a column with exactly that meaning. Renaming the
+warehouse table is a separate concern; using its word for a different thing on a screen read under
+a pick clock is not something to make worse in the meantime.
+"""
+
+import numpy as np
+import pandas as pd
+
+from src.draft.candidates import CANDIDATE_COLUMNS, rank_candidates
+
+# What the ranking hands over: the board's own identification and price, then the two numbers this
+# module adds and the flag that says whether they mean anything.
+WAITING_COLUMNS = CANDIDATE_COLUMNS + ["p_survives", "cost_of_waiting", "survival_known"]
+
+# What a survival frame has to carry: one row per player per overall pick, with the probability
+# already renamed away from the warehouse's colliding word.
+SURVIVAL_COLUMNS = ["player_id", "overall_pick", "p_survives"]
+
+
+def _at_pick(survival: pd.DataFrame, overall_pick: int | None) -> dict[str, float]:
+    """Every player's probability at one pick, as a plain lookup."""
+    if overall_pick is None:
+        return {}
+    rows = survival.loc[survival["overall_pick"] == overall_pick]
+    return dict(zip(rows["player_id"], rows["p_survives"]))
+
+
+def _survival_probabilities(
+    player_ids: pd.Series, survival: pd.DataFrame, wait_to: int, gap_starts: int
+) -> pd.Series:
+    """P(still there at `wait_to` | still there when the gap opens), or NaN where it cannot be said.
+
+    `gap_starts` is one past the turn being decided: the first pick somebody else makes, and so the
+    first one that can take the player away.
+    """
+    covered = set(survival["player_id"])
+    at_next = _at_pick(survival, wait_to)
+    at_now = _at_pick(survival, gap_starts)
+
+    probabilities = []
+    for player_id in player_ids:
+        denominator = at_now.get(player_id)
+        if player_id not in covered or not denominator:
+            # Either the model never covered him, or it had him gone before the gap even opens and
+            # has been overtaken by the fact that he is still sitting on the board.
+            probabilities.append(np.nan)
+            continue
+        # An absent numerator is a probability under the table's floor or past his observed range.
+        # Both mean gone, which is a number, not a gap.
+        probabilities.append(min(at_next.get(player_id, 0.0) / denominator, 1.0))
+    return pd.Series(probabilities, index=player_ids.index, dtype="float64")
+
+
+def _cost_within_position(values: list[float], probabilities: list[float]) -> list[float]:
+    """Cost of waiting for each player at one position, given in value order.
+
+    Walks up from the bottom so each player is priced against what is expected to be left behind
+    him. A player with no probability is passed over: he gets no cost, and contributes nothing to
+    anyone else's expectation, because there is no honest weight to give him.
+    """
+    costs = [np.nan] * len(values)
+    expected = 0.0
+    for index in reversed(range(len(values))):
+        probability = probabilities[index]
+        if np.isnan(probability):
+            continue
+        expected = max(
+            probability * values[index] + (1.0 - probability) * expected, 0.0
+        )
+        costs[index] = values[index] - expected
+    return costs
+
+
+def _cost_of_waiting(candidates: pd.DataFrame) -> pd.Series:
+    """Cost of waiting for every candidate, one position group at a time.
+
+    `candidates` arrives in value order, which is the order the walk above depends on.
+    """
+    costs = pd.Series(np.nan, index=candidates.index, dtype="float64")
+    for _, group in candidates.groupby("position", sort=False):
+        costs.loc[group.index] = _cost_within_position(
+            list(group["points_over_replacement"]), list(group["p_survives"])
+        )
+    return costs
+
+
+def rank_by_cost_of_waiting(
+    board: pd.DataFrame,
+    survival: pd.DataFrame,
+    picks: dict,
+    position: str | None = None,
+) -> dict:
+    """The players still available, most expensive to pass on first.
+
+    `board` is one league's priced board, `survival` carries `SURVIVAL_COLUMNS` for that league,
+    and `picks` is what `ingest_picks` returned — `taken`, `next_pick` and `pick_after_next` are
+    the three keys read from it. `position` narrows the screen to one position without repricing
+    anything: cost of waiting is measured against the whole board's remaining players, so filtering
+    must not make a position look like the rest of the board had been drafted.
+
+    Returns a dict of:
+
+    - `candidates` — one row per available player with `WAITING_COLUMNS`, ranked, always with those
+      columns even when nobody is left.
+    - `degraded` — True when there is no survival data for the pick being waited to, or no such
+      pick at all, and the ranking has fallen back to points over replacement alone.
+    - `covers_to` — the last overall pick the survival frame covers, so a caller can say how far
+      past it the draft has got rather than only that something is wrong.
+    """
+    wait_to = picks["pick_after_next"]
+    covers_to = None if survival.empty else int(survival["overall_pick"].max())
+
+    # Everyone, unfiltered: a position's fallback structure is a fact about the board, not about
+    # what the drafter happens to be looking at.
+    candidates = rank_candidates(board, picks["taken"])
+
+    # No later turn is as degraded as no data for it: a last pick, and a finished draft, both have
+    # nothing to wait for and nothing to price.
+    degraded = wait_to is None or covers_to is None or wait_to > covers_to
+    if degraded:
+        candidates["p_survives"] = np.nan
+        candidates["cost_of_waiting"] = np.nan
+    else:
+        candidates["p_survives"] = _survival_probabilities(
+            candidates["player_id"], survival, wait_to, picks["next_pick"] + 1
+        )
+        candidates["cost_of_waiting"] = _cost_of_waiting(candidates)
+    candidates["survival_known"] = candidates["p_survives"].notna()
+
+    if position is not None:
+        candidates = candidates.loc[candidates["position"] == position]
+
+    # Cost of waiting first, then value, then name. The second key is not only a tiebreak: it is
+    # what ranks a player whose cost cannot be computed, and pandas puts those missing values last
+    # whichever way the first key is sorted, which is exactly where a number nobody has belongs.
+    ranked = candidates[WAITING_COLUMNS].sort_values(
+        ["cost_of_waiting", "points_over_replacement", "player_name"],
+        ascending=[False, False, True],
+        na_position="last",
+    )
+    return {
+        "candidates": ranked.reset_index(drop=True),
+        "degraded": degraded,
+        "covers_to": covers_to,
+    }

--- a/tests/test_draft_picks.py
+++ b/tests/test_draft_picks.py
@@ -305,3 +305,25 @@ def test_a_hand_marked_player_does_not_advance_the_draft():
     # read as pick 33 — nine away — at the exact moment the drafter is on the clock at pick 24.
     assert result["picks_made"] == 23
     assert result["next_pick"] == 24
+
+
+# The two cases below belong to issue #37, which needs the turn *after* the one being decided:
+# whatever is passed on at `next_pick` has to survive until then, and the gap between the two is
+# the thing cost of waiting prices.
+def test_the_pick_after_next_is_the_seats_following_turn():
+    # Seat 1 of 14 picks 1, 28, 29, 56. Deciding pick 1, the gap to survive runs to 28.
+    assert ingest_picks([], board(), league(seat=1))["pick_after_next"] == 28
+
+    # And at the turn the two are adjacent, which is what makes waiting free there.
+    # Distinct IDs, because deduplication is on the player: one repeated ID is one pick.
+    through_27 = [pick(str(n), n) for n in range(1, 28)]
+    result = ingest_picks(through_27, board(), league(seat=1))
+    assert (result["next_pick"], result["pick_after_next"]) == (28, 29)
+
+
+def test_there_is_no_pick_after_the_seats_last_one():
+    # Nothing can be waited for from the final round: there is no later turn to wait until.
+    through_the_last_gap = [pick(str(n), n) for n in range(1, 197)]
+    result = ingest_picks(through_the_last_gap, board(), league(seat=1))
+    assert result["next_pick"] == 197
+    assert result["pick_after_next"] is None

--- a/tests/test_draft_render.py
+++ b/tests/test_draft_render.py
@@ -1,8 +1,8 @@
 """What the drafter actually sees, for a given board and a given set of picks.
 
-Cases 10-17 of the terminal render ticket. `render_board` is pure — frames in, one string out —
-so these assert the screen itself rather than capturing stdout, and none of them reaches into how
-the string is assembled.
+Cases 10-17 of the terminal render ticket, and the cost-of-waiting cases from issue #37.
+`render_board` is pure — frames in, one string out — so these assert the screen itself rather
+than capturing stdout, and none of them reaches into how the string is assembled.
 
 Two things are asserted harder than the rest, because they are the ones that cost a pick:
 
@@ -14,9 +14,9 @@ Two things are asserted harder than the rest, because they are the ones that cos
 
 import pandas as pd
 
-from src.draft.candidates import rank_candidates
 from src.draft.picks import ingest_picks
 from src.draft.render import render_board
+from src.draft.waiting import rank_by_cost_of_waiting
 
 SLOTS = {"QB": 1, "RB": 2, "WR": 2, "TE": 1, "FLEX": 1, "SUPER_FLEX": 1, "K": 1, "DST": 1}
 
@@ -31,6 +31,11 @@ def candidates(*rows: dict) -> pd.DataFrame:
         "position": "RB",
         "team": "SF",
         "points_over_replacement": 100.0,
+        # Cost of waiting (issue #37) widened what the ranking hands over. The three columns are
+        # defaulted here rather than asserted, so the cases above stay about what they were about.
+        "p_survives": 0.35,
+        "cost_of_waiting": 42.0,
+        "survival_known": True,
         "bye_week": 9,
     }
     frame = pd.DataFrame(
@@ -217,8 +222,16 @@ def test_the_three_halves_join_on_a_real_payload():
         "player_id": "4034", "roster_id": 6, "pick_no": 1,
         "metadata": {"first_name": "A", "last_name": "Back", "position": "RB"},
     }]
+    survival = pd.DataFrame(
+        [
+            {"player_id": "00-0000001", "overall_pick": 2, "p_survives": 1.0},
+            {"player_id": "00-0000002", "overall_pick": 2, "p_survives": 1.0},
+            {"player_id": "00-0000001", "overall_pick": 28, "p_survives": 0.4},
+            {"player_id": "00-0000002", "overall_pick": 28, "p_survives": 0.6},
+        ]
+    )
     result = ingest_picks(picks, board, LEAGUE)
-    ranked = rank_candidates(board, result["taken"]).merge(
+    ranked = rank_by_cost_of_waiting(board, survival, result)["candidates"].merge(
         board[["player_id", "bye_week"]], on="player_id", how="left"
     )
 
@@ -227,3 +240,87 @@ def test_the_three_halves_join_on_a_real_payload():
     # Drafted, by me: off the board and onto the roster, not both and not neither.
     assert any("A Back" in row for row in section(out, "My roster"))
     assert not any("A Back" in row for row in section(out, "Best available"))
+
+
+# The cases below belong to issue #37, which changed the ranking rule from raw value to cost of
+# waiting. Two numbers joined the candidate row, and the screen now has to say which rule it
+# ranked by — because the tool falls back to value ranking on its own, past the point the survival
+# model covers, and a drafter who cannot see that has no way to know what he is reading.
+
+
+def test_a_candidate_shows_his_survival_probability_and_what_waiting_costs():
+    out = render_board(
+        candidates({"player_name": "Bijan Robinson", "p_survives": 0.34,
+                    "cost_of_waiting": 72.3, "points_over_replacement": 178.4}),
+        ingested(),
+        LEAGUE,
+    )
+    row = line_naming(out, "Bijan Robinson")
+    assert "34%" in row
+    assert "72.3" in row
+    # The value it is traded off against stays on the row: the ranking is auditable or it is
+    # obeyed, and the whole design says auditable.
+    assert "178.4" in row
+
+
+def test_the_probabilities_are_anchored_to_a_named_pick():
+    """A bare percentage means nothing without the pick it is a probability of reaching."""
+    out = render_board(candidates({}), ingested(next_pick=56, picks_made=29), LEAGUE)
+    heading = next(line for line in out.splitlines() if line.startswith("Best available"))
+    assert "#56" in heading
+    assert "cost of waiting" in heading
+
+
+def test_the_screen_says_survives_and_survival_probability():
+    """The vocabulary rule, on the surface it exists to protect."""
+    out = render_board(candidates({}), ingested(), LEAGUE)
+    assert "survives" in out
+    assert "survival probability" in out
+
+
+def test_the_screen_never_says_availability():
+    """The glossary spends that word on how much of a season a player can play.
+
+    Two different meanings under one word, on a screen read under a pick clock, is how a drafter
+    ends up reading a supply number as an injury number.
+    """
+    out = render_board(
+        candidates({"p_survives": 0.34, "cost_of_waiting": 72.3}),
+        ingested(unmatched=[{"sleeper_id": "1", "player_name": "Someone Unknown",
+                             "position": "WR", "pick_no": 14}]),
+        LEAGUE,
+    )
+    assert "availability" not in out.lower()
+
+
+def test_a_candidate_with_no_survival_data_shows_gaps_rather_than_numbers():
+    out = render_board(
+        candidates({"player_name": "Unpriced Rookie", "p_survives": None,
+                    "cost_of_waiting": None, "survival_known": False}),
+        ingested(),
+        LEAGUE,
+    )
+    row = line_naming(out, "Unpriced Rookie")
+    assert "nan" not in row.lower()
+    assert "<NA>" not in row
+    assert "0%" not in row
+    # He is still on the board — a missing number hides him from nobody.
+    assert "Unpriced Rookie" in row
+
+
+def test_a_degraded_result_says_it_has_fallen_back_to_value_ranking():
+    out = render_board(
+        candidates({"player_name": "Best Left", "p_survives": None, "cost_of_waiting": None,
+                    "survival_known": False}),
+        ingested(next_pick=196, picks_made=195),
+        LEAGUE,
+        degraded=True,
+        covers_to=180,
+    )
+    assert "points over replacement" in out
+    # Both numbers named, so the drafter can see how far past the model he is rather than being
+    # told only that something is wrong.
+    assert "#196" in out
+    assert "#180" in out
+    # And it must not still claim to be ranking by a rule it no longer has the inputs for.
+    assert "cost of waiting" not in out

--- a/tests/test_draft_render.py
+++ b/tests/test_draft_render.py
@@ -69,6 +69,7 @@ def ingested(**overrides) -> dict:
         "roster": roster(("QB", 1, []), ("RB", 2, []), ("SUPER_FLEX", 1, [])),
         "unmatched": [],
         "next_pick": 29,
+        "pick_after_next": 56,
         "picks_made": 28,
         **overrides,
     }
@@ -184,7 +185,11 @@ def test_a_clean_draft_shows_no_warning():
 
 # 16. A finished draft says so instead of printing `None` for the next pick.
 def test_a_finished_draft_says_so_rather_than_printing_none():
-    out = render_board(candidates({}), ingested(next_pick=None, picks_made=210), LEAGUE)
+    out = render_board(
+        candidates({}),
+        ingested(next_pick=None, pick_after_next=None, picks_made=210),
+        LEAGUE,
+    )
     header = out.splitlines()[0]
     assert "None" not in header
     assert "complete" in header.lower()
@@ -265,8 +270,11 @@ def test_a_candidate_shows_his_survival_probability_and_what_waiting_costs():
 
 def test_the_probabilities_are_anchored_to_a_named_pick():
     """A bare percentage means nothing without the pick it is a probability of reaching."""
-    out = render_board(candidates({}), ingested(next_pick=56, picks_made=29), LEAGUE)
+    out = render_board(
+        candidates({}), ingested(next_pick=29, pick_after_next=56, picks_made=28), LEAGUE
+    )
     heading = next(line for line in out.splitlines() if line.startswith("Best available"))
+    # The turn after the one being decided, which is what a passed-over player has to survive to.
     assert "#56" in heading
     assert "cost of waiting" in heading
 
@@ -312,7 +320,7 @@ def test_a_degraded_result_says_it_has_fallen_back_to_value_ranking():
     out = render_board(
         candidates({"player_name": "Best Left", "p_survives": None, "cost_of_waiting": None,
                     "survival_known": False}),
-        ingested(next_pick=196, picks_made=195),
+        ingested(next_pick=195, pick_after_next=196, picks_made=194),
         LEAGUE,
         degraded=True,
         covers_to=180,

--- a/tests/test_draft_waiting.py
+++ b/tests/test_draft_waiting.py
@@ -5,23 +5,29 @@ set of picks — never how it gets there. Fixtures are a handful of players with
 probabilities chosen so the expected number can be worked out on paper, which is the only kind of
 expectation that survives a rebuild of the warehouse those inputs really come from.
 
-## The one thing worth reading before the cases
+## The two pick numbers, which are the whole of these cases
+
+Cost of waiting prices a decision at one pick against a fallback at another. The seat has both:
+`next_pick` is the turn being decided, `pick_after_next` is the turn a player passed on has to
+survive to. Seat 1 of 14 deciding pick 1 is waiting until 28; deciding 28 he is waiting until 29,
+which is the immediately following selection and therefore no wait at all.
 
 `draft_availability` holds an **unconditional** probability: P(this player's draft position lands
 at or after pick k), computed days ago from his ADP distribution. That is not the number a drafter
-wants. He is looking at a board on which the player is *demonstrably still there*, so the question
-is P(survives to my next pick **given** he is here now).
-
-Availability is a monotone event — once a player is gone he stays gone — so that conditional is an
+wants, because it counts every pick from the top of the draft — including his own, and including
+the ones already made. Availability is a monotone event, so the conditional he does want is an
 exact ratio of two numbers the table already holds, not a new model:
 
-    p_survives = p(next pick) / p(the pick about to be made)
+    p_survives = p(pick after next) / p(next pick + 1)
 
-Case 20 is the case that pins this down. On the clock with back-to-back picks, the two picks are
-the same pick, the ratio is 1, and cost of waiting is zero for everybody — which is the whole point
-of user story 8: at the turn the tool must stop urging a reach when both players can simply be
-taken. Read against the raw unconditional number instead, De'Von Achane shows a 12% survival
-probability and a large cost of waiting at the exact moment the drafter is already on the clock.
+The denominator starts one past the pick being decided, because that pick is *mine* and I am the
+one passing: my own turn cannot be part of the hazard a player has to survive.
+
+Case 20 is the case that pins this down. At the turn the two picks are adjacent, numerator and
+denominator are the same pick, the ratio is one, and cost of waiting is zero for everybody — user
+story 8, that the tool stop urging a reach when both players can simply be taken. Read off the raw
+column instead, De'Von Achane shows a 9% survival probability and a large cost of waiting from a
+seat that is about to pick twice in a row.
 
 ## Vocabulary
 
@@ -37,12 +43,12 @@ import pytest
 from src.draft.candidates import CANDIDATE_COLUMNS
 from src.draft.waiting import WAITING_COLUMNS, rank_by_cost_of_waiting
 
-# The pick about to be made is `picks_made + 1`, and the conditional ratio's denominator is read
-# there. Most cases below sit a seat mid-round: 29 picks gone, pick 30 on the clock, my next turn
-# at 56. Cases that need the turn set them equal instead.
-PICKS_MADE = 29
-NOW = PICKS_MADE + 1
-NEXT_PICK = 56
+# Seat 1 of 14 picks 1, 28, 29, 56, 57. Most cases below have it deciding pick 29 and waiting
+# until 56, so the gap it has to survive opens at pick 30. Cases about the turn use 28 and 29
+# instead, where that gap is empty.
+NEXT_PICK = 29
+WAIT_TO = 56
+GAP_STARTS = NEXT_PICK + 1
 
 
 def board(*rows: dict) -> pd.DataFrame:
@@ -96,7 +102,8 @@ def picks(**overrides) -> dict:
         "roster": pd.DataFrame(),
         "unmatched": [],
         "next_pick": NEXT_PICK,
-        "picks_made": PICKS_MADE,
+        "pick_after_next": WAIT_TO,
+        "picks_made": NEXT_PICK - 1,
         **overrides,
     }
 
@@ -116,19 +123,19 @@ def row_for(result: dict, name: str) -> pd.Series:
 # 20. At the turn, where the next pick is the immediately following selection, every survival
 #     probability is at its maximum and cost of waiting is therefore near zero for all candidates.
 def test_at_the_turn_nothing_costs_anything_to_wait_for():
-    # Seat 1 in a 14-team snake picks 28 and 29 back to back. On the clock at 28 with 27 gone,
-    # the pick about to be made *is* my next pick, so there is no gap to survive.
+    # Seat 1 in a 14-team snake picks 28 and 29 back to back. Deciding 28, the turn a passed-over
+    # player must survive to is 29 — the immediately following selection, so there is no gap.
     result = rank_by_cost_of_waiting(
         board(
             player("00-0000001", "Fragile Back", 118.8),
             player("00-0000002", "Likely Back", 93.7),
             player("00-0000003", "Safe Receiver", 85.3, position="WR"),
         ),
-        # Real numbers off the sleeper board at pick 28. Unconditionally the first of these is 88%
-        # gone; conditional on him sitting in front of me right now he is certain to last a gap of
-        # no picks at all. A ranking built on the raw column fails here, which is the point.
-        survival(*at(28, ("00-0000001", 0.122), ("00-0000002", 0.562), ("00-0000003", 0.934))),
-        picks(picks_made=27, next_pick=28),
+        # Real numbers off the sleeper board at pick 29. Unconditionally the first of these is 91%
+        # gone; conditional on his surviving the picks *other* people make in between — of which
+        # there are none — he is certain. A ranking built on the raw column fails here.
+        survival(*at(29, ("00-0000001", 0.086), ("00-0000002", 0.500), ("00-0000003", 0.917))),
+        picks(next_pick=28, pick_after_next=29, picks_made=27),
     )
 
     assert list(result["candidates"]["p_survives"]) == [1.0, 1.0, 1.0]
@@ -143,8 +150,8 @@ def test_a_gap_of_real_picks_does_cost_something():
         player("00-0000002", "Likely Back", 93.7),
     )
     frame = survival(
-        *at(NOW, ("00-0000001", 1.0), ("00-0000002", 1.0)),
-        *at(NEXT_PICK, ("00-0000001", 0.1), ("00-0000002", 0.9)),
+        *at(GAP_STARTS, ("00-0000001", 1.0), ("00-0000002", 1.0)),
+        *at(WAIT_TO, ("00-0000001", 0.1), ("00-0000002", 0.9)),
     )
 
     result = rank_by_cost_of_waiting(the_board, frame, picks())
@@ -166,9 +173,9 @@ def test_of_two_equally_valuable_players_the_one_less_likely_to_last_ranks_highe
             player("00-0000004", "Backup Tight End", 50.0, position="TE"),
         ),
         survival(
-            *at(NOW, ("00-0000001", 1.0), ("00-0000002", 1.0),
+            *at(GAP_STARTS, ("00-0000001", 1.0), ("00-0000002", 1.0),
                      ("00-0000003", 1.0), ("00-0000004", 1.0)),
-            *at(NEXT_PICK, ("00-0000001", 0.2), ("00-0000002", 1.0),
+            *at(WAIT_TO, ("00-0000001", 0.2), ("00-0000002", 1.0),
                            ("00-0000003", 0.8), ("00-0000004", 1.0)),
         ),
         picks(),
@@ -197,8 +204,8 @@ def test_of_two_players_costing_the_same_to_wait_for_the_more_valuable_ranks_hig
             player("00-0000002", "Greater Receiver", 200.0, position="WR"),
         ),
         survival(
-            *at(NOW, ("00-0000001", 1.0), ("00-0000002", 1.0)),
-            *at(NEXT_PICK, ("00-0000001", 0.5), ("00-0000002", 0.75)),
+            *at(GAP_STARTS, ("00-0000001", 1.0), ("00-0000002", 1.0)),
+            *at(WAIT_TO, ("00-0000001", 0.5), ("00-0000002", 0.75)),
         ),
         picks(),
     )
@@ -216,8 +223,8 @@ def test_a_player_with_no_survival_data_is_ranked_by_value_and_flagged():
         player("00-0000002", "Mid Back", 60.0),
     ]
     frame = survival(
-        *at(NOW, ("00-0000001", 1.0), ("00-0000002", 1.0)),
-        *at(NEXT_PICK, ("00-0000001", 0.5), ("00-0000002", 1.0)),
+        *at(GAP_STARTS, ("00-0000001", 1.0), ("00-0000002", 1.0)),
+        *at(WAIT_TO, ("00-0000001", 0.5), ("00-0000002", 1.0)),
     )
     # Two of them, so "ranked by value" is an ordering that can be checked rather than a position
     # of one. The rookie outvalues everyone on the board and still cannot be given a cost.
@@ -258,7 +265,7 @@ def test_a_pick_past_the_survival_model_degrades_to_value_ranking():
             *at(168, ("00-0000001", 0.9), ("00-0000002", 0.8), ("00-0000003", 0.7)),
             *at(180, ("00-0000001", 0.5), ("00-0000002", 0.4), ("00-0000003", 0.3)),
         ),
-        picks(picks_made=195, next_pick=196),
+        picks(next_pick=195, pick_after_next=196, picks_made=194),
     )
 
     assert result["degraded"] is True
@@ -273,17 +280,17 @@ def test_a_pick_past_the_survival_model_degrades_to_value_ranking():
 # list leaves implicit, and the two judgement calls the spec did not reach.
 
 
-def test_the_probability_is_anchored_to_the_stated_next_pick():
-    """Change the pick, change the number: nothing here is a per-player constant."""
+def test_the_probability_is_anchored_to_the_pick_it_waits_to():
+    """Change the pick waited to, change the number: nothing here is a per-player constant."""
     the_board = board(player("00-0000001", "A Back", 100.0))
     frame = survival(
-        *at(NOW, ("00-0000001", 1.0)),
+        *at(GAP_STARTS, ("00-0000001", 1.0)),
         *at(40, ("00-0000001", 0.8)),
-        *at(NEXT_PICK, ("00-0000001", 0.3)),
+        *at(WAIT_TO, ("00-0000001", 0.3)),
     )
 
-    near = rank_by_cost_of_waiting(the_board, frame, picks(next_pick=40))
-    far = rank_by_cost_of_waiting(the_board, frame, picks(next_pick=NEXT_PICK))
+    near = rank_by_cost_of_waiting(the_board, frame, picks(pick_after_next=40))
+    far = rank_by_cost_of_waiting(the_board, frame, picks(pick_after_next=WAIT_TO))
 
     assert row_for(near, "A Back")["p_survives"] == pytest.approx(0.8)
     assert row_for(far, "A Back")["p_survives"] == pytest.approx(0.3)
@@ -305,9 +312,9 @@ def test_a_cliff_costs_more_to_wait_on_than_a_deep_position():
             player("00-0000004", "Deep Backup", 90.0, position="RB"),
         ),
         survival(
-            *at(NOW, ("00-0000001", 1.0), ("00-0000002", 1.0),
+            *at(GAP_STARTS, ("00-0000001", 1.0), ("00-0000002", 1.0),
                      ("00-0000003", 1.0), ("00-0000004", 1.0)),
-            *at(NEXT_PICK, ("00-0000001", 0.5), ("00-0000002", 1.0),
+            *at(WAIT_TO, ("00-0000001", 0.5), ("00-0000002", 1.0),
                            ("00-0000003", 0.5), ("00-0000004", 1.0)),
         ),
         picks(),
@@ -331,10 +338,10 @@ def test_a_player_the_table_drops_at_my_pick_is_gone_rather_than_unknown():
             player("00-0000002", "Next Back", 40.0),
         ),
         survival(
-            *at(NOW, ("00-0000001", 1.0), ("00-0000002", 1.0)),
+            *at(GAP_STARTS, ("00-0000001", 1.0), ("00-0000002", 1.0)),
             # No row for the faller at my pick; the other player still has one, so the frame
             # covers that pick and the absence is about him rather than about the table.
-            *at(NEXT_PICK, ("00-0000002", 1.0)),
+            *at(WAIT_TO, ("00-0000002", 1.0)),
         ),
         picks(),
     )
@@ -360,8 +367,8 @@ def test_a_player_the_table_already_had_gone_gets_no_probability_at_all():
         ),
         survival(
             ("00-0000001", 1, 1.0),
-            *at(NOW, ("00-0000002", 1.0)),
-            *at(NEXT_PICK, ("00-0000002", 0.5)),
+            *at(GAP_STARTS, ("00-0000002", 1.0)),
+            *at(WAIT_TO, ("00-0000002", 0.5)),
         ),
         picks(),
     )
@@ -379,11 +386,27 @@ def test_a_finished_draft_degrades_rather_than_raising():
             player("00-0000001", "Best Left", 40.0),
             player("00-0000002", "Second Left", 30.0, position="WR"),
         ),
-        survival(*at(NOW, ("00-0000001", 1.0), ("00-0000002", 1.0))),
-        picks(next_pick=None, picks_made=210),
+        survival(*at(GAP_STARTS, ("00-0000001", 1.0), ("00-0000002", 1.0))),
+        picks(next_pick=None, pick_after_next=None, picks_made=210),
     )
 
     assert result["degraded"] is True
+    assert names(result) == ["Best Left", "Second Left"]
+
+
+def test_the_last_round_has_nothing_to_wait_for_either():
+    """A seat's final pick has no later turn, so there is no gap and no cost to price."""
+    result = rank_by_cost_of_waiting(
+        board(
+            player("00-0000001", "Best Left", 40.0),
+            player("00-0000002", "Second Left", 30.0, position="WR"),
+        ),
+        survival(*at(GAP_STARTS, ("00-0000001", 1.0), ("00-0000002", 1.0))),
+        picks(next_pick=197, pick_after_next=None, picks_made=196),
+    )
+
+    assert result["degraded"] is True
+    assert result["candidates"]["cost_of_waiting"].isna().all()
     assert names(result) == ["Best Left", "Second Left"]
 
 
@@ -395,7 +418,7 @@ def test_a_fully_drafted_board_returns_no_candidates_without_raising():
 
     result = rank_by_cost_of_waiting(
         the_board,
-        survival(*at(NEXT_PICK, ("00-0000001", 0.5), ("00-0000002", 0.5))),
+        survival(*at(WAIT_TO, ("00-0000001", 0.5), ("00-0000002", 0.5))),
         picks(taken={"00-0000001", "00-0000002"}),
     )
 
@@ -412,8 +435,8 @@ def test_a_taken_player_never_appears_among_the_candidates():
             player("00-0000002", "Free Back", 120.0),
         ),
         survival(
-            *at(NOW, ("00-0000001", 1.0), ("00-0000002", 1.0)),
-            *at(NEXT_PICK, ("00-0000001", 0.5), ("00-0000002", 0.5)),
+            *at(GAP_STARTS, ("00-0000001", 1.0), ("00-0000002", 1.0)),
+            *at(WAIT_TO, ("00-0000001", 0.5), ("00-0000002", 0.5)),
         ),
         picks(taken={"00-0000001"}),
     )
@@ -434,8 +457,8 @@ def test_points_over_replacement_comes_back_exactly_as_the_board_priced_it():
             player("00-0000002", "Below Replacement", -12.5, position="WR"),
         ),
         survival(
-            *at(NOW, ("00-0000001", 1.0), ("00-0000002", 1.0)),
-            *at(NEXT_PICK, ("00-0000001", 0.5), ("00-0000002", 0.5)),
+            *at(GAP_STARTS, ("00-0000001", 1.0), ("00-0000002", 1.0)),
+            *at(WAIT_TO, ("00-0000001", 0.5), ("00-0000002", 0.5)),
         ),
         picks(),
     )
@@ -458,8 +481,8 @@ def test_filtering_to_one_position_leaves_every_cost_of_waiting_unchanged():
         player("00-0000003", "A Back", 200.0),
     )
     frame = survival(
-        *at(NOW, ("00-0000001", 1.0), ("00-0000002", 1.0), ("00-0000003", 1.0)),
-        *at(NEXT_PICK, ("00-0000001", 0.2), ("00-0000002", 0.9), ("00-0000003", 0.4)),
+        *at(GAP_STARTS, ("00-0000001", 1.0), ("00-0000002", 1.0), ("00-0000003", 1.0)),
+        *at(WAIT_TO, ("00-0000001", 0.2), ("00-0000002", 0.9), ("00-0000003", 0.4)),
     )
 
     everyone = rank_by_cost_of_waiting(the_board, frame, picks())
@@ -479,8 +502,8 @@ def test_the_inputs_are_left_exactly_as_they_were_handed_in():
         player("00-0000002", "A Receiver", 120.0, position="WR"),
     )
     frame = survival(
-        *at(NOW, ("00-0000001", 1.0), ("00-0000002", 1.0)),
-        *at(NEXT_PICK, ("00-0000001", 0.5), ("00-0000002", 0.5)),
+        *at(GAP_STARTS, ("00-0000001", 1.0), ("00-0000002", 1.0)),
+        *at(WAIT_TO, ("00-0000001", 0.5), ("00-0000002", 0.5)),
     )
     board_before = the_board.copy(deep=True)
     frame_before = frame.copy(deep=True)
@@ -497,16 +520,18 @@ def test_the_inputs_are_left_exactly_as_they_were_handed_in():
 
 
 def test_a_probability_is_never_read_off_the_wrong_pick():
-    """The denominator is the pick about to be made, not the last one completed.
+    """The denominator starts one past my own turn, not at it.
 
-    An off-by-one here is invisible: every number stays in range and the ordering barely moves,
-    which is the worst shape a draft-night error can have.
+    The pick being decided is mine, and I am the one passing, so it cannot be part of the hazard a
+    player has to survive — counting it would charge me for the chance that I take him myself. An
+    off-by-one here is invisible: every number stays in range and the ordering barely moves, which
+    is the worst shape a draft-night error can have.
     """
     the_board = board(player("00-0000001", "A Back", 100.0))
     frame = survival(
-        ("00-0000001", PICKS_MADE, 0.5),
-        ("00-0000001", NOW, 0.4),
-        ("00-0000001", NEXT_PICK, 0.2),
+        ("00-0000001", NEXT_PICK, 0.5),
+        ("00-0000001", GAP_STARTS, 0.4),
+        ("00-0000001", WAIT_TO, 0.2),
     )
 
     result = rank_by_cost_of_waiting(the_board, frame, picks())
@@ -524,8 +549,8 @@ def test_a_probability_never_comes_back_above_one_or_below_zero():
         ),
         survival(
             # A ratio a hair over one, which floating point reaches on its own.
-            *at(NOW, ("00-0000001", 0.3), ("00-0000002", 1.0)),
-            *at(NEXT_PICK, ("00-0000001", 0.30000000000000004), ("00-0000002", 0.0)),
+            *at(GAP_STARTS, ("00-0000001", 0.3), ("00-0000002", 1.0)),
+            *at(WAIT_TO, ("00-0000001", 0.30000000000000004), ("00-0000002", 0.0)),
         ),
         picks(),
     )

--- a/tests/test_draft_waiting.py
+++ b/tests/test_draft_waiting.py
@@ -1,0 +1,535 @@
+"""Spec cases 20-24 from issue #37: rank the board by what it costs to pass, not by raw value.
+
+These assert what comes *out* of `rank_by_cost_of_waiting` for a given board, survival frame and
+set of picks — never how it gets there. Fixtures are a handful of players with values and
+probabilities chosen so the expected number can be worked out on paper, which is the only kind of
+expectation that survives a rebuild of the warehouse those inputs really come from.
+
+## The one thing worth reading before the cases
+
+`draft_availability` holds an **unconditional** probability: P(this player's draft position lands
+at or after pick k), computed days ago from his ADP distribution. That is not the number a drafter
+wants. He is looking at a board on which the player is *demonstrably still there*, so the question
+is P(survives to my next pick **given** he is here now).
+
+Availability is a monotone event — once a player is gone he stays gone — so that conditional is an
+exact ratio of two numbers the table already holds, not a new model:
+
+    p_survives = p(next pick) / p(the pick about to be made)
+
+Case 20 is the case that pins this down. On the clock with back-to-back picks, the two picks are
+the same pick, the ratio is 1, and cost of waiting is zero for everybody — which is the whole point
+of user story 8: at the turn the tool must stop urging a reach when both players can simply be
+taken. Read against the raw unconditional number instead, De'Von Achane shows a 12% survival
+probability and a large cost of waiting at the exact moment the drafter is already on the clock.
+
+## Vocabulary
+
+`p_survives`, never `p_available`. The glossary already spends *availability* on the share of a
+season a player can play, and the board carries a column with that meaning. Renaming the warehouse
+table is out of scope; using its word for a different thing anywhere the drafter can see is not.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from src.draft.candidates import CANDIDATE_COLUMNS
+from src.draft.waiting import WAITING_COLUMNS, rank_by_cost_of_waiting
+
+# The pick about to be made is `picks_made + 1`, and the conditional ratio's denominator is read
+# there. Most cases below sit a seat mid-round: 29 picks gone, pick 30 on the clock, my next turn
+# at 56. Cases that need the turn set them equal instead.
+PICKS_MADE = 29
+NOW = PICKS_MADE + 1
+NEXT_PICK = 56
+
+
+def board(*rows: dict) -> pd.DataFrame:
+    """A board with the columns ranking reads, plus one it must leave behind."""
+    defaults = {
+        "player_id": "00-0000001",
+        "player_name": "A Back",
+        "position": "RB",
+        "team": "SF",
+        "points_over_replacement": 100.0,
+        "consensus_adp": 24.5,
+    }
+    return pd.DataFrame(
+        [{**defaults, **row} for row in rows], columns=list(defaults)
+    )
+
+
+def player(player_id: str, name: str, por: float, position: str = "RB", **rest) -> dict:
+    """One board row, in the order the arguments read on the page."""
+    return {
+        "player_id": player_id,
+        "player_name": name,
+        "position": position,
+        "points_over_replacement": por,
+        **rest,
+    }
+
+
+def survival(*rows: tuple) -> pd.DataFrame:
+    """The survival frame, as `(player_id, overall_pick, p_survives)` triples.
+
+    Shaped like what the warehouse hands over: one row per player per pick, and *no row at all*
+    where the player's probability has fallen under the table's own floor or past the latest pick
+    he has ever actually lasted to. Absence is therefore data, not a gap — which is why two of the
+    cases below are about telling one from the other.
+    """
+    return pd.DataFrame(
+        list(rows), columns=["player_id", "overall_pick", "p_survives"]
+    ).astype({"player_id": "object", "overall_pick": "int64", "p_survives": "float64"})
+
+
+def at(pick: int, *pairs: tuple) -> list[tuple]:
+    """Every player's probability at one pick, as rows for `survival`."""
+    return [(player_id, pick, probability) for player_id, probability in pairs]
+
+
+def picks(**overrides) -> dict:
+    """What `ingest_picks` returns — only the three keys the ranking actually reads."""
+    return {
+        "taken": set(),
+        "roster": pd.DataFrame(),
+        "unmatched": [],
+        "next_pick": NEXT_PICK,
+        "picks_made": PICKS_MADE,
+        **overrides,
+    }
+
+
+def names(result: dict) -> list[str]:
+    """The candidate names in the order they came back."""
+    return list(result["candidates"]["player_name"])
+
+
+def row_for(result: dict, name: str) -> pd.Series:
+    """One candidate's row, so a claim is about that player alone."""
+    matched = result["candidates"].loc[result["candidates"]["player_name"] == name]
+    assert len(matched) == 1, f"expected exactly one row for {name!r}, got {len(matched)}"
+    return matched.iloc[0]
+
+
+# 20. At the turn, where the next pick is the immediately following selection, every survival
+#     probability is at its maximum and cost of waiting is therefore near zero for all candidates.
+def test_at_the_turn_nothing_costs_anything_to_wait_for():
+    # Seat 1 in a 14-team snake picks 28 and 29 back to back. On the clock at 28 with 27 gone,
+    # the pick about to be made *is* my next pick, so there is no gap to survive.
+    result = rank_by_cost_of_waiting(
+        board(
+            player("00-0000001", "Fragile Back", 118.8),
+            player("00-0000002", "Likely Back", 93.7),
+            player("00-0000003", "Safe Receiver", 85.3, position="WR"),
+        ),
+        # Real numbers off the sleeper board at pick 28. Unconditionally the first of these is 88%
+        # gone; conditional on him sitting in front of me right now he is certain to last a gap of
+        # no picks at all. A ranking built on the raw column fails here, which is the point.
+        survival(*at(28, ("00-0000001", 0.122), ("00-0000002", 0.562), ("00-0000003", 0.934))),
+        picks(picks_made=27, next_pick=28),
+    )
+
+    assert list(result["candidates"]["p_survives"]) == [1.0, 1.0, 1.0]
+    assert list(result["candidates"]["cost_of_waiting"]) == [0.0, 0.0, 0.0]
+    assert result["degraded"] is False
+
+
+def test_a_gap_of_real_picks_does_cost_something():
+    """The other half of case 20: the collapse is the turn's doing, not the function's."""
+    the_board = board(
+        player("00-0000001", "Fragile Back", 118.8),
+        player("00-0000002", "Likely Back", 93.7),
+    )
+    frame = survival(
+        *at(NOW, ("00-0000001", 1.0), ("00-0000002", 1.0)),
+        *at(NEXT_PICK, ("00-0000001", 0.1), ("00-0000002", 0.9)),
+    )
+
+    result = rank_by_cost_of_waiting(the_board, frame, picks())
+
+    assert row_for(result, "Fragile Back")["cost_of_waiting"] > 0
+    assert row_for(result, "Likely Back")["cost_of_waiting"] > 0
+
+
+# 21. Given two players with equal points over replacement, the one less likely to survive to the
+#     next pick ranks higher.
+def test_of_two_equally_valuable_players_the_one_less_likely_to_last_ranks_higher():
+    # Two positions built to be structurally identical — same top value, same backup value, same
+    # backup probability — so the survival probability is the only thing that differs.
+    result = rank_by_cost_of_waiting(
+        board(
+            player("00-0000001", "Fragile Quarterback", 100.0, position="QB"),
+            player("00-0000002", "Backup Quarterback", 50.0, position="QB"),
+            player("00-0000003", "Safe Tight End", 100.0, position="TE"),
+            player("00-0000004", "Backup Tight End", 50.0, position="TE"),
+        ),
+        survival(
+            *at(NOW, ("00-0000001", 1.0), ("00-0000002", 1.0),
+                     ("00-0000003", 1.0), ("00-0000004", 1.0)),
+            *at(NEXT_PICK, ("00-0000001", 0.2), ("00-0000002", 1.0),
+                           ("00-0000003", 0.8), ("00-0000004", 1.0)),
+        ),
+        picks(),
+    )
+
+    ranked = names(result)
+    assert ranked.index("Fragile Quarterback") < ranked.index("Safe Tight End")
+    # Equal value is the premise, so it has to be true of what came back rather than of the fixture.
+    assert (
+        row_for(result, "Fragile Quarterback")["points_over_replacement"]
+        == row_for(result, "Safe Tight End")["points_over_replacement"]
+    )
+    # 100 - [0.2 x 100 + 0.8 x 50] against 100 - [0.8 x 100 + 0.2 x 50], worked out by hand.
+    assert row_for(result, "Fragile Quarterback")["cost_of_waiting"] == pytest.approx(40.0)
+    assert row_for(result, "Safe Tight End")["cost_of_waiting"] == pytest.approx(10.0)
+
+
+# 22. Given two players with equal cost of waiting, the higher points over replacement ranks
+#     higher.
+def test_of_two_players_costing_the_same_to_wait_for_the_more_valuable_ranks_higher():
+    # One player at each position, so cost of waiting is just value x P(gone): 100 x 0.5 and
+    # 200 x 0.25 both come to 50.
+    result = rank_by_cost_of_waiting(
+        board(
+            player("00-0000001", "Lesser Back", 100.0),
+            player("00-0000002", "Greater Receiver", 200.0, position="WR"),
+        ),
+        survival(
+            *at(NOW, ("00-0000001", 1.0), ("00-0000002", 1.0)),
+            *at(NEXT_PICK, ("00-0000001", 0.5), ("00-0000002", 0.75)),
+        ),
+        picks(),
+    )
+
+    assert row_for(result, "Lesser Back")["cost_of_waiting"] == pytest.approx(50.0)
+    assert row_for(result, "Greater Receiver")["cost_of_waiting"] == pytest.approx(50.0)
+    assert names(result) == ["Greater Receiver", "Lesser Back"]
+
+
+# 23. A player with no row in the survival frame is ranked by points over replacement and flagged
+#     as lacking survival data, and his missing probability is never treated as a number.
+def test_a_player_with_no_survival_data_is_ranked_by_value_and_flagged():
+    priced = [
+        player("00-0000001", "Priced Back", 120.0),
+        player("00-0000002", "Mid Back", 60.0),
+    ]
+    frame = survival(
+        *at(NOW, ("00-0000001", 1.0), ("00-0000002", 1.0)),
+        *at(NEXT_PICK, ("00-0000001", 0.5), ("00-0000002", 1.0)),
+    )
+    # Two of them, so "ranked by value" is an ordering that can be checked rather than a position
+    # of one. The rookie outvalues everyone on the board and still cannot be given a cost.
+    unpriced = [
+        player("00-0000003", "Unpriced Rookie", 200.0, position="WR"),
+        player("00-0000004", "Unpriced Camp Body", 30.0, position="WR"),
+    ]
+
+    result = rank_by_cost_of_waiting(board(*priced, *unpriced), frame, picks())
+
+    rookie = row_for(result, "Unpriced Rookie")
+    assert rookie["survival_known"] == False  # noqa: E712 — the flag itself is the claim
+    assert pd.isna(rookie["p_survives"])
+    assert pd.isna(rookie["cost_of_waiting"])
+    # Ranked by value: after everyone who has a cost of waiting, and among themselves by value.
+    assert names(result)[-2:] == ["Unpriced Rookie", "Unpriced Camp Body"]
+
+    # The strong form of "never treated as a number": a missing probability is not silently a 0 or
+    # a 1, so the players who *do* have one price identically whether or not he is on the board.
+    without = rank_by_cost_of_waiting(board(*priced), frame, picks())
+    assert row_for(result, "Priced Back")["cost_of_waiting"] == pytest.approx(
+        row_for(without, "Priced Back")["cost_of_waiting"]
+    )
+
+
+# 24. A next pick number beyond the survival frame's coverage produces a result flagged as degraded
+#     to value ranking.
+def test_a_pick_past_the_survival_model_degrades_to_value_ranking():
+    # The sleeper table stops at overall pick 180 against a 210-pick draft, so the last two rounds
+    # genuinely fall off the end of it. This is that, in miniature.
+    result = rank_by_cost_of_waiting(
+        board(
+            player("00-0000001", "Best Left", 40.0),
+            player("00-0000002", "Second Left", 30.0, position="WR"),
+            player("00-0000003", "Third Left", 20.0, position="TE"),
+        ),
+        survival(
+            *at(168, ("00-0000001", 0.9), ("00-0000002", 0.8), ("00-0000003", 0.7)),
+            *at(180, ("00-0000001", 0.5), ("00-0000002", 0.4), ("00-0000003", 0.3)),
+        ),
+        picks(picks_made=195, next_pick=196),
+    )
+
+    assert result["degraded"] is True
+    # Named, because "degraded" on its own does not tell a drafter what the tool still covers.
+    assert result["covers_to"] == 180
+    assert result["candidates"]["p_survives"].isna().all()
+    assert result["candidates"]["cost_of_waiting"].isna().all()
+    assert names(result) == ["Best Left", "Second Left", "Third Left"]
+
+
+# The cases below were not numbered in the spec. They cover the acceptance criteria the numbered
+# list leaves implicit, and the two judgement calls the spec did not reach.
+
+
+def test_the_probability_is_anchored_to_the_stated_next_pick():
+    """Change the pick, change the number: nothing here is a per-player constant."""
+    the_board = board(player("00-0000001", "A Back", 100.0))
+    frame = survival(
+        *at(NOW, ("00-0000001", 1.0)),
+        *at(40, ("00-0000001", 0.8)),
+        *at(NEXT_PICK, ("00-0000001", 0.3)),
+    )
+
+    near = rank_by_cost_of_waiting(the_board, frame, picks(next_pick=40))
+    far = rank_by_cost_of_waiting(the_board, frame, picks(next_pick=NEXT_PICK))
+
+    assert row_for(near, "A Back")["p_survives"] == pytest.approx(0.8)
+    assert row_for(far, "A Back")["p_survives"] == pytest.approx(0.3)
+    assert row_for(far, "A Back")["cost_of_waiting"] > row_for(near, "A Back")["cost_of_waiting"]
+
+
+def test_a_cliff_costs_more_to_wait_on_than_a_deep_position():
+    """The headline claim of the ticket, and the reason value alone is not enough.
+
+    Two players with identical value and identical survival probability. The one whose position
+    falls off a cliff behind him is expensive to pass on; the one with a near-equal player behind
+    him is cheap. Nothing about the players themselves distinguishes them.
+    """
+    result = rank_by_cost_of_waiting(
+        board(
+            player("00-0000001", "Cliff Tight End", 100.0, position="TE"),
+            player("00-0000002", "Cliff Backup", 10.0, position="TE"),
+            player("00-0000003", "Deep Back", 100.0, position="RB"),
+            player("00-0000004", "Deep Backup", 90.0, position="RB"),
+        ),
+        survival(
+            *at(NOW, ("00-0000001", 1.0), ("00-0000002", 1.0),
+                     ("00-0000003", 1.0), ("00-0000004", 1.0)),
+            *at(NEXT_PICK, ("00-0000001", 0.5), ("00-0000002", 1.0),
+                           ("00-0000003", 0.5), ("00-0000004", 1.0)),
+        ),
+        picks(),
+    )
+
+    assert row_for(result, "Cliff Tight End")["cost_of_waiting"] == pytest.approx(45.0)
+    assert row_for(result, "Deep Back")["cost_of_waiting"] == pytest.approx(5.0)
+    assert names(result)[0] == "Cliff Tight End"
+
+
+def test_a_player_the_table_drops_at_my_pick_is_gone_rather_than_unknown():
+    """Absence at one pick is a probability of zero, not missing data.
+
+    The warehouse drops a row once the probability falls under its own floor, and clips it to zero
+    past the latest pick the player has ever actually lasted to. Both mean *gone*. Reading that as
+    "no data" would flag the most certain players on the board as the least certain.
+    """
+    result = rank_by_cost_of_waiting(
+        board(
+            player("00-0000001", "Certain Faller", 100.0),
+            player("00-0000002", "Next Back", 40.0),
+        ),
+        survival(
+            *at(NOW, ("00-0000001", 1.0), ("00-0000002", 1.0)),
+            # No row for the faller at my pick; the other player still has one, so the frame
+            # covers that pick and the absence is about him rather than about the table.
+            *at(NEXT_PICK, ("00-0000002", 1.0)),
+        ),
+        picks(),
+    )
+
+    faller = row_for(result, "Certain Faller")
+    assert faller["survival_known"] == True  # noqa: E712 — the flag itself is the claim
+    assert faller["p_survives"] == 0.0
+    # Certain to be gone, so waiting costs the whole drop to the next back: 100 - 40.
+    assert faller["cost_of_waiting"] == pytest.approx(60.0)
+
+
+def test_a_player_the_table_already_had_gone_gets_no_probability_at_all():
+    """The other side of that: the model has been overtaken by events, so it has nothing to say.
+
+    A player with no row at the pick about to be made is one the table says is *already* gone —
+    yet here he sits on the board. The conditional has a zero denominator, and there is no honest
+    number to put in its place, so he is flagged like anyone else the model does not cover.
+    """
+    result = rank_by_cost_of_waiting(
+        board(
+            player("00-0000001", "Long Faller", 100.0),
+            player("00-0000002", "Priced Back", 40.0),
+        ),
+        survival(
+            ("00-0000001", 1, 1.0),
+            *at(NOW, ("00-0000002", 1.0)),
+            *at(NEXT_PICK, ("00-0000002", 0.5)),
+        ),
+        picks(),
+    )
+
+    faller = row_for(result, "Long Faller")
+    assert faller["survival_known"] == False  # noqa: E712 — the flag itself is the claim
+    assert pd.isna(faller["p_survives"])
+    assert pd.isna(faller["cost_of_waiting"])
+    assert result["degraded"] is False
+
+
+def test_a_finished_draft_degrades_rather_than_raising():
+    result = rank_by_cost_of_waiting(
+        board(
+            player("00-0000001", "Best Left", 40.0),
+            player("00-0000002", "Second Left", 30.0, position="WR"),
+        ),
+        survival(*at(NOW, ("00-0000001", 1.0), ("00-0000002", 1.0))),
+        picks(next_pick=None, picks_made=210),
+    )
+
+    assert result["degraded"] is True
+    assert names(result) == ["Best Left", "Second Left"]
+
+
+def test_a_fully_drafted_board_returns_no_candidates_without_raising():
+    the_board = board(
+        player("00-0000001", "A Back", 150.0),
+        player("00-0000002", "A Receiver", 120.0, position="WR"),
+    )
+
+    result = rank_by_cost_of_waiting(
+        the_board,
+        survival(*at(NEXT_PICK, ("00-0000001", 0.5), ("00-0000002", 0.5))),
+        picks(taken={"00-0000001", "00-0000002"}),
+    )
+
+    assert len(result["candidates"]) == 0
+    # An empty frame with no columns would break the renderer at the end of a draft, which is
+    # exactly when nobody wants to find out. The shape has to survive the emptiness.
+    assert list(result["candidates"].columns) == WAITING_COLUMNS
+
+
+def test_a_taken_player_never_appears_among_the_candidates():
+    result = rank_by_cost_of_waiting(
+        board(
+            player("00-0000001", "Taken Back", 150.0),
+            player("00-0000002", "Free Back", 120.0),
+        ),
+        survival(
+            *at(NOW, ("00-0000001", 1.0), ("00-0000002", 1.0)),
+            *at(NEXT_PICK, ("00-0000001", 0.5), ("00-0000002", 0.5)),
+        ),
+        picks(taken={"00-0000001"}),
+    )
+
+    assert names(result) == ["Free Back"]
+    assert "00-0000001" not in set(result["candidates"]["player_id"])
+    # A player already drafted is not a fallback either — the cost of passing on the free back is
+    # measured against nobody, not against the man who has gone.
+    assert row_for(result, "Free Back")["cost_of_waiting"] == pytest.approx(60.0)
+
+
+def test_points_over_replacement_comes_back_exactly_as_the_board_priced_it():
+    result = rank_by_cost_of_waiting(
+        board(
+            player("00-0000001", "Still Here", 140.0),
+            # Replacement level is a real player, so someone ranked below him prices out under
+            # zero. A rescale or a floor-at-zero would quietly eat this.
+            player("00-0000002", "Below Replacement", -12.5, position="WR"),
+        ),
+        survival(
+            *at(NOW, ("00-0000001", 1.0), ("00-0000002", 1.0)),
+            *at(NEXT_PICK, ("00-0000001", 0.5), ("00-0000002", 0.5)),
+        ),
+        picks(),
+    )
+
+    assert list(result["candidates"]["points_over_replacement"]) == [140.0, -12.5]
+    assert list(result["candidates"].columns) == WAITING_COLUMNS
+    assert WAITING_COLUMNS[: len(CANDIDATE_COLUMNS)] == CANDIDATE_COLUMNS
+
+
+def test_filtering_to_one_position_leaves_every_cost_of_waiting_unchanged():
+    """A display filter, and nothing more.
+
+    Cost of waiting is measured against the players who would still be there at my next pick,
+    which is a fact about the whole board. Narrowing the screen to quarterbacks must not reprice
+    the quarterbacks as though the rest of the board had been drafted.
+    """
+    the_board = board(
+        player("00-0000001", "A Quarterback", 150.0, position="QB"),
+        player("00-0000002", "Another Quarterback", 90.0, position="QB"),
+        player("00-0000003", "A Back", 200.0),
+    )
+    frame = survival(
+        *at(NOW, ("00-0000001", 1.0), ("00-0000002", 1.0), ("00-0000003", 1.0)),
+        *at(NEXT_PICK, ("00-0000001", 0.2), ("00-0000002", 0.9), ("00-0000003", 0.4)),
+    )
+
+    everyone = rank_by_cost_of_waiting(the_board, frame, picks())
+    quarterbacks = rank_by_cost_of_waiting(the_board, frame, picks(), position="QB")
+
+    assert names(quarterbacks) == ["A Quarterback", "Another Quarterback"]
+    assert set(quarterbacks["candidates"]["position"]) == {"QB"}
+    for name in ["A Quarterback", "Another Quarterback"]:
+        assert row_for(quarterbacks, name)["cost_of_waiting"] == pytest.approx(
+            row_for(everyone, name)["cost_of_waiting"]
+        )
+
+
+def test_the_inputs_are_left_exactly_as_they_were_handed_in():
+    the_board = board(
+        player("00-0000001", "A Back", 150.0),
+        player("00-0000002", "A Receiver", 120.0, position="WR"),
+    )
+    frame = survival(
+        *at(NOW, ("00-0000001", 1.0), ("00-0000002", 1.0)),
+        *at(NEXT_PICK, ("00-0000001", 0.5), ("00-0000002", 0.5)),
+    )
+    board_before = the_board.copy(deep=True)
+    frame_before = frame.copy(deep=True)
+    the_picks = picks(taken={"00-0000001"})
+    taken_before = set(the_picks["taken"])
+
+    rank_by_cost_of_waiting(the_board, frame, the_picks)
+
+    # Both frames are read by every other surface on the screen. Sorting or filtering either in
+    # place here would silently change what those surfaces see.
+    pd.testing.assert_frame_equal(the_board, board_before)
+    pd.testing.assert_frame_equal(frame, frame_before)
+    assert the_picks["taken"] == taken_before
+
+
+def test_a_probability_is_never_read_off_the_wrong_pick():
+    """The denominator is the pick about to be made, not the last one completed.
+
+    An off-by-one here is invisible: every number stays in range and the ordering barely moves,
+    which is the worst shape a draft-night error can have.
+    """
+    the_board = board(player("00-0000001", "A Back", 100.0))
+    frame = survival(
+        ("00-0000001", PICKS_MADE, 0.5),
+        ("00-0000001", NOW, 0.4),
+        ("00-0000001", NEXT_PICK, 0.2),
+    )
+
+    result = rank_by_cost_of_waiting(the_board, frame, picks())
+
+    # 0.2 / 0.4, not 0.2 / 0.5.
+    assert row_for(result, "A Back")["p_survives"] == pytest.approx(0.5)
+
+
+def test_a_probability_never_comes_back_above_one_or_below_zero():
+    """Belt and braces on the ratio, since a probability out of range would print as one."""
+    result = rank_by_cost_of_waiting(
+        board(
+            player("00-0000001", "A Back", 100.0),
+            player("00-0000002", "A Receiver", 80.0, position="WR"),
+        ),
+        survival(
+            # A ratio a hair over one, which floating point reaches on its own.
+            *at(NOW, ("00-0000001", 0.3), ("00-0000002", 1.0)),
+            *at(NEXT_PICK, ("00-0000001", 0.30000000000000004), ("00-0000002", 0.0)),
+        ),
+        picks(),
+    )
+
+    probabilities = result["candidates"]["p_survives"]
+    assert probabilities.between(0.0, 1.0).all()
+    assert not np.isinf(probabilities).any()


### PR DESCRIPTION
Closes #37.

The ranking changes from what a player is worth to what it costs to pass on him.

## What it does

Cost of waiting is the points over replacement expected to be lost by passing on a player at one turn and hoping he lasts to the seat's next one. Within a position, in value order, the expected best available walks up from the bottom, and each player's cost is his value minus it — which rearranges to *the chance he is gone × the drop to whoever is expected to be there instead*. So a deep position is cheap to wait on even when the individual player is likely to go, and a cliff is expensive even when he will probably last.

Both inputs are frozen. `points_over_replacement` comes back exactly as the board priced it, and the probabilities exactly as `draft_availability` computed them days ago. Nothing is refitted on the night.

```
Best available — 12 of 655, ranked by cost of waiting to pick #28
  SURV — survival probability, the chance he survives to that pick; COST — what waiting gives up
    #  POS  PLAYER                  TM   BYE      PoR   SURV     COST
    1  RB   Bijan Robinson          ATL   11    178.4     0%     83.5
    2  RB   Jahmyr Gibbs            DET    6    178.1     0%     83.1
    3  QB   Josh Allen              BUF    7    160.5     0%     72.0
    4  WR   Puka Nacua              LA    11    129.7     0%     52.4
    ...
    8  RB   Jonathan Taylor         IND   13    129.2     0%     34.3
```

Jonathan Taylor prices above three of the receivers above him and ranks below them, which is the whole point: running back is deep behind him and receiver is not.

## The one decision worth reviewing

`draft_availability` holds an **unconditional** probability — P(his draft position lands at or after pick k), counting every pick from the top of the draft including my own. That is not the number a drafter wants, and reading it raw makes the tool urge a reach at the turn. Availability is a monotone event, so the conditional is an exact ratio of two numbers the table already holds:

```
p_survives = p(pick after next) / p(next pick + 1)
```

The denominator starts one past the turn being decided because that turn is *mine* and I am the one passing — my own pick cannot be part of the hazard a player has to survive. At the turn the two picks are adjacent, the ratio is one, and cost of waiting is zero for everybody. That is acceptance criterion 3 and user story 8, true by arithmetic rather than by fixture.

`ingest_picks` therefore reports both of the seat's picks. `next_pick` is the turn being decided; `pick_after_next` is what a passed-over player has to survive to. One number cannot say that — on the clock, `next_pick` is the pick being made and everybody survives to it by definition.

## Three kinds of missing, and only one of them is missing data

The warehouse drops a row once the probability falls under its 1% floor, and clips it to zero past the latest pick the player has ever actually lasted to, so absence is usually *data*:

- **No row at the pick I am waiting to** → he is gone. `p_survives` 0, and waiting costs the full drop to whoever is behind him.
- **No row at the pick the gap opens on** → the table already had him gone and here he sits. Zero denominator, no honest number.
- **No row anywhere** → no ADP, nothing to say.

The last two are flagged, ranked by value at the end of the list, and never enter anyone else's fallback expectation. Past pick 180 — the last the sleeper survival table covers — the whole ranking falls back to value and says so, naming both pick numbers.

## Verified

- 100 tests pass, including spec cases 20-24 written and committed before the implementation.
- Run against the live draft at pick 1, and against synthetic ADP-ordered payloads at the turn (all free), across a real 26-pick gap, past the model's coverage, and at the seat's final pick.

## Note on the two commits

The test commit encoded a misreading of "next pick" — running the tool against the real draft showed every candidate at 100% / 0.0 at the 1.01. The claims of cases 20-24 are unchanged; the two pick numbers feeding them are corrected in the feature commit, and the correction is written up in both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)