### PR TITLE
Show which roster shapes the opening is still on track for

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -100,6 +100,14 @@ A **plan** stated as a specific sequence — quarterback first, then two backs. 
 distinguishing from **composition** where the sequence itself is the claim being tested.
 _Avoid_: draft order (that means **seat** ordering, not position ordering)
 
+**Band**:
+Every **plan** sharing one position's count — "the openings that take two quarterbacks" — scored
+as the mean of its members. The unit composition guidance is stated in, because the plan table
+records trials but no dispersion: the leading compositions sit within simulation noise of each
+other, while the bands underneath them are far apart. A band is never a recommendation to draft a
+specific player.
+_Avoid_: bucket, tier (the **board** already spends *tier* on an offensive line's grade)
+
 **Field**:
 The other teams in a simulated draft, and how they behave. A field drafting straight off ADP is the
 friendliest possible room, because the focal team is the only one deviating.

--- a/README.md
+++ b/README.md
@@ -423,6 +423,15 @@ python -m src.draft.live --once       # draw it once and exit
 It resolves the seat from the draft order, subtracts the picks already made, ranks what is left by
 what waiting for it would cost, and shows the roster so far and the next overall pick number.
 
+Beside that ranking it shows which roster shapes the opening is still on track for, read from
+`draft_plans` for this league and this seat at run time. Cost of waiting looks one pick ahead at
+one player, so it cannot see the roster being assembled; this is the half that can. It is stated
+as position-count bands rather than as a named opening — the plan table records no dispersion, so
+the leading compositions cannot be told apart from simulation noise — and it is withdrawn once the
+rounds the plan table covers have passed. Nothing about it is hardcoded, which matters because the
+finding reverses between the two leagues: point it at the ESPN rows and it stops recommending
+quarterbacks.
+
 Type a player's name at it to mark him taken by hand, and `-name` to take that back. Marks are held
 for the session and unioned with the picks Sleeper reports rather than replacing them, so the draft
 stays followable through an outage — which is the one thing polling cannot fix by itself.

--- a/src/draft/composition.py
+++ b/src/draft/composition.py
@@ -1,0 +1,354 @@
+"""Which roster shapes the opening is still on track for, read from the plan table on the night.
+
+The one signal in this package that is not about a player. Pure like the rest of it — a plan
+frame and my picks so far in, bands and a leader out; no network, no warehouse connection, no
+printing, and nothing handed in is modified.
+
+## Why a ranking of players cannot say this
+
+Cost of waiting looks exactly one pick ahead, at one player at a time. That is the right question
+for the pick on the clock and it is structurally blind to the roster being assembled: there is
+always a more urgent individual player, so a drafter following it greedily can walk past the shape
+he needed and never see a number complaining. The plan table is the other half — it scores an
+*opening* by the whole roster it produces, which is precisely what five picks cannot see about
+themselves.
+
+The two are complementary, so they are kept apart. Guidance never enters the cost-of-waiting
+arithmetic and never reorders anything; it sits beside the ranking and says what a position would
+keep open or close off, so the recommendation stays auditable at the moment it is being trusted.
+
+## Nothing about the finding is written here
+
+The plan table's own headline reverses between the two leagues this repo serves: opening with two
+quarterbacks is worth roughly +22 points against the field in the superflex league and roughly -41
+in the one-quarterback league. A rule encoding "take two quarterbacks early" would therefore be
+actively harmful in the other league already on the shelf.
+
+So no composition string appears in this module, and neither does the length of an opening. Both
+are read out of the frame: a plan's label is parsed into counts, and how many picks an opening
+spends is the total of those counts. Point this at the other league's rows and it says the
+opposite thing, which is the property worth having rather than the answer.
+
+## Bands, and why nothing finer is offered
+
+The plan table records trials but no dispersion, so the difference between the leading
+compositions cannot be told apart from simulation noise — the top several sit within about twenty
+points of one another over three hundred trials. What is *not* close is the band structure
+underneath them: quarterback count across the opening moves the outcome by roughly a hundred
+points and triples the win rate, monotonically.
+
+A **band** is therefore every open plan sharing one position's count — "the openings that take two
+quarterbacks" — scored as the mean of its members. Coarse enough to survive the noise, and the
+unit the guidance is stated in. A single composition is never named as optimal.
+
+Every open band is reported, not only the best one, because being warned away from a badly-scoring
+shape is half of what this is for and a leader on its own does not say what the alternatives cost.
+
+## Open, and closing
+
+A plan is **open** when it is still reachable: it wants at least as many of every position as I
+have already taken. Since every plan spends the same number of picks, that single test is enough —
+the surplus it still owes is exactly the picks I have left.
+
+That makes "what does this pick cost me" answerable without simulating anything. Taking one more
+of position *p* keeps a plan open only if that plan wanted more of *p* than I already have, so the
+positions that keep the best band alive are the ones some member of it still wants. Everything
+else closes it — a kicker included, which is why the message names what keeps the band rather than
+what closes it: a position the plan table has never heard of closes every plan at once.
+
+## When it says nothing, it says that
+
+Three quiet states, and they are not the same:
+
+- **Withdrawn.** The opening the table covers is behind us, or the table holds nothing for this
+  seat. There is no guidance to give and none is extrapolated — the plan model constrained the
+  first rounds and says nothing about what follows.
+- **No open plans.** The opening so far matches no plan in the table. That is information, not an
+  error: it is a shape nobody simulated, and it is reported as such rather than raising.
+- **Everything is open.** Before the first pick, which is when the bands are widest and the
+  guidance is worth the most.
+
+## Known limitation, inherited
+
+The plans were scored against a field drafting straight off ADP, which the glossary calls the
+friendliest possible room. Read a band's margin as an upper bound on what the same opening is
+worth against a room that is also deviating.
+"""
+
+import re
+
+import numpy as np
+import pandas as pd
+
+# What a plan's label looks like when it is a composition: a count and a position, repeated, with
+# the positions a plan takes none of simply absent (`2QB2RB1TE`). Anything else — the pure-ADP
+# control the table carries beside the compositions, an ordering written as a sequence — is not an
+# opening anybody can be on track for and is left out rather than guessed at.
+_COMPOSITION = re.compile(r"(\d+)([A-Za-z]+)")
+
+# What the guidance reads out of `draft_plans`. `trials` is the weight behind a plan's mean, and
+# is carried so a band of plans simulated different numbers of times is still an honest average.
+PLAN_COLUMNS = ["draft_slot", "plan", "trials", "points_vs_field", "win_rate"]
+
+# One row per open band: the position and count that define it, how many open plans it holds, and
+# what those plans average.
+BAND_COLUMNS = ["position", "count", "plans", "points_vs_field", "win_rate"]
+
+
+def _counts(label) -> dict[str, int] | None:
+    """A plan's label parsed into position counts, or None if it is not a composition at all.
+
+    The whole label has to be counts and positions with nothing left over, so `best available`
+    parses to nothing rather than to something. A label naming a position twice is refused for the
+    same reason: it is not a shape this can read, and reading it wrongly would be worse.
+    """
+    text = str(label).strip()
+    matches = list(_COMPOSITION.finditer(text))
+    if not matches or "".join(match.group(0) for match in matches) != text:
+        return None
+
+    counts: dict[str, int] = {}
+    for match in matches:
+        position = match.group(2).upper()
+        if position in counts:
+            return None
+        counts[position] = int(match.group(1))
+    return counts
+
+
+def _plans_for_seat(plans: pd.DataFrame, seat: int) -> list[dict]:
+    """This seat's compositions, parsed, and only those spending a full opening's worth of picks.
+
+    A snake gives every slot a completely different draft, which is why the plan table is keyed on
+    the seat: reading another seat's rows would be guidance for somebody else's draft.
+    """
+    if plans.empty:
+        return []
+
+    mine = plans.loc[plans["draft_slot"] == seat]
+    parsed = []
+    for row in mine.itertuples():
+        counts = _counts(row.plan)
+        if counts is None:
+            continue
+        parsed.append({
+            "counts": counts,
+            "picks": sum(counts.values()),
+            "trials": float(row.trials),
+            "points_vs_field": float(row.points_vs_field),
+            "win_rate": float(row.win_rate),
+        })
+
+    # How long an opening is, read from the plans rather than assumed. Anything shorter is not an
+    # opening of the kind the rest of the table describes and cannot be compared with one.
+    if not parsed:
+        return []
+    opening = max(plan["picks"] for plan in parsed)
+    return [plan for plan in parsed if plan["picks"] == opening]
+
+
+def _positions(plans: list[dict]) -> list[str]:
+    """Every position the plans mention, in the order the labels write them.
+
+    First appearance rather than alphabetical, so the screen reads QB, RB, WR, TE — the order the
+    warehouse writes a composition in, and the one a drafter's eye already knows.
+    """
+    order = []
+    for plan in plans:
+        for position in plan["counts"]:
+            if position not in order:
+                order.append(position)
+    return order
+
+
+def _weighted(plans: list[dict], column: str) -> float:
+    """One band's mean, weighted by the drafts behind each plan."""
+    weights = [plan["trials"] for plan in plans]
+    values = [plan[column] for plan in plans]
+    if sum(weights) <= 0:
+        return float(np.mean(values))
+    return float(np.average(values, weights=weights))
+
+
+def _bands(open_plans: list[dict], positions: list[str]) -> pd.DataFrame:
+    """Every position-count band the open plans still describe, in the order it is read down.
+
+    The position holding the best band comes first, then its counts in order, so the table leads
+    with the choice the guidance above it is actually about and the rest read as alternatives to
+    that one.
+
+    The tempting ordering — by how far a position's bands are spread apart, widest first — is
+    quietly unfair between positions: the sweep behind the plan table caps an opening at two
+    quarterbacks and two tight ends but allows five backs or five receivers, so the positions with
+    more counts to their name have more room to be extreme and sort above the one the guidance is
+    about. `5WR` is the widest thing on this table and nobody is drafting it.
+    """
+    rows = []
+    for position in positions:
+        for count in sorted({plan["counts"].get(position, 0) for plan in open_plans}):
+            members = [
+                plan for plan in open_plans if plan["counts"].get(position, 0) == count
+            ]
+            rows.append({
+                "position": position,
+                "count": count,
+                "plans": len(members),
+                "points_vs_field": _weighted(members, "points_vs_field"),
+                "win_rate": _weighted(members, "win_rate"),
+            })
+
+    frame = pd.DataFrame(rows, columns=BAND_COLUMNS)
+    if frame.empty:
+        return frame
+
+    leader = frame.groupby("position")["points_vs_field"].max()
+    return (
+        frame.assign(
+            _leader=frame["position"].map(leader),
+            _position=frame["position"].map(positions.index),
+        )
+        .sort_values(
+            ["_leader", "_position", "count"], ascending=[False, True, True]
+        )
+        .drop(columns=["_leader", "_position"])
+        .reset_index(drop=True)
+    )
+
+
+def _best(bands: pd.DataFrame, positions: list[str]) -> dict:
+    """The best-scoring band of the lot.
+
+    Read out rather than taken off the top of the table, which is ordered to *lead with the
+    position* holding this band and then to run that position's counts in order — the count that
+    reads first there is the lowest, not the best. Ties go to the earlier position and then to the
+    smaller count, so the same frame always names the same band.
+    """
+    ordered = bands.assign(_position=bands["position"].map(positions.index)).sort_values(
+        ["points_vs_field", "_position", "count"], ascending=[False, True, True]
+    )
+    return ordered.drop(columns="_position").iloc[0].to_dict()
+
+
+def _nothing(reason: str, **rest) -> dict:
+    """A result with no bands in it, saying why rather than being silently empty."""
+    return {
+        "withdrawn": False,
+        "reason": reason,
+        "opening_rounds": None,
+        "picks_spent": 0,
+        "taken": {},
+        "open_plans": 0,
+        "total_plans": 0,
+        "bands": pd.DataFrame(columns=BAND_COLUMNS),
+        "best": None,
+        "keeps_best": [],
+        "closes_best": [],
+        **rest,
+    }
+
+
+def composition_guidance(plans: pd.DataFrame, picks: dict, league: dict) -> dict:
+    """Which shapes this seat's opening is still on track for, and what the next pick closes.
+
+    `plans` is `draft_plans` for one league, carrying `PLAN_COLUMNS`; the league filter belongs to
+    the read because it names a table's key, and the seat filter belongs here because the seat is
+    resolved on the night. `picks` is what `ingest_picks` returned — `mine` is the only key read
+    from it — and `league` supplies `seat`.
+
+    Returns a dict of:
+
+    - `withdrawn` — True once the opening the plan table covers is behind us, or when the table
+      holds nothing for this seat. There is nothing to say and nothing is extrapolated.
+    - `reason` — why there is nothing to say, as a sentence for the screen, or None.
+    - `opening_rounds` — how many picks an opening spends, read from the plans themselves.
+    - `picks_spent` — how many of them I have made.
+    - `taken` — my opening so far as position counts, including positions no plan mentions.
+    - `open_plans` / `total_plans` — how many of this seat's plans are still reachable.
+    - `bands` — every open band with `BAND_COLUMNS`, the position holding the best one first.
+    - `best` — the best-scoring open band, or None when none are open.
+    - `keeps_best` / `closes_best` — the plans' own positions, split by whether taking one more of
+      them leaves the best band reachable. A position the plans never mention is in neither, and
+      closes every plan there is.
+    """
+    mine = list(picks.get("mine") or [])
+    spent = len(mine)
+
+    seat_plans = _plans_for_seat(plans, league["seat"])
+    if not seat_plans:
+        return _nothing(
+            withdrawn=True,
+            reason=(
+                f"the plan table holds no opening plans for seat {league['seat']}, so there is "
+                "nothing to be on track for"
+            ),
+            picks_spent=spent,
+        )
+
+    positions = _positions(seat_plans)
+    opening_rounds = seat_plans[0]["picks"]
+
+    # My opening as counts, plans' positions first so the screen reads in the table's own order,
+    # then anything else I have taken — a kicker in the opening is exactly why nothing matches.
+    drafted = [player["position"] for player in mine]
+    taken = {
+        position: drafted.count(position)
+        for position in positions + [p for p in drafted if p not in positions]
+        if drafted.count(position)
+    }
+
+    shared = {
+        "opening_rounds": opening_rounds,
+        "picks_spent": spent,
+        "taken": taken,
+        "total_plans": len(seat_plans),
+    }
+
+    if spent >= opening_rounds:
+        return _nothing(
+            withdrawn=True,
+            reason=(
+                f"the plan table covers the first {opening_rounds} rounds and says nothing "
+                "about the picks that follow"
+            ),
+            **shared,
+        )
+
+    # Still reachable: wants at least as many of every position as I have already taken.
+    open_plans = [
+        plan
+        for plan in seat_plans
+        if all(plan["counts"].get(position, 0) >= count for position, count in taken.items())
+    ]
+    if not open_plans:
+        return _nothing(
+            reason=(
+                "no plan for this seat matches this opening, so there is nothing left to be on "
+                "track for"
+            ),
+            **shared,
+        )
+
+    bands = _bands(open_plans, positions)
+    best = _best(bands, positions)
+
+    # A plan in the best band survives one more pick at a position only if it wanted more of that
+    # position than I already have. Everything else — a position no plan mentions included —
+    # closes the band, which is why the screen says what keeps it open.
+    in_best = [
+        plan for plan in open_plans if plan["counts"].get(best["position"], 0) == best["count"]
+    ]
+    keeps = [
+        position
+        for position in positions
+        if any(plan["counts"].get(position, 0) > taken.get(position, 0) for plan in in_best)
+    ]
+    return {
+        "withdrawn": False,
+        "reason": None,
+        "open_plans": len(open_plans),
+        "bands": bands,
+        "best": best,
+        "keeps_best": keeps,
+        "closes_best": [position for position in positions if position not in keeps],
+        **shared,
+    }

--- a/src/draft/live.py
+++ b/src/draft/live.py
@@ -54,8 +54,8 @@ not revisited under a pick clock.
 
 ## This module is the edge, and the only part of `src/draft/` that is
 
-`picks`, `candidates`, `seat` and `render` are all pure: frames and payloads in, frames and
-strings out. Everything that touches the world is here, in one file, so that "does this tool
+`picks`, `candidates`, `seat`, `composition` and `render` are all pure: frames and payloads in,
+frames and strings out. Everything that touches the world is here, in one file, so that "does this tool
 write anything" is a question answered by reading one module rather than four.
 
 What it touches, exhaustively:
@@ -64,7 +64,7 @@ What it touches, exhaustively:
   picks on every tick. There is no POST anywhere in this package, which is what "never makes a
   pick" means in practice: the tool has no code path that could submit one, rather than a flag
   saying it shouldn't.
-- Two reads of `data/warehouse.duckdb` through `src.query.q`, which opens read-only and closes
+- Three reads of `data/warehouse.duckdb` through `src.query.q`, which opens read-only and closes
   before each returns. A draft-night process cannot corrupt what the pipeline built, and cannot
   hold the file lock against a rebuild either.
 - Whatever has been typed at **stdin**, read without blocking and resolved against the board by
@@ -100,6 +100,7 @@ from datetime import datetime, timedelta
 import pandas as pd
 import requests
 
+from src.draft.composition import composition_guidance
 from src.draft.marks import combine, read_mark
 from src.draft.picks import ingest_picks, picks_made
 from src.draft.refresh import fingerprint, status_line
@@ -253,6 +254,32 @@ def load_survival(league_key: str = LEAGUE_KEY) -> pd.DataFrame:
     return survival
 
 
+def load_plans(league_key: str = LEAGUE_KEY) -> pd.DataFrame:
+    """What each opening plan was worth from each seat, as the simulation scored it days ago.
+
+    The one table here that prices a *roster shape* rather than a player. It is read whole for the
+    league and filtered to the seat above, in `composition`, because the seat is not known until
+    the draft record has been fetched — and because a pure function that does its own filtering is
+    a pure function whose filtering can be tested.
+    """
+    plans = q(
+        """
+        SELECT draft_slot, plan, trials, points_vs_field, win_rate
+        FROM draft_plans
+        WHERE league_key = ?
+        """,
+        [league_key],
+    )
+    if plans.empty:
+        # Not a refusal, for the same reason a missing survival table is not: the board is still
+        # worth reading, and the screen says the opening guidance has nothing behind it.
+        print(
+            f"\ndraft_plans holds no rows for league {league_key!r} — the board will show no "
+            "opening guidance. Run scripts/build_warehouse.sh to price roster shapes.\n"
+        )
+    return plans
+
+
 def prepare() -> dict:
     """Everything that cannot change once the draft is under way, read once.
 
@@ -264,6 +291,7 @@ def prepare() -> dict:
     return {
         "board": load_board(),
         "survival": load_survival(),
+        "plans": load_plans(),
         "draft": draft,
         "league": resolve_seat(draft, user_id(USERNAME)),
     }
@@ -296,9 +324,14 @@ def screen(
     candidates = ranked["candidates"].merge(
         context["board"][["player_id", "bye_week"]], on="player_id", how="left"
     )
+
+    # Beside the ranking, never in it: the guidance is read from the plan table and says what a
+    # position keeps open or closes off, and the order below it is the same order either way.
+    guidance = composition_guidance(context["plans"], result, context["league"])
     return render_board(
         candidates, result, context["league"], limit,
         degraded=ranked["degraded"], covers_to=ranked["covers_to"], marked=marked,
+        guidance=guidance,
     )
 
 

--- a/src/draft/picks.py
+++ b/src/draft/picks.py
@@ -194,6 +194,10 @@ def ingest_picks(picks: list[dict], board: pd.DataFrame, league: dict) -> dict:
 
     - `taken` — the board's own player IDs for everyone drafted, mine and everyone else's.
     - `roster` — my lineup so far, a frame of one row per starting slot.
+    - `mine` — my own picks, in the order I made them, carrying the position each one was. The
+      roster frame reports an *assignment* — a third back sits in the flex, and the bench mixes
+      every position together — so the shape of my opening cannot be read back out of it. This is
+      the same picks, unassigned, and it is what `composition` reads.
     - `unmatched` — every pick whose player the board could not identify, named, in draft order.
     - `next_pick` — the overall number of my next turn, or None once the draft is over.
     - `pick_after_next` — the turn after that, or None when my next turn is my last. This is what
@@ -240,6 +244,7 @@ def ingest_picks(picks: list[dict], board: pd.DataFrame, league: dict) -> dict:
     return {
         "taken": taken,
         "roster": _roster_frame(_assign_to_slots(mine, league["slots"]), league["slots"]),
+        "mine": mine,
         "unmatched": unmatched,
         "next_pick": next_pick,
         # The same walk, started from my next turn rather than from the draft: whatever I pass on

--- a/src/draft/render.py
+++ b/src/draft/render.py
@@ -10,6 +10,7 @@ something that has to be eyeballed on a draft night to know whether it is right.
     unmatched picks                    loud, and above everything else
     marked by hand                     short, and only when there is one
     my roster                          short, and answers "what do I still need"
+    opening shape                      short, and answers "what am I still on track for"
     best available                     the long list, last
 
 The order is the only real decision here, and it is decided by what a wrong screen costs. An
@@ -22,6 +23,12 @@ The hand-marked block sits under the warning for the same reason the warning is 
 players are gone on the drafter's own say-so, with nothing from Sleeper behind them, and a mistyped
 mark hides a player who is actually available. It is above the roster because it is the part of the
 screen most likely to be wrong.
+
+The opening-shape block sits between the roster and the board deliberately. It is a claim about
+the roster rather than about a player, so it belongs with the roster; and it must be *beside* the
+ranking rather than inside it, because the ranking is the recommendation and this is the thing a
+drafter overrules it with. A column of it on a candidate row would fold the two together and leave
+neither auditable — which is the same reason the repo keeps a blended metric's inputs visible.
 
 ## Missing values print as gaps, never as values
 
@@ -168,6 +175,76 @@ def _roster(roster: pd.DataFrame, league: dict) -> list[str]:
     return lines
 
 
+def _signed(value) -> str:
+    """A band's score, with the sign written out — the direction is the whole of the reading."""
+    if value is None or pd.isna(value):
+        return _MISSING
+    return f"{value:+.1f}"
+
+
+def _either(positions: list[str]) -> str:
+    """A list of positions as a drafter would say it: `RB, WR or TE`."""
+    if len(positions) < 2:
+        return "".join(positions)
+    return f"{', '.join(positions[:-1])} or {positions[-1]}"
+
+
+def _band(row) -> str:
+    """A band named the way the guidance states it — a count of a position, never a plan."""
+    return f"{int(row['count'])} {row['position']}"
+
+
+def _guidance(guidance: dict | None) -> list[str]:
+    """What the opening is still on track for, beside the ranking and never inside it.
+
+    Bands rather than plans, because the plan table records no dispersion and the leading
+    compositions cannot be told apart from simulation noise. Every open band is printed, not only
+    the best one: being warned away from a shape that scored badly is half of what this is for,
+    and a leader on its own does not say what the alternatives cost.
+
+    A block that has nothing to say still says that. Guidance the research does not support is
+    withdrawn rather than extrapolated, and an opening no plan covers is reported as such — either
+    one silently vanishing would read as guidance that agreed with whatever the drafter just did.
+    """
+    if guidance is None:
+        return []
+
+    if guidance["withdrawn"]:
+        return ["", "Opening shape — withdrawn", f"  {guidance['reason']}"]
+
+    spent = [f"{guidance['picks_spent']} of {guidance['opening_rounds']} opening picks"]
+    if guidance["taken"]:
+        spent.append(
+            ", ".join(f"{position} {count}" for position, count in guidance["taken"].items())
+        )
+    spent.append(f"{guidance['open_plans']} of {guidance['total_plans']} plans still open")
+    lines = ["", "Opening shape — " + "  ·  ".join(spent)]
+
+    best = guidance["best"]
+    if best is None:
+        lines.append(f"  {guidance['reason']}")
+        return lines
+
+    plans = int(best["plans"])
+    lines.append(
+        f"  best band still open   {_band(best)}   {_signed(best['points_vs_field'])} vs field"
+        f"  ·  {_percent(best['win_rate'])} wins  ·  over {plans} plan"
+        f"{'' if plans == 1 else 's'}"
+    )
+    if guidance["closes_best"]:
+        lines.append(
+            f"  {_either(guidance['closes_best'])} now closes it — only "
+            f"{_either(guidance['keeps_best'])} keeps it open"
+        )
+    for position, group in guidance["bands"].groupby("position", sort=False):
+        counts = "   ".join(
+            f"{int(count)} {_signed(score):>6}"
+            for count, score in zip(group["count"], group["points_vs_field"])
+        )
+        lines.append(f"  {position:<6}{counts}")
+    return lines
+
+
 def _ranking(picks: dict, degraded: bool, covers_to: int | None) -> list[str]:
     """How the list below was ordered, and — when it is not the good rule — why not.
 
@@ -229,6 +306,7 @@ def render_board(
     degraded: bool = False,
     covers_to: int | None = None,
     marked: list[dict] | tuple = (),
+    guidance: dict | None = None,
 ) -> str:
     """The whole screen as one string.
 
@@ -244,11 +322,16 @@ def render_board(
     `marked` is the players the drafter has taken off the board by hand. They are already gone
     from `candidates` and already counted in `picks` — this is what puts them on screen, so that
     a subtraction Sleeper never reported is visible rather than inferred from a shorter board.
+
+    `guidance` is what `composition_guidance` returned, or None for a screen without it. It is
+    printed beside the ranking and changes nothing about it: the candidate list is the same list,
+    in the same order, whether it is passed or not.
     """
     marked = list(marked)
     lines = [_header(picks, league, marked)]
     lines += _unmatched(picks["unmatched"])
     lines += _marked(marked)
     lines += _roster(picks["roster"], league)
+    lines += _guidance(guidance)
     lines += _candidates(candidates, picks, limit, degraded, covers_to)
     return "\n".join(lines)

--- a/tests/test_draft_composition.py
+++ b/tests/test_draft_composition.py
@@ -1,0 +1,261 @@
+"""Spec cases 29-35 from issue #38: which roster shapes the opening is still on track for.
+
+These assert what comes *out* of `composition_guidance` for a given plan frame and a given set of
+picks already spent — never how it gets there. Cost of waiting looks one pick ahead, one player at
+a time, and so cannot see the roster being assembled; this is the signal that can, and it is read
+from the plan table at run time rather than encoded as a rule.
+
+## Why the fixture scores openings on their quarterback count alone
+
+The finding this feature exists to carry *reverses between the two leagues this repo serves*:
+opening with two quarterbacks is worth roughly +22 points against the field in the superflex
+league and roughly -41 in the one-quarterback league. So the thing worth testing is not that the
+guidance says "take two quarterbacks" — it is that the guidance says whatever the frame it was
+handed says, and the opposite when handed the opposite frame.
+
+Every fixture opening therefore scores purely on how many quarterbacks it takes, with the two
+score maps below being mirror images. That makes every expected band mean workable on paper: a
+band's score is the mean of its members' quarterback-level scores, and the quarterback bands are
+the only ones made up of a single level, which is what makes one of them the best band in either
+direction.
+
+The ten openings are chosen so that no band other than a quarterback band is made up entirely of
+openings from one quarterback level. Without that, a receiver band that happened to contain only
+two-quarterback openings would tie with the quarterback band it is really just restating, and the
+"best band" would be an artifact of the fixture rather than of the arithmetic.
+
+## Vocabulary
+
+*Plan*, *composition* and *band*, as the glossary has them: a plan is a claim about the opening, a
+composition is that plan stated as counts, and a band is every composition sharing one position's
+count. The guidance never names a composition — the plan table records trials but no dispersion,
+so the leading compositions cannot be told apart from simulation noise, and only the coarse band
+structure underneath them is real enough to show.
+"""
+
+import pandas as pd
+
+from src.draft.composition import composition_guidance
+
+SEAT = 3
+ANOTHER_SEAT = 7
+
+# The order the plan table writes a composition in, which is the order these labels are built in.
+POSITIONS = ("QB", "RB", "WR", "TE")
+
+# Ten five-pick openings, as (QB, RB, WR, TE) counts. Three at each quarterback level bar one, and
+# arranged so that every running back, receiver and tight end count is shared across levels — see
+# the module docstring on why that matters.
+OPENINGS = [
+    (2, 1, 1, 1), (2, 2, 1, 0), (2, 1, 2, 0),
+    (1, 2, 1, 1), (1, 1, 2, 1), (1, 1, 1, 2), (1, 2, 2, 0),
+    (0, 2, 2, 1), (0, 1, 2, 2), (0, 2, 1, 2),
+]
+
+# Openings three picks long rather than five, for the case that the length is read from the frame
+# rather than assumed. Same rule: the score is the quarterback count and nothing else.
+SHORT_OPENINGS = [(2, 1, 0, 0), (1, 1, 1, 0), (1, 0, 1, 1), (0, 2, 1, 0), (0, 1, 1, 1)]
+
+# What an opening is worth against the field, by how many quarterbacks it takes. The first is this
+# repo's superflex league, in shape if not in exact numbers; the second is the one-quarterback
+# league, where the same opening is the worst one available.
+QB_FIRST = {0: -42.0, 1: 0.0, 2: 38.0}
+QB_LAST = {0: 38.0, 1: 0.0, 2: -42.0}
+
+# Simulated drafts behind every plan, as the plan table records it: the same for each, which is
+# what makes a band mean a plain average of its members.
+TRIALS = 300
+
+
+def label(counts: tuple[int, ...]) -> str:
+    """A composition written the way the plan table writes it — `2QB1RB1WR1TE`."""
+    return "".join(f"{n}{position}" for n, position in zip(counts, POSITIONS) if n)
+
+
+def plan_frame(
+    scores: dict[int, float] = QB_FIRST,
+    openings: list[tuple[int, ...]] = OPENINGS,
+    seat: int = SEAT,
+    rows: tuple[dict, ...] = (),
+) -> pd.DataFrame:
+    """`draft_plans` as the warehouse hands it over, already filtered to one league.
+
+    One row per (seat, plan), carrying only the columns the guidance reads. `rows` appends
+    anything else the real table holds — the pure-ADP control, or another seat's plans.
+    """
+    planned = [
+        {
+            "draft_slot": seat,
+            "plan": label(counts),
+            "trials": TRIALS,
+            "points_vs_field": scores[counts[0]],
+            # Win rate moves with the score rather than being invented separately, so a frame
+            # cannot say one thing on points and the opposite on wins.
+            "win_rate": round(0.25 + scores[counts[0]] / 400, 3),
+        }
+        for counts in openings
+    ]
+    return pd.DataFrame(planned + list(rows))
+
+
+def picks(*positions: str) -> dict:
+    """What ingestion hands over, with the only part the guidance reads: my picks so far."""
+    return {
+        "mine": [
+            {
+                "player_id": f"00-000000{number}",
+                "player_name": f"Player {number}",
+                "position": position,
+            }
+            for number, position in enumerate(positions, start=1)
+        ]
+    }
+
+
+def league(seat: int = SEAT) -> dict:
+    """The league shape `resolve_seat` reads out of the draft record."""
+    return {"seat": seat, "roster_id": 6, "team_count": 14, "rounds": 15, "slots": {}}
+
+
+def band(guidance: dict, position: str) -> pd.DataFrame:
+    """One position's bands, lowest count first."""
+    bands = guidance["bands"]
+    return bands.loc[bands["position"] == position].sort_values("count")
+
+
+# 29. Guidance is derived from the supplied frame, not from constants: a frame in which
+#     zero-quarterback openings score best yields guidance toward zero quarterbacks.
+def test_a_frame_that_likes_no_quarterbacks_gives_guidance_toward_none():
+    guidance = composition_guidance(plan_frame(QB_LAST), picks(), league())
+
+    assert guidance["best"]["position"] == "QB"
+    assert guidance["best"]["count"] == 0
+
+
+# 30. The same code path, given a plan frame whose best band is the opposite of the superflex
+#     league's, produces the opposite guidance — the case that proves no finding is encoded here.
+def test_the_same_call_on_the_opposite_frame_gives_the_opposite_band():
+    toward_none = composition_guidance(plan_frame(QB_LAST), picks(), league())
+    toward_two = composition_guidance(plan_frame(QB_FIRST), picks(), league())
+
+    assert toward_none["best"]["position"] == "QB"
+    assert toward_two["best"]["position"] == "QB"
+    assert (toward_none["best"]["count"], toward_two["best"]["count"]) == (0, 2)
+
+
+# 31. Guidance is expressed as a position-count band and never names a single composition as
+#     optimal — the plan table has no dispersion, so the leaders cannot be told apart from noise.
+def test_guidance_names_a_band_and_never_a_composition():
+    frame = plan_frame()
+    guidance = composition_guidance(frame, picks(), league())
+
+    assert set(guidance["best"]) >= {"position", "count"}
+
+    printed = str(guidance) + guidance["bands"].to_string()
+    for plan in frame["plan"]:
+        assert plan not in printed
+
+
+# 31 (continued). Every open band is reported, so the shapes that score badly are as visible as
+#     the one that scores well — being warned away is half of what the signal is for.
+def test_every_open_band_is_reported_with_what_it_scored():
+    guidance = composition_guidance(plan_frame(), picks(), league())
+
+    quarterbacks = band(guidance, "QB")
+    assert list(quarterbacks["count"]) == [0, 1, 2]
+    assert list(quarterbacks["points_vs_field"]) == [-42.0, 0.0, 38.0]
+
+
+# 32. Guidance is absent, and marked absent, once the opening rounds the plan table covers have
+#     passed. The table says nothing about round six, so neither does this.
+def test_guidance_is_withdrawn_once_the_opening_is_over():
+    guidance = composition_guidance(
+        plan_frame(), picks("QB", "QB", "RB", "WR", "TE"), league()
+    )
+
+    assert guidance["withdrawn"] is True
+    assert guidance["best"] is None
+    assert guidance["bands"].empty
+    assert guidance["reason"]
+
+
+# 32 (continued). How long the opening is comes from the frame too, not from a number typed here.
+def test_the_length_of_the_opening_is_read_from_the_frame():
+    frame = plan_frame(openings=SHORT_OPENINGS)
+
+    assert composition_guidance(frame, picks("QB", "RB"), league())["withdrawn"] is False
+    assert composition_guidance(frame, picks("QB", "RB", "WR"), league())["withdrawn"] is True
+
+
+# 34. A roster consistent with no plan in the frame reports no open plans and does not raise.
+def test_an_opening_no_plan_covers_reports_nothing_open():
+    guidance = composition_guidance(plan_frame(), picks("QB", "QB", "QB"), league())
+
+    assert guidance["open_plans"] == 0
+    assert guidance["best"] is None
+    assert guidance["bands"].empty
+    assert guidance["withdrawn"] is False
+    assert guidance["reason"]
+
+
+# 34 (continued). A position the plan table has never heard of is the same kind of nothing, and
+#     is reported rather than dropped so the screen can say why it has stopped talking.
+def test_a_position_outside_the_plans_closes_every_one_of_them():
+    guidance = composition_guidance(plan_frame(), picks("QB", "K"), league())
+
+    assert guidance["open_plans"] == 0
+    assert guidance["taken"]["K"] == 1
+
+
+# 35. A candidate whose position would close the best-scoring open band is reported as doing so.
+def test_the_positions_that_would_close_the_best_band_are_named():
+    guidance = composition_guidance(
+        plan_frame(), picks("QB", "RB", "WR", "TE"), league()
+    )
+
+    assert (guidance["best"]["position"], guidance["best"]["count"]) == ("QB", 2)
+    assert guidance["keeps_best"] == ["QB"]
+    assert guidance["closes_best"] == ["RB", "WR", "TE"]
+
+
+# The seat filter, from the ticket's first acceptance criterion: the bands are this seat's. A
+# snake gives every slot a different draft, and the plan table is keyed on the seat for that
+# reason — reading another seat's rows would be guidance for somebody else's draft.
+def test_only_the_drafters_own_seat_is_read():
+    frame = pd.concat(
+        [plan_frame(QB_FIRST, seat=SEAT), plan_frame(QB_LAST, seat=ANOTHER_SEAT)],
+        ignore_index=True,
+    )
+
+    assert composition_guidance(frame, picks(), league(SEAT))["best"]["count"] == 2
+    assert composition_guidance(frame, picks(), league(ANOTHER_SEAT))["best"]["count"] == 0
+
+
+def test_a_seat_the_table_does_not_cover_withdraws_rather_than_guessing():
+    guidance = composition_guidance(plan_frame(seat=ANOTHER_SEAT), picks(), league(SEAT))
+
+    assert guidance["withdrawn"] is True
+    assert guidance["bands"].empty
+    assert guidance["reason"]
+
+
+# The plan table carries the pure-ADP control beside the compositions, under a label that is not
+# a composition at all. It is not an opening anybody can still be on track for, and it must not
+# become a band — least of all the best one.
+def test_a_row_that_is_not_a_composition_is_left_out():
+    frame = plan_frame(
+        rows=(
+            {
+                "draft_slot": SEAT,
+                "plan": "best available",
+                "trials": TRIALS,
+                "points_vs_field": 500.0,
+                "win_rate": 0.9,
+            },
+        )
+    )
+    guidance = composition_guidance(frame, picks(), league())
+
+    assert guidance["best"]["position"] == "QB"
+    assert guidance["best"]["count"] == 2
+    assert guidance["open_plans"] == len(OPENINGS)

--- a/tests/test_draft_picks.py
+++ b/tests/test_draft_picks.py
@@ -327,3 +327,30 @@ def test_there_is_no_pick_after_the_seats_last_one():
     result = ingest_picks(through_the_last_gap, board(), league(seat=1))
     assert result["next_pick"] == 197
     assert result["pick_after_next"] is None
+
+
+# Issue #38 needs one thing the roster frame cannot give it: what my picks *were*, by position and
+# in order. The frame reports an assignment — a back who fell to the flex is in the flex row, and
+# the bench mixes every position together — so the opening's composition cannot be read back out
+# of it. This is the same picks, unassigned.
+def test_my_own_picks_are_reported_in_draft_order_with_their_positions():
+    result = ingest_picks(
+        [
+            pick("5849", pick_no=1, roster_id=MY_ROSTER, position="WR"),
+            pick("4034", pick_no=2, roster_id=ANOTHER_ROSTER),
+            pick("6794", pick_no=3, roster_id=MY_ROSTER, position="QB"),
+        ],
+        board(
+            {"player_id": "00-0000002", "sleeper_id": "5849", "player_name": "My Receiver",
+             "position": "WR"},
+            {"player_id": "00-0000001", "sleeper_id": "4034", "player_name": "Their Back"},
+            {"player_id": "00-0000003", "sleeper_id": "6794", "player_name": "My Quarterback",
+             "position": "QB"},
+        ),
+        league(),
+    )
+
+    assert [player["player_name"] for player in result["mine"]] == [
+        "My Receiver", "My Quarterback"
+    ]
+    assert [player["position"] for player in result["mine"]] == ["WR", "QB"]

--- a/tests/test_draft_render.py
+++ b/tests/test_draft_render.py
@@ -365,3 +365,120 @@ def test_the_players_marked_by_hand_are_named_on_screen():
 def test_a_draft_with_nothing_marked_by_hand_says_nothing_about_it():
     out = render_board(candidates({"player_name": "Still There"}), ingested(), LEAGUE)
     assert "hand" not in out.lower()
+
+
+# Issue #38's render cases. Composition guidance is the one signal on this screen that is not
+# about a player: it says which roster shapes the opening is still on track for, read from the
+# plan table at run time. It sits *beside* the ranking rather than inside it — the ranking is the
+# recommendation and this is the thing a drafter overrules it with, and folding one into the other
+# would leave neither auditable.
+
+
+def guidance(**overrides) -> dict:
+    """What `composition_guidance` hands over, defaulted to a live band with a leader."""
+    bands = pd.DataFrame(
+        [
+            {"position": "QB", "count": 1, "plans": 3, "points_vs_field": 0.0,
+             "win_rate": 0.25, "spread": 38.0},
+            {"position": "QB", "count": 2, "plans": 1, "points_vs_field": 38.0,
+             "win_rate": 0.44, "spread": 38.0},
+            {"position": "RB", "count": 1, "plans": 3, "points_vs_field": 12.7,
+             "win_rate": 0.31, "spread": 12.7},
+            {"position": "RB", "count": 2, "plans": 1, "points_vs_field": 0.0,
+             "win_rate": 0.25, "spread": 12.7},
+        ]
+    )
+    return {
+        "withdrawn": False,
+        "reason": None,
+        "opening_rounds": 5,
+        "picks_spent": 4,
+        "taken": {"QB": 1, "RB": 1, "WR": 1, "TE": 1},
+        "open_plans": 4,
+        "total_plans": 10,
+        "bands": bands,
+        "best": {"position": "QB", "count": 2, "plans": 1, "points_vs_field": 38.0,
+                 "win_rate": 0.44, "spread": 38.0},
+        "keeps_best": ["QB"],
+        "closes_best": ["RB", "WR", "TE"],
+        **overrides,
+    }
+
+
+def test_the_opening_shape_is_shown_beside_the_ranking():
+    out = render_board(
+        candidates({"player_name": "Bijan Robinson"}), ingested(), LEAGUE,
+        guidance=guidance(),
+    )
+    heading = line_naming(out, "Opening shape")
+
+    # Beside the ranking means above it and outside it: a block of its own, not a column on a
+    # candidate row, so that nothing about it can be mistaken for part of the order below.
+    assert out.index(heading) < out.index(line_naming(out, "Best available"))
+    assert not any("Opening shape" in row for row in section(out, "Best available"))
+
+
+def test_the_guidance_names_a_band_rather_than_a_composition():
+    out = render_board(candidates(), ingested(), LEAGUE, guidance=guidance())
+    rows = section(out, "Opening shape")
+
+    # A position and a count, and the score behind it — never a composition string, because the
+    # plan table records no dispersion and cannot tell the leading compositions apart.
+    assert any("QB" in row and "2" in row and "38" in row for row in rows)
+    assert "2QB2RB1TE" not in out
+
+
+# 33. Guidance never changes the order of the recommendations.
+def test_guidance_does_not_reorder_the_recommendations():
+    board = candidates(
+        {"player_name": "A Quarterback", "position": "QB", "cost_of_waiting": 60.0},
+        {"player_name": "A Back", "position": "RB", "cost_of_waiting": 40.0},
+        {"player_name": "A Receiver", "position": "WR", "cost_of_waiting": 20.0},
+    )
+    without = render_board(board, ingested(), LEAGUE)
+    with_guidance = render_board(board, ingested(), LEAGUE, guidance=guidance())
+
+    assert section(without, "Best available") == section(with_guidance, "Best available")
+
+
+# 35. A candidate whose position would close the best-scoring open band is reported as doing so.
+def test_the_positions_that_would_close_the_best_band_are_named_on_screen():
+    out = render_board(candidates(), ingested(), LEAGUE, guidance=guidance())
+    rows = section(out, "Opening shape")
+
+    closing = [row for row in rows if "RB" in row and "WR" in row and "TE" in row]
+    assert closing, f"no line named the positions that close the band: {rows}"
+
+
+# 32. Guidance is absent, and *marked* absent, once the opening the plan table covers is over.
+def test_withdrawn_guidance_says_so_rather_than_quietly_vanishing():
+    out = render_board(
+        candidates(), ingested(), LEAGUE,
+        guidance=guidance(
+            withdrawn=True,
+            reason="the plan table covers the first 5 rounds, which are behind us",
+            bands=pd.DataFrame(columns=["position", "count", "plans", "points_vs_field",
+                                        "win_rate", "spread"]),
+            best=None, keeps_best=[], closes_best=[], open_plans=0, picks_spent=5,
+        ),
+    )
+    assert "withdrawn" in line_naming(out, "Opening shape").lower()
+    assert "the plan table covers the first 5 rounds" in out
+
+
+def test_an_opening_no_plan_covers_says_so_rather_than_showing_a_band():
+    out = render_board(
+        candidates(), ingested(), LEAGUE,
+        guidance=guidance(
+            reason="no plan for this seat matches the opening so far",
+            bands=pd.DataFrame(columns=["position", "count", "plans", "points_vs_field",
+                                        "win_rate", "spread"]),
+            best=None, keeps_best=[], closes_best=[], open_plans=0,
+        ),
+    )
+    assert "no plan for this seat matches the opening so far" in out
+
+
+def test_a_screen_with_no_guidance_says_nothing_about_the_opening():
+    out = render_board(candidates(), ingested(), LEAGUE)
+    assert "Opening shape" not in out

--- a/tests/test_draft_render.py
+++ b/tests/test_draft_render.py
@@ -379,13 +379,13 @@ def guidance(**overrides) -> dict:
     bands = pd.DataFrame(
         [
             {"position": "QB", "count": 1, "plans": 3, "points_vs_field": 0.0,
-             "win_rate": 0.25, "spread": 38.0},
+             "win_rate": 0.25},
             {"position": "QB", "count": 2, "plans": 1, "points_vs_field": 38.0,
-             "win_rate": 0.44, "spread": 38.0},
+             "win_rate": 0.44},
             {"position": "RB", "count": 1, "plans": 3, "points_vs_field": 12.7,
-             "win_rate": 0.31, "spread": 12.7},
+             "win_rate": 0.31},
             {"position": "RB", "count": 2, "plans": 1, "points_vs_field": 0.0,
-             "win_rate": 0.25, "spread": 12.7},
+             "win_rate": 0.25},
         ]
     )
     return {
@@ -398,7 +398,7 @@ def guidance(**overrides) -> dict:
         "total_plans": 10,
         "bands": bands,
         "best": {"position": "QB", "count": 2, "plans": 1, "points_vs_field": 38.0,
-                 "win_rate": 0.44, "spread": 38.0},
+                 "win_rate": 0.44},
         "keeps_best": ["QB"],
         "closes_best": ["RB", "WR", "TE"],
         **overrides,
@@ -458,7 +458,7 @@ def test_withdrawn_guidance_says_so_rather_than_quietly_vanishing():
             withdrawn=True,
             reason="the plan table covers the first 5 rounds, which are behind us",
             bands=pd.DataFrame(columns=["position", "count", "plans", "points_vs_field",
-                                        "win_rate", "spread"]),
+                                        "win_rate"]),
             best=None, keeps_best=[], closes_best=[], open_plans=0, picks_spent=5,
         ),
     )
@@ -472,7 +472,7 @@ def test_an_opening_no_plan_covers_says_so_rather_than_showing_a_band():
         guidance=guidance(
             reason="no plan for this seat matches the opening so far",
             bands=pd.DataFrame(columns=["position", "count", "plans", "points_vs_field",
-                                        "win_rate", "spread"]),
+                                        "win_rate"]),
             best=None, keeps_best=[], closes_best=[], open_plans=0,
         ),
     )

--- a/tests/test_draft_watch.py
+++ b/tests/test_draft_watch.py
@@ -52,7 +52,14 @@ BOARD = pd.DataFrame(
 # by points over replacement and says so on screen, which renders exactly as fully as the other.
 SURVIVAL = pd.DataFrame(columns=["player_id", "overall_pick", "p_survives"])
 
-CONTEXT = {"board": BOARD, "survival": SURVIVAL, "draft": {"draft_id": "1"}, "league": LEAGUE}
+# Empty for the same reason, and a state the warehouse can genuinely be in: with no plans for this
+# seat the opening guidance is withdrawn and says so, which is a screen like any other.
+PLANS = pd.DataFrame(columns=["draft_slot", "plan", "trials", "points_vs_field", "win_rate"])
+
+CONTEXT = {
+    "board": BOARD, "survival": SURVIVAL, "plans": PLANS,
+    "draft": {"draft_id": "1"}, "league": LEAGUE,
+}
 
 
 def pick(number: int, sleeper_id: str, roster_id: int = 3) -> dict:


### PR DESCRIPTION
Closes #38.

Cost of waiting looks exactly one pick ahead, at one player at a time, so it is structurally blind
to the roster being assembled — a drafter following it greedily can walk past the shape he needed
because there was always a more urgent individual player. This adds the missing structural view,
read live from `draft_plans` rather than encoded as a rule.

## What it does

`src/draft/composition.py` is pure like the rest of the package: a plan frame and my picks so far
in, bands and a leader out. It filters the plan table to the drafter's seat, keeps the plans still
reachable given what has already been taken, and groups them into **bands** — every open plan
sharing one position's count.

On screen, between the roster and the board:

```
Opening shape — 2 of 5 opening picks  ·  QB 1, RB 1  ·  15 of 36 plans still open
  best band still open   2 QB   +100.9 vs field  ·  31% wins  ·  over 6 plans
  QB    1  +72.9   2 +100.9
  RB    1  +71.9   2  +96.7   3  +95.2   4  +60.6
  TE    0  +78.3   1  +96.1   2  +77.4
  WR    0  +93.1   1  +89.1   2  +73.1   3  +37.4
```

At four picks spent it also names what the next one costs: `RB, WR or TE now closes it — only QB
keeps it open`. Past the opening the table covers, the block says `withdrawn` and why.

## Nothing about the finding is in the code

No composition string appears in the module, and neither does the length of an opening: a label is
parsed into counts, and the opening's length is their total. Against the real table the same code
names `2 QB` as Sleeper's best open band from seat 3 and never puts a quarterback band on top of
ESPN's, which is the reversal the spec warns a hardcoded rule would get backwards.

Only the coarse structure is shown. The plan table records trials but no dispersion, so a single
composition is never named as optimal, and the number of plans behind a band is printed so a thin
one reads as thin.

## Also here

- `ingest_picks` gains `mine`: my own picks, in order, with their positions. The roster frame
  reports an *assignment* — a third back sits in the flex, the bench mixes positions — so the
  opening's shape cannot be read back out of it.
- `render_board` gains `guidance`, printed beside the ranking and changing nothing about it.
- `live.load_plans` is the third read of the warehouse, read-only like the other two.
- A `Band` entry in `CONTEXT.md`, and the README's draft-night section.

## Tests

Spec cases 29-35, written before the implementation, plus the seat filter the first acceptance
criterion asks for, the control row the real plan table carries beside the compositions, and the
opening's length being read from the frame rather than assumed. The fixture scores an opening on
its quarterback count alone in two mirrored directions, so the case that matters is that the same
code produces the opposite guidance from the opposite frame.

163 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)