### PR TITLE
Keep the board refreshing as picks come in

### DIFF
--- a/src/draft/live.py
+++ b/src/draft/live.py
@@ -1,11 +1,43 @@
-"""Render the live draft board once, from the terminal, and exit.
+"""Keep the live draft board current from the terminal, until it is interrupted.
 
     python -m src.draft.live
     python -m src.draft.live --limit 50
+    python -m src.draft.live --once
 
-The first thing here that can be pointed at a real draft. It resolves my seat from the draft
-order, reads the picks made so far, subtracts them from the board the warehouse built days ago,
-and prints what is left. Then it stops — refreshing as picks come in is the next ticket.
+It resolves my seat from the draft order, reads the picks made so far, subtracts them from the
+board the warehouse built days ago, and prints what is left — then does that again every few
+seconds for the length of the draft, redrawing only when the picks have actually changed. What
+counts as a change, and what the live line under the board says, are both in `refresh`.
+
+## The screen appends, and the status line does not
+
+A changed board is drawn *below* the last one rather than over a cleared screen, so the whole
+draft stays in scrollback: what the board looked like at pick 14 is worth being able to scroll
+back to at pick 40, and a tool that clears itself every three seconds has thrown that away. The
+thing that would make an appending screen unreadable is the status line, which changes every tick
+and says almost nothing new — so it is written with a carriage return and no newline of its own,
+and each tick writes over the last one rather than under it. Boards are the only thing that
+accumulates.
+
+## Why the loop's four effects are handed in
+
+`poll`, `sleep`, `now` and `write` are parameters with the real ones as defaults. A loop is the
+one shape of code here that cannot be checked by reading it — whether it redraws too often,
+whether it survives a dropped poll, whether it ends cleanly — and none of those questions should
+have to be answered by pointing the tool at a real draft, which happens once a year.
+
+## What is read once, and what is read on a tick
+
+The board, the survival frame, the draft record and my seat are read once, before the loop: they
+were computed by a rebuild days ago or drawn before the first pick, and nothing on the night
+changes them. That is not only saved work — re-opening the warehouse every three seconds for two
+hours would hold its file lock against any rebuild for the length of the draft. Only the picks are
+fetched on a tick.
+
+The staleness refusal is likewise once, at startup. A warehouse that ages past the limit *during*
+a draft would otherwise shut the tool down at pick 60, which is far worse than a board a couple of
+hours older than the rule prefers. That decision is taken before the draft, deliberately, and is
+not revisited under a pick clock.
 
 ## This module is the edge, and the only part of `src/draft/` that is
 
@@ -15,9 +47,10 @@ write anything" is a question answered by reading one module rather than four.
 
 What it touches, exhaustively:
 
-- Four HTTP **GET**s to Sleeper — the user, the league's drafts, the draft, the picks. There is no
-  POST anywhere in this package, which is what "never makes a pick" means in practice: the tool
-  has no code path that could submit one, rather than a flag saying it shouldn't.
+- HTTP **GET**s to Sleeper — the user, the league's drafts and the draft once each, then the
+  picks on every tick. There is no POST anywhere in this package, which is what "never makes a
+  pick" means in practice: the tool has no code path that could submit one, rather than a flag
+  saying it shouldn't.
 - Two reads of `data/warehouse.duckdb` through `src.query.q`, which opens read-only and closes
   before each returns. A draft-night process cannot corrupt what the pipeline built, and cannot
   hold the file lock against a rebuild either.
@@ -43,12 +76,14 @@ is a screen being drawn.
 """
 
 import argparse
+import time
 from datetime import datetime, timedelta
 
 import pandas as pd
 import requests
 
-from src.draft.picks import ingest_picks
+from src.draft.picks import ingest_picks, picks_made
+from src.draft.refresh import fingerprint, status_line
 from src.draft.render import render_board
 from src.draft.seat import resolve_seat
 from src.draft.waiting import rank_by_cost_of_waiting
@@ -74,8 +109,13 @@ MAX_WAREHOUSE_AGE = timedelta(hours=24)
 DEFAULT_LIMIT = 30
 
 # A draft night has a pick clock. A request that hangs is worse than one that fails, because a
-# failure can be retried by pressing up-enter and a hang cannot be anything.
+# failure is reported and retried on the next tick and a hang is a screen that has stopped.
 TIMEOUT_SECONDS = 10
+
+# How often to look. A Sleeper pick takes a manager tens of seconds at best, so a few seconds is
+# already faster than the draft can move; the cost of going faster is a rate limit in the middle
+# of a draft, and the cost of going slower is advice priced against a board that has moved on.
+REFRESH_SECONDS = 3.0
 
 
 def _get(path: str):
@@ -194,46 +234,160 @@ def load_survival(league_key: str = LEAGUE_KEY) -> pd.DataFrame:
     return survival
 
 
-def render_once(limit: int = DEFAULT_LIMIT) -> str:
-    """Everything, once: fetch, resolve, subtract, rank, and give back the screen."""
-    board = load_board()
-    survival = load_survival()
+def prepare() -> dict:
+    """Everything that cannot change once the draft is under way, read once.
+
+    The board and the survival frame were computed by a rebuild days ago; the draft record and the
+    seat were settled when the order was drawn. Nothing on the night moves any of them, so the
+    loop above carries this rather than re-reading it — see the module docstring on the file lock.
+    """
     draft = find_draft(LEAGUE_ID, SEASON)
-    league = resolve_seat(draft, user_id(USERNAME))
-    result = ingest_picks(_get(f"/draft/{draft['draft_id']}/picks"), board, league)
-    ranked = rank_by_cost_of_waiting(board, survival, result)
+    return {
+        "board": load_board(),
+        "survival": load_survival(),
+        "draft": draft,
+        "league": resolve_seat(draft, user_id(USERNAME)),
+    }
+
+
+def fetch_picks(context: dict) -> list[dict]:
+    """The one thing that changes: every pick made so far, the whole draft, every poll."""
+    return _get(f"/draft/{context['draft']['draft_id']}/picks")
+
+
+def screen(context: dict, picks: list[dict], limit: int = DEFAULT_LIMIT) -> str:
+    """One picks payload against the frozen half, drawn — subtract, rank, render.
+
+    Pure given the context, which is what lets the loop be driven over hand-written payloads
+    without a network or a warehouse behind it.
+    """
+    result = ingest_picks(picks, context["board"], context["league"])
+    ranked = rank_by_cost_of_waiting(context["board"], context["survival"], result)
 
     # The bye week is joined back on by ID rather than carried through the ranking: what the
     # ranking returns is a fixed contract, and a display column is not the ranking's business.
     # Joining on `player_id` is the same identity the whole feature runs on.
     candidates = ranked["candidates"].merge(
-        board[["player_id", "bye_week"]], on="player_id", how="left"
+        context["board"][["player_id", "bye_week"]], on="player_id", how="left"
     )
     return render_board(
-        candidates, result, league, limit,
+        candidates, result, context["league"], limit,
         degraded=ranked["degraded"], covers_to=ranked["covers_to"],
     )
 
 
-def main(limit: int = DEFAULT_LIMIT) -> None:
+def render_once(limit: int = DEFAULT_LIMIT) -> str:
+    """Everything, once: fetch, resolve, subtract, rank, and give back the screen."""
+    context = prepare()
+    return screen(context, fetch_picks(context), limit)
+
+
+def _write(text: str) -> None:
+    """Straight at the terminal, unbuffered, adding no newline of its own.
+
+    The loop decides where lines end, because the status line deliberately does not end: it is
+    written over on the next tick rather than under.
+    """
+    print(text, end="", flush=True)
+
+
+def _rule(made: int) -> str:
+    """The line between one board and the next, naming the pick that brought the new one."""
+    return f"── pick {made} " + "─" * 48
+
+
+def watch(
+    context: dict,
+    limit: int = DEFAULT_LIMIT,
+    poll=None,
+    sleep=time.sleep,
+    now=datetime.now,
+    write=_write,
+    interval: float = REFRESH_SECONDS,
+) -> None:
+    """Draw the board, then keep it current until interrupted.
+
+    `context` is what `prepare` returned. The four effects default to the real ones and are
+    parameters so the loop can be driven without a clock, a network or a terminal.
+
+    A poll that fails is a line on the screen and nothing more: it is reported with the time of
+    the last check that did work, and the next tick asks again. Nothing short of Ctrl-C ends this,
+    because a session that ends at pick eleven is a session nobody restarts in time.
+    """
+    poll = poll or (lambda: fetch_picks(context))
+
+    drawn = None        # the fingerprint of the board currently on screen
+    checked_at = None   # when a poll last succeeded, which is what the status line reports
+    made = 0
+    status_width = 0    # how much of the last status line there is to write over
+
+    try:
+        while True:
+            # Read once per tick, so the time on screen is the time of the check it describes.
+            moment = now()
+            error = None
+            try:
+                payload = poll()
+            except requests.RequestException as failure:
+                error = failure
+            else:
+                checked_at = moment
+                made = picks_made(payload)
+                mark = fingerprint(payload)
+                if mark != drawn:
+                    # End whatever status line is sitting on the terminal before drawing past it.
+                    lead = "\n" if drawn is None else f"\n{_rule(made)}\n"
+                    write(f"{lead}\n{screen(context, payload, limit)}\n")
+                    drawn = mark
+                    status_width = 0
+
+            line = status_line(made, checked_at, moment, error)
+            # Padded to the last line's width: a shorter line written over a longer one otherwise
+            # leaves the tail of the old one behind, which reads as part of the new one.
+            write("\r" + line + " " * max(status_width - len(line), 0))
+            status_width = len(line)
+
+            sleep(interval)
+    except KeyboardInterrupt:
+        write(f"\n\nstopped at {made} picks made — no pick was ever submitted\n")
+
+
+def main(limit: int = DEFAULT_LIMIT, once: bool = False) -> None:
     built_at = warehouse_built_at()
     check_recency(built_at, datetime.now())
-    print(render_once(limit))
-    print(f"\nboard built {built_at:%Y-%m-%d %H:%M} — read-only, no pick is ever submitted")
+    built = f"board built {built_at:%Y-%m-%d %H:%M} — read-only, no pick is ever submitted"
+
+    if once:
+        print(render_once(limit))
+        print(f"\n{built}")
+        return
+
+    context = prepare()
+    print(f"{built}\nrefreshing every {REFRESH_SECONDS:.0f}s — Ctrl-C to stop")
+    watch(context, limit)
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description="Show what is still on the board in the live Sleeper draft."
+        description="Keep what is still on the board in the live Sleeper draft on screen."
     )
     parser.add_argument(
         "--limit", type=int, default=DEFAULT_LIMIT,
         help=f"how many candidates to show (default {DEFAULT_LIMIT})",
     )
+    parser.add_argument(
+        "--once", action="store_true",
+        help="draw the board once and exit, instead of refreshing until interrupted",
+    )
     arguments = parser.parse_args()
 
     try:
-        main(arguments.limit)
+        main(arguments.limit, arguments.once)
+    except KeyboardInterrupt:
+        # Ctrl-C before the loop starts — during the warehouse read or the first fetch. The loop
+        # has its own, which stops cleanly rather than unwinding.
+        print("\nstopped before the board was drawn\n")
+        raise SystemExit(0)
     except RuntimeError as error:
         # A stale or missing warehouse is a thing the drafter has to fix, not a bug — a traceback
         # in front of a pick clock buries the one sentence that says what to do.

--- a/src/draft/picks.py
+++ b/src/draft/picks.py
@@ -110,7 +110,7 @@ def _picked_name(entry: dict) -> str | None:
     return " ".join(part for part in parts if part) or None
 
 
-def _picks_made(picks: list[dict]) -> int:
+def picks_made(picks: list[dict]) -> int:
     """How far the draft has actually got, read from pick numbers rather than list length.
 
     A hand-marked player is a pick that happened but has no number; counting the list would
@@ -233,9 +233,9 @@ def ingest_picks(picks: list[dict], board: pd.DataFrame, league: dict) -> dict:
         if entry.get("roster_id") == league["roster_id"]:
             mine.append(row)
 
-    picks_made = _picks_made(ordered)
+    made = picks_made(ordered)
     next_pick = next_pick_number(
-        picks_made, league["seat"], league["team_count"], league["rounds"]
+        made, league["seat"], league["team_count"], league["rounds"]
     )
     return {
         "taken": taken,
@@ -251,5 +251,5 @@ def ingest_picks(picks: list[dict], board: pd.DataFrame, league: dict) -> dict:
                 next_pick, league["seat"], league["team_count"], league["rounds"]
             )
         ),
-        "picks_made": picks_made,
+        "picks_made": made,
     }

--- a/src/draft/refresh.py
+++ b/src/draft/refresh.py
@@ -1,0 +1,91 @@
+"""What changed since the last look, and when we last heard anything at all.
+
+The two pure decisions underneath the refresh loop. `live.watch` supplies the clock, the GET and
+the writing; everything it actually decides is here, where it can be checked without either.
+
+## The fingerprint, and which way it is allowed to be wrong
+
+Sleeper returns the whole draft on every poll, so "has anything happened" is a question about two
+payloads rather than something the API answers. Redrawing regardless would put thirty rows of
+board through the terminal every few seconds, which makes the list unreadable at exactly the
+moment it is being read — a drafter scanning row nine does not want row nine to move.
+
+So the loop draws only on a change, and the fingerprint decides what a change is. The two failure
+directions are not symmetric:
+
+- Too sensitive costs a redraw nobody needed.
+- Too blunt leaves a player who has just been drafted sitting on the board looking available,
+  which is the exact failure this whole feature exists to prevent.
+
+Hence the pick count *and* the most recent pick, rather than either alone. A count alone misses a
+commissioner's correction and misses the moment the API catches up with a hand-marked player —
+same number of picks, different players in them. The count is of distinct players rather than of
+list entries, because a payload that repeats a pick describes the same board and `ingest_picks`
+would dedupe it anyway; a redraw on that would be a flicker with no cause behind it.
+
+The most recent pick is read as the highest pick number rather than the last element, so a payload
+that arrives in a different order than it did last time is not mistaken for a draft that moved.
+
+## The status line, and the one fact that makes it worth printing
+
+A draft room can sit for three minutes while somebody takes a phone call. A dropped connection
+looks identical from this side: no new picks, forever. The distinguishing fact is not on the board
+and cannot be — it is whether the *last poll* succeeded, which is why the line reports the time of
+the last successful check rather than the current time. A clock that ticked regardless would read
+as healthy right up until the pick that never appeared.
+
+When a poll does fail, the failure goes on the same line rather than into a log nobody is reading,
+carrying what went wrong and — the part that matters at a pick clock — that the tool is still
+going. A message that reads like the end of the session sends a drafter to another window.
+"""
+
+from datetime import datetime
+
+# Separator between the facts on the status line, matching the header the board is drawn under so
+# the two read as the same screen rather than as a tool and its log.
+_DOT = "  ·  "
+
+
+def fingerprint(picks: list[dict]) -> tuple:
+    """What the board is made of right now, cheaply enough to compute every few seconds.
+
+    Two payloads describing the same draft give equal fingerprints; anything that would change
+    the board gives a different one. Compared, never inspected — the parts are meaningful only
+    to the docstring above.
+    """
+    numbered = [entry for entry in picks if entry.get("pick_no") is not None]
+    latest = max(numbered, key=lambda entry: entry["pick_no"], default=None)
+    return (
+        len({entry.get("player_id") for entry in picks}),
+        latest and latest.get("player_id"),
+        latest and latest.get("pick_no"),
+    )
+
+
+def _age(seconds: float) -> str:
+    """How long ago, in the units a person waiting for a pick is counting in."""
+    if seconds < 60:
+        return f"{seconds:.0f}s"
+    return f"{seconds // 60:.0f}m{seconds % 60:02.0f}s"
+
+
+def status_line(
+    made: int,
+    checked_at: datetime | None,
+    now: datetime,
+    error: BaseException | None = None,
+) -> str:
+    """The one live line under the board: how far the draft has got, and whether we can still see.
+
+    `checked_at` is when a poll last *succeeded*, which is the whole point of the line — see the
+    module docstring. `now` is only used to say how stale that is once something has gone wrong.
+    It is None only when nothing has succeeded yet, which is the tool being started while the
+    connection is already down; the line says so rather than reporting a check that never happened.
+    """
+    when = "not checked yet" if checked_at is None else f"last checked {checked_at:%H:%M:%S}"
+    line = f"{made} picks made{_DOT}{when}"
+    if error is None:
+        return line
+
+    ago = "" if checked_at is None else f" ({_age((now - checked_at).total_seconds())} ago)"
+    return f"{line}{ago}{_DOT}Sleeper did not answer: {error} — retrying"

--- a/tests/test_draft_refresh.py
+++ b/tests/test_draft_refresh.py
@@ -1,0 +1,111 @@
+"""Cases 1-10 of the refresh ticket: what changed, and when we last heard anything.
+
+Two pure decisions sit under a loop that is otherwise just a clock and a GET, and both of them
+are the difference between a screen that can be trusted and one that cannot:
+
+- **The fingerprint** decides whether the board on screen is still the board. Redrawing thirty
+  rows every three seconds makes the list unreadable exactly when it is being read, so the loop
+  redraws only on a change — which means a fingerprint that misses a change leaves a drafted
+  player sitting on the board looking available. It is allowed to be too sensitive. It is not
+  allowed to be too blunt.
+- **The status line** is the whole of "is this thing still working". A draft room can go three
+  minutes without a pick, and a dead connection looks exactly the same from the outside. The
+  distinguishing fact is the time of the last *successful* check, which is why it is reported
+  rather than the current time — a clock that ticks regardless would say everything is fine right
+  up until the pick that isn't there.
+"""
+
+from datetime import datetime, timedelta
+
+import requests
+
+from src.draft.refresh import fingerprint, status_line
+
+NOW = datetime(2026, 9, 3, 18, 42, 7)
+
+
+def pick(number: int | None, player_id: str, roster_id: int = 1) -> dict:
+    """One entry of a Sleeper picks payload, trimmed to what the fingerprint can see."""
+    return {"pick_no": number, "player_id": player_id, "roster_id": roster_id}
+
+
+# 1. The tick that changes nothing must be recognisable as such, or the board redraws forever.
+def test_the_same_payload_twice_fingerprints_the_same():
+    payload = [pick(1, "4034"), pick(2, "6786")]
+    assert fingerprint(payload) == fingerprint(list(payload))
+
+
+# 2. The change the loop exists for.
+def test_a_new_pick_changes_the_fingerprint():
+    before = [pick(1, "4034"), pick(2, "6786")]
+    after = [*before, pick(3, "8146")]
+    assert fingerprint(after) != fingerprint(before)
+
+
+# 3. Same count, different last pick. A commissioner correction does this, and so does the API
+# catching up with a hand-marked player. Counting alone would call this no change.
+def test_the_same_count_with_a_different_last_pick_changes_the_fingerprint():
+    before = [pick(1, "4034"), pick(2, "6786")]
+    after = [pick(1, "4034"), pick(2, "8146")]
+    assert fingerprint(after) != fingerprint(before)
+
+
+# 4. Sleeper returns the payload sorted, but nothing here should depend on that: an order that
+# wobbled would redraw the board on a tick where nothing happened.
+def test_picks_out_of_order_fingerprint_the_same_as_in_order():
+    ordered = [pick(1, "4034"), pick(2, "6786"), pick(3, "8146")]
+    shuffled = [ordered[2], ordered[0], ordered[1]]
+    assert fingerprint(shuffled) == fingerprint(ordered)
+
+
+# 5. The tool can be started before the first pick, which is the normal way to start it.
+def test_an_empty_payload_fingerprints_and_differs_from_one_pick():
+    assert fingerprint([]) == fingerprint([])
+    assert fingerprint([]) != fingerprint([pick(1, "4034")])
+
+
+# 6. A hand-marked player (issue #36) carries no pick number. He is still a change to the board,
+# and a fingerprint that only watched pick numbers would not redraw for him.
+def test_a_pick_with_no_number_still_moves_the_fingerprint():
+    api_only = [pick(1, "4034")]
+    with_hand_mark = [*api_only, pick(None, "6786")]
+    assert fingerprint(with_hand_mark) != fingerprint(api_only)
+
+
+# 7. The two facts the line exists to carry.
+def test_the_status_line_names_the_picks_made_and_the_time_of_the_last_check():
+    line = status_line(27, checked_at=NOW, now=NOW)
+    assert "27" in line
+    assert "18:42:07" in line
+
+
+# 8. A quiet draft room still gets a moving clock, because the poll succeeded even though the
+# payload did not change. This is what says the connection is alive.
+def test_a_later_successful_check_moves_the_time_the_line_reports():
+    later = NOW + timedelta(seconds=6)
+    line = status_line(27, checked_at=later, now=later)
+    assert "18:42:13" in line
+    assert "18:42:07" not in line
+
+
+# 9. A broken connection is the same silence with a frozen clock. The time reported is the last
+# one that succeeded, never the current one, and how long ago it was is on screen.
+def test_a_failed_check_keeps_the_last_successful_time_and_shows_it_ageing():
+    line = status_line(
+        27, checked_at=NOW, now=NOW + timedelta(seconds=14),
+        error=requests.ConnectionError("connection reset"),
+    )
+    assert "18:42:07" in line
+    assert "18:42:21" not in line
+    assert "14s" in line
+
+
+# 10. A failure that reads like the end of the session sends a drafter to another window. It has
+# to say what went wrong and that the tool is still going.
+def test_a_failed_check_says_what_failed_and_that_it_will_retry():
+    line = status_line(
+        27, checked_at=NOW, now=NOW + timedelta(seconds=3),
+        error=requests.ConnectionError("connection reset"),
+    )
+    assert "connection reset" in line
+    assert "retry" in line.lower()

--- a/tests/test_draft_watch.py
+++ b/tests/test_draft_watch.py
@@ -1,0 +1,176 @@
+"""Cases 11-17 of the refresh ticket: the loop that keeps the board current for a whole draft.
+
+`watch` is the one thing in this package that has a clock and a network in it, so the four things
+it touches the world with — the poll, the sleep, the time and the writing — are handed in. The
+real ones are supplied by `main`; these cases supply fakes and then assert what a drafter would
+have seen on screen, which is the only thing about a loop that actually matters.
+
+The board itself is rendered through the real pure pipeline against a hand-written three-player
+board, rather than being stubbed out. A loop test that stubbed the rendering could not tell the
+difference between redrawing and redrawing the same thing.
+
+## What each case is protecting
+
+A draft night has exactly two failure modes here and they pull in opposite directions. Redrawing
+on every tick makes thirty rows scroll past while they are being read; redrawing on too few makes
+the board quietly wrong, which is the failure the whole feature exists to prevent. And a session
+that ends on the first dropped packet is a session that ends, because nobody restarts a tool at
+pick eleven — so a failed poll has to be a line on screen and nothing more.
+"""
+
+from datetime import datetime, timedelta
+
+import pandas as pd
+import requests
+
+from src.draft.live import watch
+
+NOW = datetime(2026, 9, 3, 18, 42, 7)
+
+SLOTS = {"QB": 1, "RB": 2, "WR": 2, "TE": 1, "FLEX": 1, "SUPER_FLEX": 1, "K": 1, "DST": 1}
+
+LEAGUE = {"seat": 1, "roster_id": 6, "team_count": 14, "rounds": 15, "slots": SLOTS}
+
+BOARD = pd.DataFrame(
+    [
+        {
+            "player_id": "00-0000001", "sleeper_id": "4034", "player_name": "Alpha Back",
+            "position": "RB", "team": "SF", "points_over_replacement": 150.0, "bye_week": 9,
+        },
+        {
+            "player_id": "00-0000002", "sleeper_id": "6786", "player_name": "Bravo Wideout",
+            "position": "WR", "team": "KC", "points_over_replacement": 120.0, "bye_week": 6,
+        },
+        {
+            "player_id": "00-0000003", "sleeper_id": "8146", "player_name": "Charlie Ender",
+            "position": "TE", "team": "BUF", "points_over_replacement": 90.0, "bye_week": 12,
+        },
+    ]
+)
+
+# Empty rather than populated: these cases are about the loop, and an empty survival frame ranks
+# by points over replacement and says so on screen, which renders exactly as fully as the other.
+SURVIVAL = pd.DataFrame(columns=["player_id", "overall_pick", "p_survives"])
+
+CONTEXT = {"board": BOARD, "survival": SURVIVAL, "draft": {"draft_id": "1"}, "league": LEAGUE}
+
+
+def pick(number: int, sleeper_id: str, roster_id: int = 3) -> dict:
+    """One entry of a Sleeper picks payload, as the API hands it over."""
+    return {
+        "pick_no": number,
+        "player_id": sleeper_id,
+        "roster_id": roster_id,
+        "metadata": {"first_name": "Someone", "last_name": "Else", "position": "RB"},
+    }
+
+
+def poller(*outcomes):
+    """A poll handing back each payload in turn; an exception among them is raised instead."""
+    remaining = list(outcomes)
+
+    def poll():
+        outcome = remaining.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+    return poll
+
+
+def ticker(ticks: int):
+    """A sleep that records what it was asked to wait, and interrupts after `ticks` of them.
+
+    A real loop only ever ends by Ctrl-C, which lands in the sleep. Ending these the same way
+    keeps the loop under test the loop that runs on the night.
+    """
+    waits = []
+
+    def sleep(seconds):
+        waits.append(seconds)
+        if len(waits) >= ticks:
+            raise KeyboardInterrupt
+
+    return sleep, waits
+
+
+def clock(step=timedelta(seconds=3)):
+    """A time that advances one tick per reading."""
+    readings = [NOW - step]
+
+    def now():
+        readings.append(readings[-1] + step)
+        return readings[-1]
+
+    return now
+
+
+def run(*outcomes, ticks: int = None, interval: float = 0.5):
+    """Drive `watch` over the given poll outcomes and give back everything it wrote."""
+    written = []
+    sleep, waits = ticker(ticks if ticks is not None else len(outcomes))
+    watch(
+        CONTEXT, limit=5, poll=poller(*outcomes), sleep=sleep, now=clock(),
+        write=written.append, interval=interval,
+    )
+    return written, waits
+
+
+def boards(written: list[str]) -> list[str]:
+    """Just the chunks that are a drawn board, which is what a drafter reads."""
+    return [chunk for chunk in written if "Best available" in chunk]
+
+
+# 11. There is nothing on screen until the first draw, so it is never skipped.
+def test_the_first_tick_draws_the_board():
+    written, _ = run([pick(1, "4034")])
+    assert len(boards(written)) == 1
+    assert "Bravo Wideout" in boards(written)[0]
+
+
+# 12. Thirty rows redrawn under a reading eye, every three seconds, for two hours.
+def test_a_tick_that_changes_nothing_draws_nothing():
+    payload = [pick(1, "4034")]
+    written, _ = run(payload, list(payload))
+    assert len(boards(written)) == 1
+
+
+# 13. The change that matters: the drafted player is off the board on the next draw.
+def test_a_tick_with_a_new_pick_draws_the_board_again():
+    first = [pick(1, "4034")]
+    second = [*first, pick(2, "6786")]
+    written, _ = run(first, second)
+    drawn = boards(written)
+    assert len(drawn) == 2
+    assert "Bravo Wideout" in drawn[0]
+    assert "Bravo Wideout" not in drawn[1]
+
+
+# 14. A dropped poll is a line, not an ending. The loop must come back round and ask again.
+def test_a_failed_poll_draws_no_board_and_does_not_end_the_session():
+    written, _ = run(requests.ConnectionError("connection reset"), [pick(1, "4034")])
+    assert len(boards(written)) == 1
+    assert any("connection reset" in chunk for chunk in written)
+
+
+# 15. And the board that was missed during the outage is on screen the moment it comes back.
+def test_the_tick_after_a_failure_draws_the_board_it_missed():
+    first = [pick(1, "4034")]
+    written, _ = run(first, requests.ConnectionError("timed out"), [*first, pick(2, "6786")])
+    drawn = boards(written)
+    assert len(drawn) == 2
+    assert "Bravo Wideout" not in drawn[1]
+
+
+# 16. Fixed interval, as configured — a loop that polled as fast as it could would be rate limited
+# off the API in the middle of a draft.
+def test_the_loop_waits_the_configured_interval_between_polls():
+    payload = [pick(1, "4034")]
+    _, waits = run(payload, list(payload), list(payload), interval=0.5)
+    assert waits == [0.5, 0.5, 0.5]
+
+
+# 17. Ctrl-C at pick 40 is how this tool ends every time it is ever used.
+def test_an_interrupt_ends_the_loop_cleanly():
+    written, _ = run([pick(1, "4034")])
+    assert "stopped" in written[-1].lower()


### PR DESCRIPTION
Closes #35.

The tool stops being a one-shot command: it draws the board, then polls Sleeper every three
seconds for the length of the draft, redrawing only when the picks have actually changed.
`--once` keeps the previous behaviour.

## Acceptance criteria

- [x] Refreshes on a fixed interval of a few seconds — `REFRESH_SECONDS = 3.0`
- [x] Skips redrawing when the payload has not changed, judged by a fingerprint of the pick count
      and the most recent pick
- [x] Shows how many picks have been made and the time of the last successful check
- [x] A failed poll is reported inline and retried on the next tick rather than ending the session
- [x] Can be interrupted cleanly

## What the fingerprint is allowed to get wrong

Count *and* most recent pick, rather than either alone. A count alone misses a commissioner's
correction and misses the moment the API catches up with a hand-marked player — same number of
picks, different players in them. The two failure directions are not symmetric: too sensitive
costs a redraw, too blunt leaves a drafted player sitting on the board looking available, which
is the failure the whole feature exists to prevent.

## Why the status line reports the last *successful* check

A draft room can sit quiet for three minutes while somebody takes a phone call, and a dropped
connection looks identical from this side. The time of the last poll that worked is the only fact
that separates them; a clock that ticked regardless would read as healthy right up until the pick
that never appeared.

## The screen appends

A changed board is drawn below the last one rather than over a cleared screen, so the whole draft
stays in scrollback. The status line is the one thing that would make that unreadable, so it is
written with a carriage return and no newline and each tick writes over the last one.

## Tests

Seventeen cases, agreed and committed red before the implementation (3ba91db), then green
(e5a30ed). The loop's four effects — poll, sleep, time, write — are parameters with the real ones
as defaults, so the loop is driven over fake payloads through the real rendering pipeline. Full
suite: 117 passed.

Also run against the real draft: `--once`, then eleven seconds of the live loop interrupted with
SIGINT, then the loop driven over a moving fake draft on the real 655-row board — drafted players
leave the board, my own pick lands on the roster, an unmatched pick warns above it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)