### PR TITLE
feat: let the drafter mark a player taken by hand

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,9 +34,10 @@ Dependencies are pinned in `requirements.txt` — keep it in sync when adding ne
     tables (e.g. `consensus.py`). Pure SQL/Python over the warehouse — no fetch step, no network.
   - `src/draft/` — the live draft assistant, and the one part of `src/` that is not a medallion
     layer. It is neither: it reads no raw file and writes nothing at all. `src/draft/live.py` is
-    the runnable edge and the only module here that touches the world — GETs to Sleeper, and the
-    warehouse read through `src/query.py`, which opens read-only and closes per call. Every other
-    module is pure: already-built frames and a live API payload in, frames and strings out.
+    the runnable edge and the only module here that touches the world — GETs to Sleeper, the
+    warehouse read through `src/query.py`, which opens read-only and closes per call, and whatever
+    the drafter has typed at stdin. Every other module is pure: already-built frames, a live API
+    payload and a typed name in, frames and strings out.
     Everything about a player's value is fixed by the warehouse rebuild days beforehand; nothing
     here recomputes any of it. New modules for this feature go here rather than under `gold/`,
     which is documented as warehouse-to-warehouse and would be a lie about what these do.

--- a/README.md
+++ b/README.md
@@ -412,16 +412,23 @@ sequence:
 ./scripts/build_warehouse.sh
 ```
 
-On draft night, render the Sleeper board once and exit:
+On draft night, keep the Sleeper board on screen and refreshing as the picks come in:
 
 ```bash
-python -m src.draft.live              # the top 30 still available
+python -m src.draft.live              # the top 30 still available, redrawn as the draft moves
 python -m src.draft.live --limit 50
+python -m src.draft.live --once       # draw it once and exit
 ```
 
-It resolves the seat from the draft order, subtracts the picks already made, and shows the roster
-so far and the next overall pick number. It reads the warehouse read-only, refuses to run against
-a build more than a day old, and has no code path that could submit a pick.
+It resolves the seat from the draft order, subtracts the picks already made, ranks what is left by
+what waiting for it would cost, and shows the roster so far and the next overall pick number.
+
+Type a player's name at it to mark him taken by hand, and `-name` to take that back. Marks are held
+for the session and unioned with the picks Sleeper reports rather than replacing them, so the draft
+stays followable through an outage — which is the one thing polling cannot fix by itself.
+
+It reads the warehouse read-only, refuses to run against a build more than a day old, and has no
+code path that could submit a pick.
 
 Query the warehouse with the DuckDB CLI or Python:
 

--- a/src/draft/live.py
+++ b/src/draft/live.py
@@ -9,6 +9,19 @@ board the warehouse built days ago, and prints what is left — then does that a
 seconds for the length of the draft, redrawing only when the picks have actually changed. What
 counts as a change, and what the live line under the board says, are both in `refresh`.
 
+## What the drafter can type at it
+
+A name typed at the running tool marks that player taken by hand, and a name after a dash takes
+the mark back. It is the fallback for the night Sleeper stops answering: marks are held for the
+session and unioned into every board drawn from then on, so the draft stays followable with the
+network down — which is the one failure the rest of this file cannot do anything about.
+
+Lines are read without ever waiting for one, on the same tick as the poll, so typing costs the
+board nothing and a half-typed name is simply still being typed. The terminal echoes it after the
+status line, where the next repaint writes over the start of the line rather than the tail — and
+if a failure message makes that line long enough to swallow the echo, the characters are still in
+the terminal's own buffer and Enter still submits exactly what was typed.
+
 ## The screen appends, and the status line does not
 
 A changed board is drawn *below* the last one rather than over a cleared screen, so the whole
@@ -54,11 +67,14 @@ What it touches, exhaustively:
 - Two reads of `data/warehouse.duckdb` through `src.query.q`, which opens read-only and closes
   before each returns. A draft-night process cannot corrupt what the pipeline built, and cannot
   hold the file lock against a rebuild either.
+- Whatever has been typed at **stdin**, read without blocking and resolved against the board by
+  `marks`. Nothing is written anywhere as a result: a hand-mark lives in memory until Ctrl-C.
 
-## Nothing is typed in
+## Nothing is configured by typing
 
 The league ID and season come from `src.silver.sleeper`, so the repo holds one league ID rather
-than two that can disagree. Everything else — seat, roster, team count, rounds, starting slots —
+than two that can disagree. A player's name typed during the draft is the one thing that is ever
+typed at this tool, and it is resolved against the board rather than configuring anything. Everything else — seat, roster, team count, rounds, starting slots —
 is read out of the draft record. The one configured name is the Sleeper username below, which is
 resolved to a user ID against the API and then to a seat against the draft order.
 
@@ -76,12 +92,15 @@ is a screen being drawn.
 """
 
 import argparse
+import select
+import sys
 import time
 from datetime import datetime, timedelta
 
 import pandas as pd
 import requests
 
+from src.draft.marks import combine, read_mark
 from src.draft.picks import ingest_picks, picks_made
 from src.draft.refresh import fingerprint, status_line
 from src.draft.render import render_board
@@ -255,13 +274,20 @@ def fetch_picks(context: dict) -> list[dict]:
     return _get(f"/draft/{context['draft']['draft_id']}/picks")
 
 
-def screen(context: dict, picks: list[dict], limit: int = DEFAULT_LIMIT) -> str:
+def screen(
+    context: dict, picks: list[dict], limit: int = DEFAULT_LIMIT, marked=()
+) -> str:
     """One picks payload against the frozen half, drawn — subtract, rank, render.
 
     Pure given the context, which is what lets the loop be driven over hand-written payloads
     without a network or a warehouse behind it.
+
+    `marked` is the players the drafter has taken off the board by hand. They are unioned into the
+    payload here rather than handled separately, so that everything below this line sees one list
+    of who is gone and `ingest_picks` does the deduplication it was written to do.
     """
-    result = ingest_picks(picks, context["board"], context["league"])
+    marked = list(marked)
+    result = ingest_picks(combine(picks, marked), context["board"], context["league"])
     ranked = rank_by_cost_of_waiting(context["board"], context["survival"], result)
 
     # The bye week is joined back on by ID rather than carried through the ranking: what the
@@ -272,7 +298,7 @@ def screen(context: dict, picks: list[dict], limit: int = DEFAULT_LIMIT) -> str:
     )
     return render_board(
         candidates, result, context["league"], limit,
-        degraded=ranked["degraded"], covers_to=ranked["covers_to"],
+        degraded=ranked["degraded"], covers_to=ranked["covers_to"], marked=marked,
     )
 
 
@@ -291,9 +317,42 @@ def _write(text: str) -> None:
     print(text, end="", flush=True)
 
 
-def _rule(made: int) -> str:
-    """The line between one board and the next, naming the pick that brought the new one."""
-    return f"── pick {made} " + "─" * 48
+def _typed(stream=None) -> list[str]:
+    """Every whole line the drafter has typed since the last look, without waiting for one.
+
+    The terminal hands a line over on the Enter key and not before, so a name half typed when a
+    tick comes round is not seen and not lost — it is still being typed, and arrives on the tick
+    after the drafter finishes it. Nothing here ever blocks: the poll cadence is the tool's, and a
+    read that waited for a name would stop the board dead every time nobody was typing one.
+
+    A stream that cannot be selected on — not a terminal, already closed, a pipe on a platform
+    that will not have it — gives back nothing rather than raising. Typing is the fallback, and a
+    fallback that could take the tool down with it would be worth less than not having it.
+    """
+    stream = sys.stdin if stream is None else stream
+    lines = []
+    try:
+        while select.select([stream], [], [], 0)[0]:
+            line = stream.readline()
+            if not line:
+                # End of input: stdin is closed or redirected from something exhausted. Nothing
+                # more will ever be typed, and select would keep saying ready forever.
+                break
+            lines.append(line)
+    except (OSError, ValueError):
+        pass
+    return lines
+
+
+def _rule(made: int, marked: int = 0) -> str:
+    """The line between one board and the next, naming the pick that brought the new one.
+
+    A hand-mark brings a new board without moving the draft on, so the count is named beside the
+    pick rather than folded into it — two boards in a row under the same pick number is exactly
+    what marking a player looks like, and the rule has to say why.
+    """
+    label = f"pick {made}" if not marked else f"pick {made} + {marked} by hand"
+    return f"── {label} " + "─" * 48
 
 
 def watch(
@@ -303,19 +362,28 @@ def watch(
     sleep=time.sleep,
     now=datetime.now,
     write=_write,
+    keys=_typed,
     interval: float = REFRESH_SECONDS,
 ) -> None:
     """Draw the board, then keep it current until interrupted.
 
-    `context` is what `prepare` returned. The four effects default to the real ones and are
-    parameters so the loop can be driven without a clock, a network or a terminal.
+    `context` is what `prepare` returned. The five effects default to the real ones and are
+    parameters so the loop can be driven without a clock, a network, a terminal or a keyboard.
 
     A poll that fails is a line on the screen and nothing more: it is reported with the time of
     the last check that did work, and the next tick asks again. Nothing short of Ctrl-C ends this,
     because a session that ends at pick eleven is a session nobody restarts in time.
+
+    A name typed at it is read on the next tick and marked taken by hand — see `marks` for what
+    that resolves against and what it refuses. Marks are held here, for the session, and unioned
+    into every draw from the moment they are made: the last payload a poll returned is kept, so a
+    mark still redraws the board on a tick Sleeper did not answer, which is the whole reason the
+    drafter is typing in the first place.
     """
     poll = poll or (lambda: fetch_picks(context))
 
+    marked = {}         # board player_id -> the board row, in the order they were marked by hand
+    picks = []          # the last payload a poll actually returned, kept across a failed one
     drawn = None        # the fingerprint of the board currently on screen
     checked_at = None   # when a poll last succeeded, which is what the status line reports
     made = 0
@@ -327,19 +395,39 @@ def watch(
             moment = now()
             error = None
             try:
-                payload = poll()
+                picks = poll()
             except requests.RequestException as failure:
                 error = failure
             else:
                 checked_at = moment
-                made = picks_made(payload)
-                mark = fingerprint(payload)
-                if mark != drawn:
-                    # End whatever status line is sitting on the terminal before drawing past it.
-                    lead = "\n" if drawn is None else f"\n{_rule(made)}\n"
-                    write(f"{lead}\n{screen(context, payload, limit)}\n")
-                    drawn = mark
-                    status_width = 0
+
+            for line in keys():
+                if not line.strip():
+                    # Enter on an empty line is how a half-typed name gets cleared.
+                    continue
+                outcome = read_mark(line, context["board"], marked)
+                if outcome["action"] == "mark":
+                    marked[outcome["player"]["player_id"]] = outcome["player"]
+                elif outcome["action"] == "unmark":
+                    marked.pop(outcome["player"]["player_id"], None)
+                # Every outcome, refusals included: a mark that said nothing would be read as one
+                # that worked. Ends the status line rather than being written over it.
+                write(f"\n{outcome['message']}\n")
+                status_width = 0
+
+            combined = combine(picks, marked.values())
+            made = picks_made(combined)
+            seen = fingerprint(combined)
+
+            # A failed poll on its own draws nothing — the board has not changed and the status
+            # line says the connection has. A mark is a change, and gets drawn whether Sleeper
+            # answered or not.
+            if (error is None or marked) and seen != drawn:
+                # End whatever status line is sitting on the terminal before drawing past it.
+                lead = "\n" if drawn is None else f"\n{_rule(made, len(marked))}\n"
+                write(f"{lead}\n{screen(context, picks, limit, marked.values())}\n")
+                drawn = seen
+                status_width = 0
 
             line = status_line(made, checked_at, moment, error)
             # Padded to the last line's width: a shorter line written over a longer one otherwise
@@ -363,7 +451,10 @@ def main(limit: int = DEFAULT_LIMIT, once: bool = False) -> None:
         return
 
     context = prepare()
-    print(f"{built}\nrefreshing every {REFRESH_SECONDS:.0f}s — Ctrl-C to stop")
+    print(
+        f"{built}\nrefreshing every {REFRESH_SECONDS:.0f}s — type a name to mark him taken by "
+        "hand, -name to undo, Ctrl-C to stop"
+    )
     watch(context, limit)
 
 

--- a/src/draft/marks.py
+++ b/src/draft/marks.py
@@ -1,0 +1,225 @@
+"""Let the drafter say a player is gone, when Sleeper cannot say it for him.
+
+The fallback for the night the network drops or the API stalls: a name typed at the running tool
+takes that player off the board, and the board stays correct without a single successful poll.
+Pure, like everything else in this package bar `live` — a string and two frames in, a decision out.
+
+## This is the one place identity is resolved by name, and it is bounded on both sides
+
+The rule everywhere else is identity by ID: picks carry Sleeper's, the board carries the
+warehouse's, and the crosswalk between them was built days ago. A drafter typing at a pick clock
+cannot supply either. So a name is resolved against the board exactly once, here, and what comes
+out is a board row carrying its own IDs — nothing downstream ever sees the string.
+
+Which makes this function's real job refusing. Marking the wrong player hides somebody who is
+genuinely available, and that is invisible on screen: a board missing a player looks exactly like
+a board where somebody took him. So an unknown name and an ambiguous one are both refused, named,
+and never resolved to whichever row the board happened to list first.
+
+## Every outcome carries a line for the screen
+
+The drafter is typing at a status line that repaints every three seconds. A mark that quietly did
+nothing would be indistinguishable from a mark that worked, so there is no silent branch here at
+all — accepted, refused and redundant all come back with something to print.
+
+## Matching, and why part of a name is enough
+
+Nobody types `Amon-Ra St. Brown` correctly while a pick clock runs, so punctuation is dropped from
+both sides and a substring of a name is accepted when exactly one player has it. `swift` is a
+mark; `allen` is a refusal naming the three of them.
+
+An exact match wins over a substring even when both are found, which is what keeps `Michael
+Carter` typeable on a board that also carries `Michael Carter II` — treating that as ambiguous
+would make the shorter name unmarkable for the whole draft.
+
+## Why a mark is unioned into the picks payload rather than kept beside it
+
+A mark becomes a pick entry with no pick number and no roster, and is appended to what the API
+returned. `picks.ingest_picks` then does the rest: it deduplicates on the player, so the moment
+Sleeper catches up there is one player rather than two, and it reads the draft's progress from
+pick numbers, so a hand-mark never pushes the seat's next turn a pick further away. Both of those
+defences were written for this, and this is the only thing that exercises them.
+
+The API's entries are listed first deliberately. Deduplication keeps the first one seen, so a real
+pick always wins over the hand-mark it catches up with — the roster fills from the manager who
+actually drafted the player, at the number he actually went.
+
+A mark therefore says a player is *gone*, never whose he is. There is no way to claim one for my
+own roster, and that is the point: a mark is a statement about supply, made under exactly the
+conditions where the drafter is least able to check it, and a mistyped one that filled my lineup
+would be a wrong answer to the question the tool exists to answer.
+
+## The one player who cannot be marked
+
+A board row whose `sleeper_id` is missing is refused. Its mark could not be told apart from the
+player's own pick when it arrived, so it would union with nothing, remove nobody, and report
+itself as an unmatched pick — a mark that appears to work and does not. Issue #31's build-time
+report exists to close exactly that gap days beforehand, with an identity override, and the
+message says so rather than leaving the drafter to guess why.
+"""
+
+import re
+
+import pandas as pd
+
+# What a mark carries: the two identities, and the three fields that name a player on screen.
+MARK_COLUMNS = ["player_id", "sleeper_id", "player_name", "position", "team"]
+
+# Typed in front of a name to take a mark back. A leading dash rather than a word because it is
+# the fewest keystrokes that cannot be the start of a player's name.
+UNMARK = "-"
+
+# How many players an ambiguous refusal names before it stops. Enough to choose from, few enough
+# to read in one glance at a line that is about to be written over.
+MAX_NAMED = 6
+
+
+def _plain(name) -> str:
+    """A name reduced to what somebody would actually type: lowercase, unpunctuated, single-spaced.
+
+    Hyphens and slashes become spaces and everything else non-alphanumeric is dropped, so
+    `Amon-Ra St. Brown` reduces to `amon ra st brown` and `D'Andre Swift` to `dandre swift`. Both
+    sides of every comparison go through this, so the board's spelling of a name never has to be
+    reproduced exactly.
+    """
+    text = re.sub(r"[-–/]", " ", str(name).lower())
+    return " ".join(re.sub(r"[^\w ]", "", text).split())
+
+
+def _rows(board: pd.DataFrame) -> list[dict]:
+    """The board as plain rows, cut to what a mark carries. The frame itself is never touched."""
+    return board[MARK_COLUMNS].to_dict("records")
+
+
+def _matching(typed: str, rows: list[dict]) -> list[dict]:
+    """Every row a typed name could mean — the exact ones if there are any, else the partial ones.
+
+    Returning the exact matches alone when they exist is what stops a whole name being ambiguous
+    with the longer names it is the start of.
+    """
+    exact = [row for row in rows if _plain(row["player_name"]) == typed]
+    return exact or [row for row in rows if typed in _plain(row["player_name"])]
+
+
+def _named(player: dict) -> str:
+    """One player, as a refusal or a confirmation names him: enough to tell two Allens apart."""
+    return f"{player['player_name']} ({player['position']}, {player['team']})"
+
+
+def _listed(players: list[dict]) -> str:
+    """Several players, named, cut off before the line becomes something nobody reads."""
+    shown = ", ".join(_named(player) for player in players[:MAX_NAMED])
+    if len(players) <= MAX_NAMED:
+        return shown
+    return f"{shown} and {len(players) - MAX_NAMED} more"
+
+
+def _nothing(message: str) -> dict:
+    """Nothing to do, and the reason, which always goes on the screen."""
+    return {"action": "none", "player": None, "message": message}
+
+
+def _mark(typed: str, board: pd.DataFrame, marked: dict) -> dict:
+    """Resolve a typed name against the board, or refuse it saying why."""
+    wanted = _plain(typed)
+    if not wanted:
+        return _nothing("type at least part of a player's name to mark him taken")
+
+    found = _matching(wanted, _rows(board))
+    if not found:
+        return _nothing(f'no player on the board matches "{typed}" — nobody has been marked')
+    if len(found) > 1:
+        return _nothing(
+            f'"{typed}" matches {len(found)} players: {_listed(found)} — type more of the name; '
+            "nobody has been marked"
+        )
+
+    player = found[0]
+    if player["player_id"] in marked:
+        return _nothing(f"{player['player_name']} is already marked taken by hand")
+    if pd.isna(player["sleeper_id"]) or not str(player["sleeper_id"]).strip():
+        return _nothing(
+            f"{player['player_name']} has no Sleeper ID on this board, so a hand-mark could not "
+            "be told apart from his own pick — nobody has been marked. He needs an identity "
+            "override and a rebuild, not a mark."
+        )
+    return {
+        "action": "mark",
+        "player": player,
+        "message": f"marked taken by hand: {_named(player)}",
+    }
+
+
+def _unmark(typed: str, marked: dict) -> dict:
+    """Resolve a typed name against what has been marked by hand, or refuse it saying why.
+
+    Against the marked set rather than the board: the drafter is choosing among his own marks, and
+    a player Sleeper reported is gone because he is gone. An unmark that appeared to work on him
+    would be the same lie as a wrong mark, pointing the other way.
+    """
+    wanted = _plain(typed)
+    if not wanted:
+        return _nothing(f'type at least part of a name after "{UNMARK}" to take a mark back')
+
+    found = _matching(wanted, list(marked.values()))
+    if not found:
+        return _nothing(f'nothing marked by hand matches "{typed}" — nothing has changed')
+    if len(found) > 1:
+        return _nothing(
+            f'"{typed}" matches {len(found)} players marked by hand: {_listed(found)} — type more '
+            "of the name; nothing has changed"
+        )
+
+    player = found[0]
+    return {
+        "action": "unmark",
+        "player": player,
+        "message": f"{player['player_name']} is no longer marked by hand",
+    }
+
+
+def read_mark(typed: str, board: pd.DataFrame, marked: dict) -> dict:
+    """One line the drafter typed, read against the board and the marks already made.
+
+    `marked` is the hand-marked players so far, keyed by the board's own `player_id`. Returns:
+
+    - `action` — `"mark"` to add the player to that set, `"unmark"` to take him out of it, and
+      `"none"` when there is nothing to do.
+    - `player` — the board row the name resolved to, or None when it resolved to nothing.
+    - `message` — always present, and always worth printing: a refusal that is not read is a mark
+      the drafter believes he made.
+    """
+    text = typed.strip()
+    if text.startswith(UNMARK):
+        return _unmark(text[len(UNMARK):].strip(), marked)
+    return _mark(text, board, marked)
+
+
+def as_picks(marked) -> list[dict]:
+    """The hand-marked players as picks payload entries, in the shape Sleeper's own arrive in.
+
+    No pick number, because the drafter knows a player is gone and not when — which is also what
+    keeps a mark from advancing the draft. No roster, because a mark never claims a player for
+    anybody's lineup.
+    """
+    entries = []
+    for player in marked:
+        first, _, last = str(player["player_name"]).partition(" ")
+        entries.append({
+            "player_id": str(player["sleeper_id"]),
+            "roster_id": None,
+            "pick_no": None,
+            "metadata": {
+                "first_name": first, "last_name": last, "position": player["position"]
+            },
+        })
+    return entries
+
+
+def combine(picks: list[dict], marked) -> list[dict]:
+    """The API's picks with the hand-marked players unioned in, the API's first.
+
+    First because `ingest_picks` keeps the first entry it sees for a player: a real pick, carrying
+    its number and its roster, always wins over the hand-mark it has caught up with.
+    """
+    return [*picks, *as_picks(marked)]

--- a/src/draft/render.py
+++ b/src/draft/render.py
@@ -8,6 +8,7 @@ something that has to be eyeballed on a draft night to know whether it is right.
 
     seat, picks made, next pick        one line, because it is the thing checked against the app
     unmatched picks                    loud, and above everything else
+    marked by hand                     short, and only when there is one
     my roster                          short, and answers "what do I still need"
     best available                     the long list, last
 
@@ -16,6 +17,11 @@ unmatched pick means a player may have been drafted and still be sitting on this
 available — the exact failure the feature exists to prevent — so it goes where it cannot be
 scrolled past, above the board rather than under thirty rows of it. Everything else is ordered by
 how often it is read, which puts the candidate list at the bottom where the eye lands.
+
+The hand-marked block sits under the warning for the same reason the warning is where it is: those
+players are gone on the drafter's own say-so, with nothing from Sleeper behind them, and a mistyped
+mark hides a player who is actually available. It is above the roster because it is the part of the
+screen most likely to be wrong.
 
 ## Missing values print as gaps, never as values
 
@@ -87,15 +93,42 @@ def _cost(value) -> str:
     return f"{value:.1f}"
 
 
-def _header(picks: dict, league: dict) -> str:
-    """Seat, progress and next turn: the line that gets checked against the Sleeper app."""
+def _header(picks: dict, league: dict, marked: list[dict]) -> str:
+    """Seat, progress and next turn: the line that gets checked against the Sleeper app.
+
+    The hand-marked count sits beside the picks made rather than inside it, because a mark is not
+    a pick: the draft has got exactly as far as Sleeper says it has. But the board below has had
+    both subtracted from it, and a board short of two players with nothing on screen to say so
+    reads as a board that has lost them.
+    """
     next_pick = picks["next_pick"]
     turn = f"next pick #{next_pick}" if next_pick is not None else "draft complete"
+    by_hand = f"  ·  {len(marked)} by hand" if marked else ""
     return (
         f"seat {league['seat']} of {league['team_count']}"
-        f"  ·  {picks['picks_made']} picks made"
+        f"  ·  {picks['picks_made']} picks made{by_hand}"
         f"  ·  {turn}"
     )
+
+
+def _marked(marked: list[dict]) -> list[str]:
+    """Who is off the board on the drafter's own say-so, named.
+
+    Named for the same reason an unmatched pick is: a mistyped mark hides a player who is actually
+    available, which is the failure this feature exists to prevent wearing the other face, and the
+    name is the only part of it a drafter can act on. It is also how he knows what to type after a
+    dash to take one back.
+    """
+    if not marked:
+        return []
+
+    lines = ["", f"Marked taken by hand — {len(marked)}"]
+    for player in marked:
+        lines.append(
+            f"  {_text(player.get('player_name'))} "
+            f"({_text(player.get('position'))}, {_text(player.get('team'))})"
+        )
+    return lines
 
 
 def _unmatched(unmatched: list[dict]) -> list[str]:
@@ -195,6 +228,7 @@ def render_board(
     limit: int = 30,
     degraded: bool = False,
     covers_to: int | None = None,
+    marked: list[dict] | tuple = (),
 ) -> str:
     """The whole screen as one string.
 
@@ -206,9 +240,15 @@ def render_board(
     `degraded` and `covers_to` are the rest of what the ranking returned. They are separate
     arguments rather than a dict because they change the words above the table and nothing else,
     and a renderer that had to be handed a ranking result could not be pointed at anything else.
+
+    `marked` is the players the drafter has taken off the board by hand. They are already gone
+    from `candidates` and already counted in `picks` — this is what puts them on screen, so that
+    a subtraction Sleeper never reported is visible rather than inferred from a shorter board.
     """
-    lines = [_header(picks, league)]
+    marked = list(marked)
+    lines = [_header(picks, league, marked)]
     lines += _unmatched(picks["unmatched"])
+    lines += _marked(marked)
     lines += _roster(picks["roster"], league)
     lines += _candidates(candidates, picks, limit, degraded, covers_to)
     return "\n".join(lines)

--- a/tests/test_draft_marks.py
+++ b/tests/test_draft_marks.py
@@ -1,0 +1,224 @@
+"""Issue #36: the drafter says a player is gone, and the board believes him.
+
+This is the one place in the feature where a player is identified by *name*. Everywhere else the
+rule is identity by ID, and it holds here too either side of one step: a typed string is resolved
+against the board once, and what comes out is a board row carrying its own IDs. Nothing downstream
+ever sees the string.
+
+That one step is where the whole risk sits, so the cases below are mostly about refusing:
+
+- A name matching nobody, and a name matching several, must both come back rejected and named.
+  Marking the wrong player hides somebody who is genuinely available, which is the mirror image of
+  the failure this feature exists to prevent — and it is invisible, because a board that is missing
+  a player looks exactly like a board where somebody took him.
+- A refusal has to say so out loud. The drafter is typing at a status line that repaints every
+  three seconds; a mark that quietly did nothing would be read as a mark that worked.
+
+The last two cases go through `ingest_picks` rather than inspecting what `as_picks` builds. What
+matters about a hand-mark is what the board does with it — the player gone, the draft not advanced,
+and one player rather than two once Sleeper catches up — and that is a claim about the union, not
+about the shape of a dict.
+"""
+
+import pandas as pd
+
+from src.draft.marks import as_picks, read_mark
+from src.draft.picks import ingest_picks
+
+SLOTS = {"QB": 1, "RB": 2, "WR": 2, "TE": 1, "FLEX": 1, "SUPER_FLEX": 1, "K": 1, "DST": 1}
+
+LEAGUE = {"seat": 1, "roster_id": 6, "team_count": 14, "rounds": 15, "slots": SLOTS}
+
+# Names chosen for the ways a typed one can go wrong: three players sharing a surname, two whose
+# punctuation nobody types under a pick clock, a pair where one full name is a prefix of the other,
+# and the rookie kicker the crosswalk missed.
+BOARD = pd.DataFrame(
+    [
+        {"player_id": "00-0000001", "sleeper_id": "4984", "player_name": "Josh Allen",
+         "position": "QB", "team": "BUF"},
+        {"player_id": "00-0000002", "sleeper_id": "4033", "player_name": "Keenan Allen",
+         "position": "WR", "team": "CHI"},
+        {"player_id": "00-0000003", "sleeper_id": "9509", "player_name": "Braelon Allen",
+         "position": "RB", "team": "NYJ"},
+        {"player_id": "00-0000004", "sleeper_id": "8112", "player_name": "Amon-Ra St. Brown",
+         "position": "WR", "team": "DET"},
+        {"player_id": "00-0000005", "sleeper_id": "6790", "player_name": "D'Andre Swift",
+         "position": "RB", "team": "CHI"},
+        {"player_id": "00-0000006", "sleeper_id": "7002", "player_name": "Michael Carter",
+         "position": "RB", "team": "ARI"},
+        {"player_id": "00-0000007", "sleeper_id": "7003", "player_name": "Michael Carter II",
+         "position": "RB", "team": "NYJ"},
+        # The residue issue #31 reports at build time: on the board, priced, and unresolvable.
+        {"player_id": "00-0000008", "sleeper_id": None, "player_name": "Rookie Kicker",
+         "position": "K", "team": "LV"},
+    ]
+)
+
+
+def marked(*names: str) -> dict:
+    """The hand-marked set, keyed the way the running tool keys it: by the board's player ID."""
+    rows = BOARD.loc[BOARD["player_name"].isin(names)]
+    return {row["player_id"]: dict(row) for _, row in rows.iterrows()}
+
+
+# 1. The plain case: a name typed in full marks that player, and what comes back is a board row.
+def test_a_full_name_marks_that_player():
+    outcome = read_mark("Josh Allen", BOARD, {})
+
+    assert outcome["action"] == "mark"
+    assert outcome["player"]["player_id"] == "00-0000001"
+    assert outcome["player"]["sleeper_id"] == "4984"
+    assert "Josh Allen" in outcome["message"]
+
+
+# 2. Typed at a pick clock, on a line that is repainting under the cursor.
+def test_case_and_spacing_do_not_matter():
+    outcome = read_mark("  josh   ALLEN  ", BOARD, {})
+
+    assert outcome["action"] == "mark"
+    assert outcome["player"]["player_name"] == "Josh Allen"
+
+
+# 3. Nobody types the apostrophe, the period or the hyphen.
+def test_punctuation_in_the_board_name_need_not_be_typed():
+    assert read_mark("dandre swift", BOARD, {})["player"]["player_name"] == "D'Andre Swift"
+    assert read_mark("amon ra st brown", BOARD, {})["player"]["player_name"] == "Amon-Ra St. Brown"
+
+
+# 4. Part of a name is enough when only one player has it, which is what makes this typeable.
+def test_part_of_a_name_marks_the_one_player_who_has_it():
+    assert read_mark("swift", BOARD, {})["player"]["player_name"] == "D'Andre Swift"
+    assert read_mark("keenan", BOARD, {})["player"]["player_name"] == "Keenan Allen"
+
+
+# 5. The failure that costs a pick: a player hidden who is actually there. It must be refused,
+# and refused loudly enough to be read on a repainting line.
+def test_a_name_matching_nobody_is_refused_and_marks_nobody():
+    outcome = read_mark("jsoh allen", BOARD, {})
+
+    assert outcome["action"] == "none"
+    assert outcome["player"] is None
+    assert "jsoh allen" in outcome["message"]
+
+
+# 6. The same failure by a different route. A surname three players share must never resolve to
+# whichever of them the board happened to list first — and the message has to name them, because
+# the only thing the drafter can do about it is type one of them.
+def test_a_name_matching_several_players_is_refused_and_names_them():
+    outcome = read_mark("allen", BOARD, {})
+
+    assert outcome["action"] == "none"
+    assert outcome["player"] is None
+    for name in ("Josh Allen", "Keenan Allen", "Braelon Allen"):
+        assert name in outcome["message"]
+
+
+# 7. "Michael Carter" is both a whole name and the start of another one. Treating that as ambiguous
+# would make the shorter name permanently untypeable, so the exact match wins.
+def test_a_whole_name_wins_over_a_longer_name_it_is_part_of():
+    outcome = read_mark("michael carter", BOARD, {})
+
+    assert outcome["action"] == "mark"
+    assert outcome["player"]["player_name"] == "Michael Carter"
+
+
+# 8. A board row with no Sleeper ID cannot be told apart from his own pick when it arrives, so a
+# mark on him would be a mark that silently did nothing. Refused, saying which player and why.
+def test_a_player_with_no_sleeper_id_is_refused_rather_than_marked():
+    outcome = read_mark("rookie kicker", BOARD, {})
+
+    assert outcome["action"] == "none"
+    assert outcome["player"] is None
+    assert "Rookie Kicker" in outcome["message"]
+    assert "Sleeper ID" in outcome["message"]
+
+
+# 9. Typing the same name twice is what happens when the first one scrolled off. It is not an
+# error, but it is not a second mark either, and the screen has to say which.
+def test_marking_a_player_already_marked_says_so_and_changes_nothing():
+    outcome = read_mark("josh allen", BOARD, marked("Josh Allen"))
+
+    assert outcome["action"] == "none"
+    assert "already" in outcome["message"].lower()
+    assert "Josh Allen" in outcome["message"]
+
+
+# 10. The way back out. A wrong mark hides an available player for the rest of the session, so it
+# has to be undoable from the same line it was made on.
+def test_a_leading_dash_takes_a_mark_back():
+    outcome = read_mark("-josh allen", BOARD, marked("Josh Allen"))
+
+    assert outcome["action"] == "unmark"
+    assert outcome["player"]["player_id"] == "00-0000001"
+    assert "Josh Allen" in outcome["message"]
+
+
+# 11. Only a hand-mark can be taken back. A player Sleeper reported is gone because he is gone, and
+# an unmark that appeared to work on him would be the same lie in the other direction.
+def test_a_player_who_was_never_marked_cannot_be_unmarked():
+    outcome = read_mark("-keenan allen", BOARD, marked("Josh Allen"))
+
+    assert outcome["action"] == "none"
+    assert outcome["player"] is None
+    assert "keenan allen" in outcome["message"]
+
+
+# 12. Ambiguity has to be refused on the way back out too, against the marked set rather than the
+# board — the drafter is choosing among what he has marked, not among everyone.
+def test_an_ambiguous_unmark_is_refused_and_names_the_marked_players():
+    outcome = read_mark("-allen", BOARD, marked("Josh Allen", "Keenan Allen"))
+
+    assert outcome["action"] == "none"
+    assert "Josh Allen" in outcome["message"]
+    assert "Keenan Allen" in outcome["message"]
+    assert "Braelon Allen" not in outcome["message"]
+
+
+# 13. A dash with nothing after it is a slip, not a command.
+def test_a_dash_with_no_name_is_refused():
+    outcome = read_mark("-", BOARD, marked("Josh Allen"))
+
+    assert outcome["action"] == "none"
+    assert outcome["message"]
+
+
+# 14. Nothing typed at this function is ever silently swallowed: every outcome carries a line for
+# the screen, whether it worked or not.
+def test_every_outcome_carries_a_message():
+    typed = ["josh allen", "allen", "jsoh allen", "rookie kicker", "-", "-allen", "michael carter"]
+    for text in typed:
+        assert read_mark(text, BOARD, marked("Josh Allen", "Keenan Allen"))["message"]
+
+
+# 15. The board is the warehouse's, read-only here as everywhere else in this package.
+def test_reading_a_mark_does_not_touch_the_board():
+    before = BOARD.copy()
+    read_mark("josh allen", BOARD, {})
+    pd.testing.assert_frame_equal(BOARD, before)
+
+
+# 16. What a mark is *for*: the player off the board, and the draft not advanced by it. Asserted
+# through the real ingestion seam, because that is where a mark either works or does not.
+def test_a_marked_player_is_taken_without_advancing_the_draft():
+    api = [{"player_id": "4033", "roster_id": 3, "pick_no": 1, "metadata": {}}]
+    outcome = read_mark("josh allen", BOARD, {})
+
+    result = ingest_picks([*api, *as_picks([outcome["player"]])], BOARD, LEAGUE)
+
+    assert result["taken"] == {"00-0000001", "00-0000002"}
+    assert result["picks_made"] == 1
+    assert result["unmatched"] == []
+
+
+# 17. And when Sleeper catches up, the pick it reports is the one that counts: one player, on the
+# roster that actually drafted him, at the number he actually went.
+def test_a_mark_gives_way_to_the_pick_when_the_api_reports_it():
+    outcome = read_mark("josh allen", BOARD, {})
+    api = [{"player_id": "4984", "roster_id": 6, "pick_no": 4, "metadata": {}}]
+
+    result = ingest_picks([*api, *as_picks([outcome["player"]])], BOARD, LEAGUE)
+
+    assert result["taken"] == {"00-0000001"}
+    assert result["picks_made"] == 4
+    qb = result["roster"].loc[result["roster"]["slot"] == "QB"]
+    assert list(qb["players"].iloc[0]) == ["Josh Allen"]

--- a/tests/test_draft_render.py
+++ b/tests/test_draft_render.py
@@ -332,3 +332,36 @@ def test_a_degraded_result_says_it_has_fallen_back_to_value_ranking():
     assert "#180" in out
     # And it must not still claim to be ranking by a rule it no longer has the inputs for.
     assert "cost of waiting" not in out
+
+
+# Issue #36's render cases. A hand-marked player is off the board on the drafter's own say-so
+# rather than Sleeper's, and that is the one subtraction nothing else on screen can account for:
+# the header's pick count does not move for a mark, so a board short of two players would look
+# like a board that had lost them. Both cases below are about being able to see what was marked.
+
+
+def test_the_players_marked_by_hand_are_named_on_screen():
+    out = render_board(
+        candidates({"player_name": "Still There"}),
+        ingested(),
+        LEAGUE,
+        marked=[
+            {"player_id": "00-0000009", "player_name": "Gone Already", "position": "QB",
+             "team": "BUF"},
+            {"player_id": "00-0000010", "player_name": "Also Gone", "position": "RB",
+             "team": "ATL"},
+        ],
+    )
+    # Named rather than counted, for the same reason an unmatched pick is: a mistyped mark hides
+    # a player who is actually available, and the name is the only part of that a drafter can act
+    # on before his next pick.
+    assert "Gone Already" in out
+    assert "Also Gone" in out
+    # And the count belongs on the line that gets checked against the Sleeper app, because that
+    # line's "28 picks made" is not what this board has subtracted.
+    assert "2 by hand" in line_naming(out, "picks made")
+
+
+def test_a_draft_with_nothing_marked_by_hand_says_nothing_about_it():
+    out = render_board(candidates({"player_name": "Still There"}), ingested(), LEAGUE)
+    assert "hand" not in out.lower()

--- a/tests/test_draft_watch.py
+++ b/tests/test_draft_watch.py
@@ -194,6 +194,16 @@ def typist(*batches):
     return keys
 
 
+def available(drawn: str) -> str:
+    """The candidate list out of one drawn board — who is actually still on it.
+
+    A hand-marked player is deliberately *named* on the screen he has been subtracted from, under
+    the block saying the drafter marked him, so "is he still on the board" is a question about
+    this section and not about whether his name appears anywhere.
+    """
+    return drawn.split("Best available")[-1]
+
+
 def run_typed(*outcomes, typed, interval: float = 0.5):
     """Drive `watch` with something typed at it, and give back everything it wrote."""
     written = []
@@ -212,7 +222,7 @@ def test_a_typed_name_marks_the_player_and_redraws_without_him():
 
     drawn = boards(written)
     assert len(drawn) == 1
-    assert "Bravo Wideout" not in drawn[0]
+    assert "Bravo Wideout" not in available(drawn[0])
 
 
 # 19. A mark that lasted one tick would be worse than none: the drafter would have to retype it
@@ -223,7 +233,7 @@ def test_a_mark_survives_the_refreshes_that_follow_it():
                         typed=[["bravo wideout"], [], []])
 
     for drawn in boards(written):
-        assert "Bravo Wideout" not in drawn
+        assert "Bravo Wideout" not in available(drawn)
 
 
 # 20. Unioned with the API's picks, never instead of them — a mark that replaced them would put
@@ -231,7 +241,7 @@ def test_a_mark_survives_the_refreshes_that_follow_it():
 def test_a_mark_is_combined_with_the_picks_the_api_reports():
     written = run_typed([pick(1, "4034")], typed=[["bravo wideout"]])
 
-    drawn = boards(written)[-1]
+    drawn = available(boards(written)[-1])
     assert "Alpha Back" not in drawn
     assert "Bravo Wideout" not in drawn
     assert "Charlie Ender" in drawn
@@ -257,8 +267,8 @@ def test_a_mark_redraws_the_board_on_a_tick_the_poll_failed():
 
     drawn = boards(written)
     assert len(drawn) == 2
-    assert "Bravo Wideout" in drawn[0]
-    assert "Bravo Wideout" not in drawn[1]
+    assert "Bravo Wideout" in available(drawn[0])
+    assert "Bravo Wideout" not in available(drawn[1])
 
 
 # 23. Enter on an empty line is how a drafter clears a half-typed name.
@@ -276,5 +286,5 @@ def test_an_unmark_puts_the_player_back_on_the_board():
 
     drawn = boards(written)
     assert len(drawn) == 2
-    assert "Bravo Wideout" not in drawn[0]
-    assert "Bravo Wideout" in drawn[1]
+    assert "Bravo Wideout" not in available(drawn[0])
+    assert "Bravo Wideout" in available(drawn[1])

--- a/tests/test_draft_watch.py
+++ b/tests/test_draft_watch.py
@@ -174,3 +174,107 @@ def test_the_loop_waits_the_configured_interval_between_polls():
 def test_an_interrupt_ends_the_loop_cleanly():
     written, _ = run([pick(1, "4034")])
     assert "stopped" in written[-1].lower()
+
+
+# Issue #36's loop cases: the drafter typing at the same line the status is repainting on.
+#
+# The pure half of hand-marking — which name resolves to which player, and what is refused — is
+# `test_draft_marks.py`'s. These are the half that only exists inside the loop: that a mark reaches
+# the board at all, that it stays there for the rest of the session, and that it still works on a
+# tick where Sleeper did not answer, which is the whole reason it exists.
+
+
+def typist(*batches):
+    """A keyboard handing back the lines typed since the last tick, one batch per tick."""
+    remaining = list(batches)
+
+    def keys():
+        return remaining.pop(0) if remaining else []
+
+    return keys
+
+
+def run_typed(*outcomes, typed, interval: float = 0.5):
+    """Drive `watch` with something typed at it, and give back everything it wrote."""
+    written = []
+    sleep, _ = ticker(len(outcomes))
+    watch(
+        CONTEXT, limit=5, poll=poller(*outcomes), sleep=sleep, now=clock(),
+        write=written.append, keys=typist(*typed), interval=interval,
+    )
+    return written
+
+
+# 18. The mark reaching the board, which is the whole feature: a player the API has not reported
+# is off the board because the drafter said so.
+def test_a_typed_name_marks_the_player_and_redraws_without_him():
+    written = run_typed([pick(1, "4034")], typed=[["bravo wideout"]])
+
+    drawn = boards(written)
+    assert len(drawn) == 1
+    assert "Bravo Wideout" not in drawn[0]
+
+
+# 19. A mark that lasted one tick would be worse than none: the drafter would have to retype it
+# every three seconds, and would not know it had lapsed.
+def test_a_mark_survives_the_refreshes_that_follow_it():
+    payload = [pick(1, "4034")]
+    written = run_typed(payload, payload, [*payload, pick(2, "8146")],
+                        typed=[["bravo wideout"], [], []])
+
+    for drawn in boards(written):
+        assert "Bravo Wideout" not in drawn
+
+
+# 20. Unioned with the API's picks, never instead of them — a mark that replaced them would put
+# thirteen other managers' picks back on the board.
+def test_a_mark_is_combined_with_the_picks_the_api_reports():
+    written = run_typed([pick(1, "4034")], typed=[["bravo wideout"]])
+
+    drawn = boards(written)[-1]
+    assert "Alpha Back" not in drawn
+    assert "Bravo Wideout" not in drawn
+    assert "Charlie Ender" in drawn
+
+
+# 21. A refusal has to be on screen. Typed at a line that repaints every three seconds, a name
+# that quietly did nothing reads exactly like a name that worked.
+def test_a_refused_name_draws_no_board_and_says_why():
+    payload = [pick(1, "4034")]
+    written = run_typed(payload, payload, typed=[[], ["nobody at all"]])
+
+    assert len(boards(written)) == 1
+    assert any("nobody at all" in chunk for chunk in written)
+
+
+# 22. The case the feature was built for. Sleeper has stopped answering, the draft has not stopped,
+# and the board still has to move.
+def test_a_mark_redraws_the_board_on_a_tick_the_poll_failed():
+    written = run_typed(
+        [pick(1, "4034")], requests.ConnectionError("connection reset"),
+        typed=[[], ["bravo wideout"]],
+    )
+
+    drawn = boards(written)
+    assert len(drawn) == 2
+    assert "Bravo Wideout" in drawn[0]
+    assert "Bravo Wideout" not in drawn[1]
+
+
+# 23. Enter on an empty line is how a drafter clears a half-typed name.
+def test_an_empty_line_changes_nothing():
+    payload = [pick(1, "4034")]
+    written = run_typed(payload, payload, typed=[[], ["", "   "]])
+
+    assert len(boards(written)) == 1
+
+
+# 24. The way back from a mistyped mark, without restarting the tool mid-draft.
+def test_an_unmark_puts_the_player_back_on_the_board():
+    payload = [pick(1, "4034")]
+    written = run_typed(payload, payload, typed=[["bravo wideout"], ["-bravo wideout"]])
+
+    drawn = boards(written)
+    assert len(drawn) == 2
+    assert "Bravo Wideout" not in drawn[0]
+    assert "Bravo Wideout" in drawn[1]


### PR DESCRIPTION
Closes #36.

The fallback for the night Sleeper stops answering: a name typed at the running tool marks that
player taken by hand, `-name` takes the mark back, and marks are held for the session and unioned
with the picks the API reports rather than replacing them.

## How it works

`src/draft/marks.py` is the new pure module and the only place in the feature where a player is
identified by name. A typed string resolves against the board once and what comes out is a board
row carrying its own IDs, so nothing downstream ever sees the string. A mark then becomes a pick
entry with no pick number and no roster, appended to what the API returned — `ingest_picks` already
had both defences this needs: it deduplicates on the player, so Sleeper's own pick wins the moment
it catches up (carrying the roster and number the mark could not know), and it reads the draft's
progress from pick numbers, so a mark never pushes the seat's next turn a pick further away.

The loop keeps the last payload a poll returned, so a mark still redraws the board on a tick where
Sleeper did not answer. A failed poll on its own still draws nothing.

## What it refuses

- An unknown name, and an ambiguous one — named, and up to six of them listed. A wrong mark hides
  a player who is actually available, and a board short of a player looks exactly like a board
  where somebody took him.
- A player with no `sleeper_id` on the board (10 of 655 today: three kickers and seven deep
  quarterbacks). His mark would union with nothing and remove nobody, so the message points at the
  identity override and a rebuild instead.
- Nothing typed is ever silently swallowed: every outcome carries a line for the screen, and the
  players marked by hand are named on the board they have been subtracted from.

## Scope decisions

- **Unmarking is in**, by decision: a wrong mark hides an available player for the rest of the
  session, which is the failure this feature exists to prevent wearing the other face, and undoing
  it must not need a restart mid-draft.
- **Ownership is out**: a mark says a player is gone, never whose he is. There is no way to claim
  one for my own roster, so a mistyped mark can never put a player in my lineup; Sleeper's pick
  fills the roster when the network returns.

## Testing

24 new cases, written and committed before the implementation (3a14ead): 17 for the resolver and
the union, five in the loop, two in the render. Suite is 143 passing.

Five of my own loop cases asserted a marked player's name was absent from the *screen*, which
contradicted the render case in the same commit requiring him to be named under the block that
marked him. They were narrowed to the candidate list, which is what they meant; no existing case
was touched.

Verified beyond the suite: the real stdin reader driven through the loop over a pipe (mark,
refusal, second mark, blank line, unmark), and name resolution against the real 655-row board —
`jamarr chase` and `ja'marr chase` reach the same player, `amon ra st brown` resolves, `allen`
is refused naming eight, and every mark came back matched with nothing unmatched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)