### PR TITLE
feat: record dispersion on the plan table so fine differences can be judged

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -102,10 +102,9 @@ _Avoid_: draft order (that means **seat** ordering, not position ordering)
 
 **Band**:
 Every **plan** sharing one position's count — "the openings that take two quarterbacks" — scored
-as the mean of its members. The unit composition guidance is stated in, because the plan table
-records trials but no dispersion: the leading compositions sit within simulation noise of each
-other, while the bands underneath them are far apart. A band is never a recommendation to draft a
-specific player.
+as the mean of its members. The unit composition guidance is stated in, because the plan table's
+own dispersion says the leading compositions sit within simulation noise of each other, while the
+bands underneath them are far apart. A band is never a recommendation to draft a specific player.
 _Avoid_: bucket, tier (the **board** already spends *tier* on an offensive line's grade)
 
 **Field**:

--- a/README.md
+++ b/README.md
@@ -426,8 +426,9 @@ what waiting for it would cost, and shows the roster so far and the next overall
 Beside that ranking it shows which roster shapes the opening is still on track for, read from
 `draft_plans` for this league and this seat at run time. Cost of waiting looks one pick ahead at
 one player, so it cannot see the roster being assembled; this is the half that can. It is stated
-as position-count bands rather than as a named opening — the plan table records no dispersion, so
-the leading compositions cannot be told apart from simulation noise — and it is withdrawn once the
+as position-count bands rather than as a named opening — the plan table records the standard error
+behind each mean, and at most seats the leading compositions sit inside it — and it is withdrawn
+once the
 rounds the plan table covers have passed. Nothing about it is hardcoded, which matters because the
 finding reverses between the two leagues: point it at the ESPN rows and it stops recommending
 quarterbacks.

--- a/src/draft/composition.py
+++ b/src/draft/composition.py
@@ -31,11 +31,12 @@ opposite thing, which is the property worth having rather than the answer.
 
 ## Bands, and why nothing finer is offered
 
-The plan table records trials but no dispersion, so the difference between the leading
-compositions cannot be told apart from simulation noise — the top several sit within about twenty
-points of one another over three hundred trials. What is *not* close is the band structure
-underneath them: quarterback count across the opening moves the outcome by roughly a hundred
-points and triples the win rate, monotonically.
+The plan table records the spread behind each of its means, and what that spread says is that the
+leading compositions mostly cannot be told apart: at ten of this league's fourteen seats the best
+two openings finish within one combined standard error of each other over three hundred trials,
+and at only three is the leader clear by more than two. In the other league it is all ten seats.
+What is *not* close is the band structure underneath them: quarterback count across the opening
+moves the outcome by roughly a hundred points and triples the win rate, monotonically.
 
 A **band** is therefore every open plan sharing one position's count — "the openings that take two
 quarterbacks" — scored as the mean of its members. Coarse enough to survive the noise, and the

--- a/src/draft/render.py
+++ b/src/draft/render.py
@@ -197,8 +197,9 @@ def _band(row) -> str:
 def _guidance(guidance: dict | None) -> list[str]:
     """What the opening is still on track for, beside the ranking and never inside it.
 
-    Bands rather than plans, because the plan table records no dispersion and the leading
-    compositions cannot be told apart from simulation noise. Every open band is printed, not only
+    Bands rather than plans, because the leading compositions cannot be told apart from simulation
+    noise — the plan table records the standard error behind every mean, and at most seats the top
+    two openings sit inside it. Every open band is printed, not only
     the best one: being warned away from a shape that scored badly is half of what this is for,
     and a leader on its own does not say what the alternatives cost.
 

--- a/src/gold/draft_plan.py
+++ b/src/gold/draft_plan.py
@@ -58,6 +58,16 @@ caps, same hindsight-optimal lineup scoring, same treatment of the superflex slo
 flex eligibility. The only differences are that the board is projected rather than historical, the
 order is sampled rather than fixed, and the focal seat is a specific slot rather than every slot
 averaged together.
+
+## How much of a gap is real
+
+A mean over three hundred sampled rooms is a number with noise on it, and two openings twenty
+points apart may be two openings twenty points apart or the same opening priced twice. So each
+point mean is written with the spread behind it: a standard deviation, which is how far one room
+moves this plan and therefore what it risks, and a standard error, which is how firmly the mean
+itself is pinned down and therefore what a gap has to clear to be believed. `_summarize_plans` has
+the arithmetic and the one caveat — the comparison between two plans is paired, so combining two
+rows' standard errors is a conservative test rather than an exact one.
 """
 
 from pathlib import Path
@@ -99,7 +109,8 @@ _OUTPUT_COLUMNS = [
 ]
 
 # Simulated drafts per (league, slot, plan). The spread across plans is a few points wide, so this
-# has to be large enough that the standard error of a plan's mean is well under that gap.
+# has to be large enough that the standard error of a plan's mean is well under that gap — which
+# each row now records, so the count is answerable from the table rather than taken on trust.
 _TRIALS = 300
 
 # Fixed so a rebuild reproduces byte-for-byte, and shared across plans within a trial so every plan
@@ -107,7 +118,9 @@ _TRIALS = 300
 _SEED = 20260903
 
 _PLAN_COLUMNS = [
-    "league_key", "draft_slot", "plan", "trials", "starter_points", "points_vs_field",
+    "league_key", "draft_slot", "plan", "trials",
+    "starter_points", "starter_points_stdev", "starter_points_stderr",
+    "points_vs_field", "points_vs_field_stdev", "points_vs_field_stderr",
     "finish_rank", "win_rate", "top_third_rate",
 ]
 
@@ -328,15 +341,42 @@ def simulate_first_pick(
 
 
 def _summarize_plans(results: pd.DataFrame, n_teams: int) -> pd.DataFrame:
-    """One row per (seat, plan): how it did across every room it was drafted into."""
+    """One row per (seat, plan): how it did across every room it was drafted into, and how widely.
+
+    Each point mean carries two numbers beside it. The **standard deviation** is how far a single
+    room moved this plan's result, which is the plan's risk: two openings can average the same and
+    reach it very differently. The **standard error** is that spread divided by the root of the
+    trial count, which is how precisely the mean itself is pinned down, and it is the number that
+    answers whether two plans finished apart or finished level twice.
+
+    A plan simulated once gets neither rather than a zero: one room cannot measure a spread, and a
+    zero there would read as certainty.
+
+    Two plans are separated when the gap between their means clears the root of the sum of their
+    squared standard errors. That test is *conservative* here, and deliberately so. Every plan
+    within a trial faces the identical room, so the honest comparison is paired, and the pairing is
+    worth a great deal: the leading openings correlate at about 0.7 across rooms, which makes the
+    true standard error of their difference roughly half what combining the two rows implies. No
+    number on a row can carry that, because it belongs to the pair rather than to either plan. So a
+    gap that clears the combined error is real, and one that does not may still be.
+    """
     grouped = results.groupby(["draft_slot", "plan"], as_index=False).agg(
         trials=("starter_points", "size"),
         starter_points=("starter_points", "mean"),
+        starter_points_stdev=("starter_points", "std"),
         points_vs_field=("points_vs_field", "mean"),
+        points_vs_field_stdev=("points_vs_field", "std"),
         finish_rank=("finish_rank", "mean"),
         win_rate=("finish_rank", lambda ranks: (ranks == 1).mean()),
         top_third_rate=("finish_rank", lambda ranks: (ranks <= n_teams / 3).mean()),
     )
+
+    # The rates get no column of their own: the standard error of a proportion is exactly
+    # sqrt(p(1-p)/trials) from the two numbers already on the row, and storing a third would be a
+    # second place for the same fact to be wrong.
+    root = np.sqrt(grouped["trials"])
+    for column in ("starter_points", "points_vs_field"):
+        grouped[f"{column}_stderr"] = grouped[f"{column}_stdev"] / root
     return grouped
 
 

--- a/tests/test_draft_composition.py
+++ b/tests/test_draft_composition.py
@@ -28,9 +28,9 @@ two-quarterback openings would tie with the quarterback band it is really just r
 
 *Plan*, *composition* and *band*, as the glossary has them: a plan is a claim about the opening, a
 composition is that plan stated as counts, and a band is every composition sharing one position's
-count. The guidance never names a composition — the plan table records trials but no dispersion,
-so the leading compositions cannot be told apart from simulation noise, and only the coarse band
-structure underneath them is real enough to show.
+count. The guidance never names a composition — the plan table's recorded dispersion puts the
+leading compositions inside each other's noise at most seats, and only the coarse band structure
+underneath them is real enough to show.
 """
 
 import pandas as pd

--- a/tests/test_draft_plan_dispersion.py
+++ b/tests/test_draft_plan_dispersion.py
@@ -1,0 +1,240 @@
+"""Issue #40: what the plan table records about the spread behind each plan's mean.
+
+The plan table has always said how many drafts a plan was simulated in and what it averaged over
+them, and nothing about how much those drafts disagreed. That makes a gap between two well-scoring
+openings unreadable: twenty points apart could be a real difference or could be the same number
+twice with noise on it, and there was no way to tell from the table which.
+
+These assert what comes *out* of the summary for a given set of simulated drafts — the columns the
+warehouse table is written from — never how the numbers are arrived at. Fixtures are a handful of
+trials with values chosen so every expected mean, standard deviation and standard error can be
+done on paper.
+
+## Why the standard error and not something cleverer
+
+Every plan meets the identical room within a trial, so the honest comparison between two of them is
+paired, and a paired difference is measurably tighter than either plan's own standard error
+suggests — the two leading openings correlate at about 0.7 across rooms. No single number on a row
+can carry that, because it is a property of the *pair*. So the row carries the plain standard error
+of its own mean, which combines across two plans as the root of the sum of squares and is therefore
+*conservative* under positive correlation: a gap that clears it is real, and a gap that does not
+may still be.
+
+The standard deviation is kept beside it because it answers a different question that a mean cannot
+— how much a plan's outcome swings room to room, which is risk rather than precision.
+"""
+
+import math
+
+import pandas as pd
+import pytest
+from pandas.testing import assert_frame_equal
+
+from src.draft.composition import composition_guidance
+from src.gold.draft_plan import _PLAN_COLUMNS, _summarize_plans
+
+SEAT = 3
+ANOTHER_SEAT = 7
+
+# A twelve-team league, so "top third" is a finish of four or better and the rates below are
+# workable by hand.
+TEAMS = 12
+
+# Nine trials whose deviations from their mean are four at -1, one at 0 and four at +1, scaled to
+# whatever spread a case wants. At this size the sum of squared deviations is 8 over 8 degrees of
+# freedom, so a scale of s gives a standard deviation of exactly s and a standard error of s/3.
+NINE = [-1, -1, -1, -1, 0, 1, 1, 1, 1]
+
+
+def trials(draft_slot, plan, starter_points, points_vs_field=None, finish_rank=None):
+    """One row per simulated draft, as the simulation hands them to the summary."""
+    points_vs_field = points_vs_field or [value - 1000 for value in starter_points]
+    finish_rank = finish_rank or [1] * len(starter_points)
+    return pd.DataFrame({
+        "draft_slot": draft_slot,
+        "plan": plan,
+        "starter_points": starter_points,
+        "points_vs_field": points_vs_field,
+        "finish_rank": finish_rank,
+    })
+
+
+def spread(mean, scale):
+    """Nine trials with a mean of `mean` and a standard deviation of exactly `scale`."""
+    return [mean + scale * deviation for deviation in NINE]
+
+
+def row(summary, plan, draft_slot=SEAT):
+    (found,) = summary[
+        (summary["plan"] == plan) & (summary["draft_slot"] == draft_slot)
+    ].to_dict("records")
+    return found
+
+
+def test_every_plan_row_carries_dispersion_beside_its_trial_count():
+    results = pd.concat([
+        trials(SEAT, "2QB3RB", spread(1700, 3)),
+        trials(SEAT, "2QB2RB1TE", spread(1720, 6)),
+    ], ignore_index=True)
+
+    summary = _summarize_plans(results, TEAMS)
+
+    measures = [
+        "starter_points_stdev", "starter_points_stderr",
+        "points_vs_field_stdev", "points_vs_field_stderr",
+    ]
+    for measure in measures:
+        assert measure in summary.columns
+        assert summary[measure].notna().all()
+        # The table the warehouse is written from, not just the frame on the way to it.
+        assert measure in _PLAN_COLUMNS
+
+
+def test_the_measure_is_the_spread_of_that_plans_own_trials():
+    results = trials(
+        SEAT, "2QB3RB",
+        starter_points=[98, 100, 102],
+        points_vs_field=[5, 10, 15],
+        finish_rank=[1, 2, 3],
+    )
+
+    plan = row(_summarize_plans(results, TEAMS), "2QB3RB")
+
+    assert plan["trials"] == 3
+    assert plan["starter_points_stdev"] == pytest.approx(2.0)
+    assert plan["starter_points_stderr"] == pytest.approx(2.0 / math.sqrt(3))
+    assert plan["points_vs_field_stdev"] == pytest.approx(5.0)
+    assert plan["points_vs_field_stderr"] == pytest.approx(5.0 / math.sqrt(3))
+
+
+def test_two_plans_with_the_same_mean_are_told_apart_by_their_spread():
+    results = pd.concat([
+        trials(SEAT, "steady", spread(1700, 2)),
+        trials(SEAT, "swingy", spread(1700, 20)),
+    ], ignore_index=True)
+
+    summary = _summarize_plans(results, TEAMS)
+    steady, swingy = row(summary, "steady"), row(summary, "swingy")
+
+    assert steady["starter_points"] == pytest.approx(swingy["starter_points"])
+    assert steady["starter_points_stdev"] == pytest.approx(2.0)
+    assert swingy["starter_points_stdev"] == pytest.approx(20.0)
+    assert steady["starter_points_stderr"] == pytest.approx(2.0 / 3)
+    assert swingy["starter_points_stderr"] == pytest.approx(20.0 / 3)
+
+
+def test_each_seat_reports_its_own_spread():
+    results = pd.concat([
+        trials(SEAT, "2QB3RB", spread(1700, 3)),
+        trials(ANOTHER_SEAT, "2QB3RB", spread(1700, 12)),
+    ], ignore_index=True)
+
+    summary = _summarize_plans(results, TEAMS)
+
+    assert row(summary, "2QB3RB")["starter_points_stdev"] == pytest.approx(3.0)
+    assert row(summary, "2QB3RB", ANOTHER_SEAT)["starter_points_stdev"] == pytest.approx(12.0)
+
+
+def test_trials_that_all_scored_the_same_report_zero_dispersion():
+    results = trials(SEAT, "2QB3RB", starter_points=[1700, 1700, 1700])
+
+    plan = row(_summarize_plans(results, TEAMS), "2QB3RB")
+
+    assert plan["starter_points_stdev"] == 0.0
+    assert plan["starter_points_stderr"] == 0.0
+    assert plan["points_vs_field_stdev"] == 0.0
+    assert plan["points_vs_field_stderr"] == 0.0
+
+
+def test_a_plan_simulated_once_reports_no_dispersion_rather_than_zero():
+    results = trials(SEAT, "2QB3RB", starter_points=[1700])
+
+    plan = row(_summarize_plans(results, TEAMS), "2QB3RB")
+
+    assert plan["trials"] == 1
+    assert math.isnan(plan["starter_points_stdev"])
+    assert math.isnan(plan["starter_points_stderr"])
+    assert math.isnan(plan["points_vs_field_stdev"])
+    assert math.isnan(plan["points_vs_field_stderr"])
+
+
+def test_a_real_gap_and_a_noise_gap_read_differently_from_the_recorded_numbers():
+    """The point of the whole ticket: two means and their standard errors settle the question.
+
+    Every plan here has a standard error of exactly one point. `apart` beats `middle` by ten, which
+    is seven combined standard errors; `alike` trails it by half a point, which is a third of one.
+    """
+    results = pd.concat([
+        trials(SEAT, "apart", spread(1710, 3)),
+        trials(SEAT, "middle", spread(1700, 3)),
+        trials(SEAT, "alike", spread(1699.5, 3)),
+    ], ignore_index=True)
+
+    summary = _summarize_plans(results, TEAMS)
+    apart, middle, alike = row(summary, "apart"), row(summary, "middle"), row(summary, "alike")
+
+    def gaps(better, worse):
+        difference = better["starter_points"] - worse["starter_points"]
+        combined = math.hypot(better["starter_points_stderr"], worse["starter_points_stderr"])
+        return difference / combined
+
+    assert gaps(apart, middle) > 3
+    assert gaps(middle, alike) < 1
+
+
+def test_the_existing_columns_keep_their_meaning():
+    results = trials(
+        SEAT, "2QB3RB",
+        starter_points=[1690, 1700, 1710],
+        points_vs_field=[90, 100, 110],
+        finish_rank=[1, 2, 5],
+    )
+
+    plan = row(_summarize_plans(results, TEAMS), "2QB3RB")
+
+    assert plan["trials"] == 3
+    assert plan["starter_points"] == pytest.approx(1700.0)
+    assert plan["points_vs_field"] == pytest.approx(100.0)
+    assert plan["finish_rank"] == pytest.approx(8 / 3)
+    assert plan["win_rate"] == pytest.approx(1 / 3)
+    # Top third of twelve is a finish of four or better: two of the three drafts.
+    assert plan["top_third_rate"] == pytest.approx(2 / 3)
+
+
+def test_there_is_still_one_row_per_seat_and_plan():
+    results = pd.concat([
+        trials(seat, plan, spread(1700, 3))
+        for seat in (SEAT, ANOTHER_SEAT)
+        for plan in ("2QB3RB", "2QB2RB1TE")
+    ], ignore_index=True)
+
+    summary = _summarize_plans(results, TEAMS)
+
+    assert len(summary) == 4
+    assert not summary.duplicated(subset=["draft_slot", "plan"]).any()
+
+
+def test_composition_guidance_reads_the_same_frame_the_same_way():
+    """The consumer that was already reading this table is not moved by the new columns."""
+    plans = pd.DataFrame([
+        {"draft_slot": SEAT, "plan": "2QB2RB1TE", "trials": 300,
+         "points_vs_field": 120.0, "win_rate": 0.44},
+        {"draft_slot": SEAT, "plan": "1QB2RB1WR1TE", "trials": 300,
+         "points_vs_field": 40.0, "win_rate": 0.22},
+        {"draft_slot": SEAT, "plan": "0QB2RB2WR1TE", "trials": 300,
+         "points_vs_field": -30.0, "win_rate": 0.09},
+    ])
+    with_dispersion = plans.assign(
+        starter_points_stdev=[60.0, 55.0, 58.0],
+        starter_points_stderr=[3.5, 3.2, 3.3],
+        points_vs_field_stdev=[52.0, 49.0, 51.0],
+        points_vs_field_stderr=[3.0, 2.8, 2.9],
+    )
+    picks = {"mine": [{"position": "QB"}, {"position": "RB"}]}
+    league = {"seat": SEAT}
+
+    before = composition_guidance(plans, picks, league)
+    after = composition_guidance(with_dispersion, picks, league)
+
+    assert_frame_equal(before.pop("bands"), after.pop("bands"))
+    assert before == after


### PR DESCRIPTION
Closes #40.

## What the table was missing

`draft_plans` recorded how many rooms a plan was drafted into and what it averaged over them, and
nothing about how much those rooms disagreed. A twenty-point gap between two openings could be a
real difference or the same number twice with noise on it, and the table could not say which.

## What each row carries now

Beside `trials`, for both point means:

- `*_stdev` — how far a single room moves this plan's result. That is the plan's **risk**: two
  openings can average the same and reach it very differently.
- `*_stderr` — that spread over the root of the trial count. That is the mean's **precision**, and
  the number a gap has to clear to be believed.

The rates get neither. A proportion's standard error is exactly `sqrt(p(1-p)/trials)` from the
columns already on the row, and storing a third would be a second place for the same fact to be
wrong.

## Why the plain standard error and not something cleverer

Every plan meets the identical room within a trial, so the honest comparison between two of them is
paired — and the pairing is worth a lot: the leading openings correlate at about 0.7 across rooms,
which makes the true standard error of their difference roughly half what combining two rows
implies. No number on a row can carry that, because it belongs to the *pair* rather than to either
plan.

A room-demeaned alternative was measured and is worse, not better: the room effect is not a common
additive lift (a room where quarterbacks fall late helps QB-heavy openings and hurts QB-light ones),
so demeaning inflates exactly the extreme plans one wants to read. Measured on 60 trials at sleeper
seat 3, `points_vs_field`:

| | naive SE of the mean | room-demeaned SE | true paired SE of the leaders' difference |
|---|---|---|---|
| top two plans | 6.65 / 7.49 | 9.12 / 8.47 | **5.84** |

So the row carries the plain standard error, which combines as `hypot(se_a, se_b)` and is therefore
*conservative* under positive correlation: a gap that clears it is real, and one that does not may
still be. The module docstring and `_summarize_plans` both say so.

## Existing consumers

Unchanged, and checked rather than assumed. The rebuilt table reproduces every mean it had —
`2QB2RB1TE` at sleeper seat 2 is 1704.997206 / 124.026260 before and after — and all three readers
(`src/draft/live.py`, `scripts/draft_page.py`, `notebooks/draft_board.ipynb`) select by name. A test
asserts composition guidance returns identical bands from a frame carrying the new columns.

## Tests, written first

The ten cases were enumerated and agreed before any implementation existed, per the repo's testing
rule. Seven failed on the first run; the three that passed are the guards on existing behaviour,
which is what they are for. Full suite: 178 passed.

## Rebuild

`python -m src.gold.draft_plan` — `draft_availability 74,192 rows`, `draft_plans 888 rows`.

## One doc consequence

Four places gave "the plan table records no dispersion" as the *reason* for presenting bands rather
than naming an opening. That reason no longer exists, so it is replaced by the measurement — which
happens to say the same thing. At **10 of the superflex league's 14 seats** the best two openings
finish within one combined standard error of each other, and at **all 10** of the one-quarterback
league's; only 3 sleeper seats have a leader clear by more than two (max 3.8σ). Bands remain the
honest unit, the live tool's behaviour is untouched, and a finer presentation stays the separate
ticket it was scoped as.

🤖 Generated with [Claude Code](https://claude.com/claude-code)