### PR TITLE
Archive the draft record and its picks as a silver source

### DIFF
--- a/src/draft/live.py
+++ b/src/draft/live.py
@@ -108,7 +108,7 @@ from src.draft.render import render_board
 from src.draft.seat import resolve_seat
 from src.draft.waiting import rank_by_cost_of_waiting
 from src.query import WAREHOUSE_PATH, q
-from src.silver.sleeper import LEAGUE_ID, SEASON
+from src.silver.sleeper import LEAGUE_ID, SEASON, select_draft
 
 BASE_URL = "https://api.sleeper.app/v1"
 
@@ -187,16 +187,12 @@ def find_draft(league_id: str, season: int) -> dict:
     Two calls, deliberately. The league's draft list carries the draft order but *not*
     `slot_to_roster_id`, so the record has to be fetched by ID to learn which roster a seat's
     picks land on — and without that, my own picks cannot be told from anyone else's.
-    """
-    drafts = [
-        draft for draft in _get(f"/league/{league_id}/drafts")
-        if str(draft.get("season")) == str(season)
-    ]
-    if not drafts:
-        raise RuntimeError(f"League {league_id} has no {season} draft.")
 
-    # Newest first, for the case where a league has a redrafted or restarted draft on record.
-    newest = max(drafts, key=lambda draft: draft.get("created") or 0)
+    Which of the league's drafts is this season's is `src.silver.sleeper`'s rule, read from there
+    rather than restated here. That module archives the picks once the draft is done, and a tool
+    watching one draft while the archive kept another is a disagreement neither screen would show.
+    """
+    newest = select_draft(_get(f"/league/{league_id}/drafts"), season)
     return _get(f"/draft/{newest['draft_id']}")
 
 

--- a/src/silver/sleeper.py
+++ b/src/silver/sleeper.py
@@ -87,6 +87,79 @@ def load_users(raw_path: Path) -> None:
     _load_json_to_table(raw_path, "sleeper_users")
 
 
+def select_draft(drafts: list[dict], season) -> dict:
+    """This season's draft, out of every draft the league has on record.
+
+    Pure, and shared with `src.draft.live`, which watches the draft this picks out. The two
+    choosing differently would mean the tool drafting from one draft while the archive kept
+    another, which is a disagreement neither screen would show.
+
+    Sleeper spells the season as a string and everything here holds an int, so both are compared
+    as strings. Where a season has more than one draft — a league that restarted or redrafted
+    keeps the abandoned one on record beside the real one — the newest wins.
+    """
+    this_season = [
+        draft for draft in drafts if str(draft.get("season")) == str(season)
+    ]
+    if not this_season:
+        raise RuntimeError(
+            f"No {season} draft among the {len(drafts)} this league has on record."
+        )
+    return max(this_season, key=lambda draft: draft.get("created") or 0)
+
+
+def _draft_id(league_id: str, season: int) -> str:
+    """The ID of this season's draft, which both fetches below are keyed on."""
+    return select_draft(_get(f"/league/{league_id}/drafts"), season)["draft_id"]
+
+
+def fetch_draft(league_id: str, season: int) -> Path:
+    """Fetch this season's draft record whole and save raw to JSON.
+
+    Two calls, because the league's draft list is not the record: it carries the season and the
+    created time `select_draft` chooses on, but not `slot_to_roster_id` or the settings, and those
+    are what say how many teams and rounds the draft ran and which roster each seat's picks landed
+    on. The archive keeps the fuller one.
+
+    Named by draft ID rather than league ID, unlike every other file here, because a league drafts
+    again next season: keying on the draft means each year's record lands beside the last rather
+    than over it.
+    """
+    record = _get(f"/draft/{_draft_id(league_id, season)}")
+    return _save_raw_json([record], f"draft_{record['draft_id']}")
+
+
+def load_draft(raw_path: Path) -> None:
+    _load_json_to_table(raw_path, "sleeper_draft")
+
+
+def fetch_draft_picks(league_id: str, season: int) -> Path:
+    """Fetch every pick made in this season's draft and save raw to JSON.
+
+    This is the archive step the live draft tool deliberately does not do. `src.draft.live` polls
+    this same endpoint every few seconds for two hours and writes none of it, because that would
+    be thousands of near-identical files; the picks are archived once, from here, after the draft.
+    """
+    draft_id = _draft_id(league_id, season)
+    return _save_raw_json(_get(f"/draft/{draft_id}/picks"), f"draft_picks_{draft_id}")
+
+
+def load_draft_picks(raw_path: Path) -> None:
+    """Load the archived picks into the warehouse, taking the payload's own shape.
+
+    Nothing is projected out by hand here, unlike `load_projections` below. These picks have never
+    been seen — this league has drafted once, in a draft that has not been made yet — so a written
+    column list would be a guess against a payload nobody has read, and a wrong guess in one would
+    load as nulls rather than fail. `json_normalize` takes whatever Sleeper sends, and the raw file
+    beside it stays the source of truth either way.
+
+    Before the draft the payload is an empty list and the table is dropped with a note, rather than
+    created with a schema invented to fill the gap. So `sleeper_draft_picks` exists from the first
+    pick onwards and not before, which is the honest answer to "what did this league draft".
+    """
+    _load_json_to_table(raw_path, "sleeper_draft_picks")
+
+
 def fetch_matchups(league_id: str, weeks: list[int]) -> Path:
     """Fetch weekly matchups (starters, points, roster_id) and save raw to JSON."""
     rows = []
@@ -224,6 +297,8 @@ if __name__ == "__main__":
     load_league(fetch_league(LEAGUE_ID))
     load_rosters(fetch_rosters(LEAGUE_ID))
     load_users(fetch_users(LEAGUE_ID))
+    load_draft(fetch_draft(LEAGUE_ID, SEASON))
+    load_draft_picks(fetch_draft_picks(LEAGUE_ID, SEASON))
     load_matchups(fetch_matchups(LEAGUE_ID, WEEKS))
     load_transactions(fetch_transactions(LEAGUE_ID, WEEKS))
     load_nfl_state(fetch_nfl_state())

--- a/tests/test_sleeper_draft.py
+++ b/tests/test_sleeper_draft.py
@@ -1,0 +1,69 @@
+"""Which draft gets archived, from the list a league hands back.
+
+The archiving pair is I/O either side of one decision: of the drafts this league has on record,
+which one is *this season's*. That decision is the only part worth a test, and it is worth one
+because it is not the only place it is made — `src.draft.live` picks the draft it watches by the
+same rule, and the two disagreeing would mean archiving a different draft than the one drafted
+from. So the rule lives in one function and both callers read it.
+
+The fixtures are Sleeper's own shape, which is where two of the cases come from: `season` arrives
+as a **string** while the repo carries the season as an int, and `created` is milliseconds since
+the epoch.
+"""
+
+import pytest
+
+from src.silver.sleeper import select_draft
+
+
+def draft(draft_id: str, season: str, created: int = 0) -> dict:
+    """One entry from `GET /league/<id>/drafts`, cut down to what the choice reads."""
+    return {
+        "draft_id": draft_id,
+        "season": season,
+        "created": created,
+        "type": "snake",
+        "status": "complete",
+    }
+
+
+# 1. A league that has drafted for years hands back all of them; the season picks one out.
+def test_the_draft_for_the_asked_for_season_is_the_one_chosen():
+    drafts = [
+        draft("2024-draft", "2024", created=1_690_000_000_000),
+        draft("2025-draft", "2025", created=1_720_000_000_000),
+        draft("2026-draft", "2026", created=1_785_963_881_642),
+    ]
+    assert select_draft(drafts, 2026)["draft_id"] == "2026-draft"
+    assert select_draft(drafts, 2024)["draft_id"] == "2024-draft"
+
+
+# 2. Sleeper spells the season as a string and every caller here holds an int.
+def test_the_season_matches_across_sleepers_string_and_the_repos_int():
+    drafts = [draft("2026-draft", "2026")]
+    assert select_draft(drafts, 2026)["draft_id"] == "2026-draft"
+    assert select_draft(drafts, "2026")["draft_id"] == "2026-draft"
+
+
+# 3. A league that restarted or redrafted has two for one season; the newest is the real one.
+def test_the_newest_draft_wins_when_a_season_has_more_than_one():
+    drafts = [
+        draft("abandoned", "2026", created=1_785_000_000_000),
+        draft("the-real-one", "2026", created=1_785_963_881_642),
+    ]
+    assert select_draft(drafts, 2026)["draft_id"] == "the-real-one"
+    # Order in the payload is not the rule — `created` is.
+    assert select_draft(list(reversed(drafts)), 2026)["draft_id"] == "the-real-one"
+
+
+# 4. Refuses rather than falling back on another year, which would archive the wrong picks.
+def test_a_season_with_no_draft_raises_rather_than_choosing_another():
+    drafts = [draft("2025-draft", "2025")]
+    with pytest.raises(RuntimeError, match="2026"):
+        select_draft(drafts, 2026)
+
+
+# 5. A league that has never drafted.
+def test_no_drafts_at_all_raises():
+    with pytest.raises(RuntimeError, match="2026"):
+        select_draft([], 2026)


### PR DESCRIPTION
Closes #39.

`src/silver/sleeper.py` gains the fetch/load pair for this season's draft, following the split
every other source in the module uses: fetch writes the unparsed response to `data/raw/sleeper/`,
load reads that file into the warehouse without touching the network.

- `fetch_draft` / `load_draft` → `sleeper_draft`
- `fetch_draft_picks` / `load_draft_picks` → `sleeper_draft_picks`
- Both run from the module's `__main__`, so `scripts/build_warehouse.sh` picks them up.

Raw files are keyed on the **draft ID** rather than the league ID, unlike everything else here,
because a league drafts again next season: each year's record lands beside the last rather than
over it.

### One rule, two callers

`select_draft(drafts, season)` is the pure choice of which of a league's drafts is this season's,
and `src/draft/live.py` now reads it from here instead of restating it. The live tool watches the
draft this function picks out and this module archives it; the two choosing differently would mean
drafting from one draft while the archive kept another, which is a disagreement neither screen
would show.

### Nothing is projected out of the picks payload

Unlike `load_projections`, which names its columns, the picks load takes whatever
`json_normalize` makes of the payload. This league has drafted once, in a draft that has not been
made yet — a hand-written column list would be a guess against a payload nobody has read, and a
wrong field name would load as nulls rather than fail. The raw file stays the source of truth
either way.

The consequence, stated plainly: **before the draft the payload is an empty list, so
`sleeper_draft_picks` does not exist yet** — the existing empty-source path drops it with a note
rather than inventing a schema to fill the gap. It appears from the first pick onwards. The issue's
"warehouse tables exist for the draft record and its picks" is met from that point, which is when
the issue says this step is run.

### Verified

- `pytest` — 168 passed.
- Fetch → load run for real against Sleeper and the warehouse: `sleeper_draft` at 1 row, picks
  archived as `[]` with the drop note, and both loads re-run against the same raw files to confirm
  idempotency.
- `load_draft` re-run with `requests.get` patched to raise, confirming the load path never reaches
  the network.
- A populated picks payload loaded into a throwaway database in the scratchpad, so the real
  warehouse was never given fake picks — nested `metadata` flattens and lands correctly.

### Tests

Five cases, written and committed before the code (`d0ee00d`), all on `select_draft`, the only
genuinely pure decision in the issue: the right season chosen from a multi-season league; Sleeper's
string season matched against the repo's int; the newest draft winning where a season has two; and
a refusal rather than a fallback when the season has none, and when the league has never drafted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)