### PR TITLE
Let the drafter narrow the board to one position

### DIFF
--- a/src/draft/filter.py
+++ b/src/draft/filter.py
@@ -1,0 +1,96 @@
+"""Narrow the board to one position, on a line typed at the running tool.
+
+Pure, like everything in this package bar `live`: a string and a frame in, a decision out. Nothing
+here ranks, reprices or renders — it only decides what the drafter asked to look at.
+
+## Why this is typed rather than passed at startup
+
+The ranking has taken a `position` argument since cost of waiting was written, and narrowing to it
+changes no number: cost of waiting is measured against the whole board's remaining players, so a
+filtered screen shows the same quarterbacks at the same prices as the unfiltered one. The argument
+was reachable from nothing.
+
+A command-line flag would not have fixed that. "Who is the best quarterback left" is a question
+asked *at* a pick, about a board that is four picks older than the one the tool started on, and the
+loop runs until Ctrl-C precisely because a session that ends at pick eleven is a session nobody
+restarts in time. A filter that could only be set by restarting would be a filter nobody used.
+
+## Precedence: a position first, a name second
+
+The filter shares the one input channel with hand-marks, so a typed line has to be read as one or
+the other. It is read as a position first, and the asymmetry is what makes that safe:
+
+- A name cannot be read as a position. A position token is one of the handful the board itself
+  carries, matched whole — `bijan` is not `RB` under any spelling.
+- A position *can* be read as a name, which is what would happen without this rule: `k` is a
+  substring of `Kyle Pitts`. It costs nothing, because a one- or two-letter mark matches half the
+  board and `marks` already refuses an ambiguous one. The drafter loses a refusal he did not want.
+
+Only positions the board actually carries are recognised, so the set is a fact about the frame
+rather than a list typed here that a rebuild could make wrong.
+
+## Every outcome carries a line for the screen
+
+Same rule `marks` is written to, for a sharper reason. A hand-mark that silently failed leaves a
+player on the board who is gone; a filter that silently *worked* leaves a drafter reading three
+quarterbacks as the whole of what is left. Both are the screen quietly meaning something other
+than what it appears to mean, so there is no silent branch here: narrowing, clearing, and the two
+ways of asking for what is already on screen all come back with something to print.
+"""
+
+import pandas as pd
+
+# Typed to put the whole board back. A word rather than a punctuation mark because `-` is already
+# spent on taking a hand-mark back, and the two undo different things.
+ALL = "all"
+
+
+def _positions(board: pd.DataFrame) -> dict[str, str]:
+    """What the drafter could type, to the board's own spelling of it.
+
+    Read off the frame rather than listed here: the board decides what positions exist, and a list
+    written in this module would be a second opinion that a rebuild could make wrong.
+    """
+    return {str(position).strip().lower(): position for position in board["position"].unique()}
+
+
+def _nothing(message: str) -> dict:
+    """Nothing to do, and the reason, which always goes on the screen."""
+    return {"action": "none", "position": None, "message": message}
+
+
+def read_position(typed: str, board: pd.DataFrame, position: str | None = None) -> dict | None:
+    """One line the drafter typed, read as a position filter — or None if it is not one.
+
+    `position` is what the board is narrowed to already, so that asking for what is on screen can
+    say so rather than redrawing in silence. Returns None when the line is not a filter command at
+    all, which is the caller's signal to read it as a name instead; otherwise:
+
+    - `action` — `"show"` to narrow to `position`, `"clear"` to put the whole board back, and
+      `"none"` when there is nothing to do.
+    - `position` — the board's own spelling of the position to show, or None for the whole board.
+    - `message` — always present, and always worth printing.
+    """
+    wanted = typed.strip().lower()
+    if not wanted:
+        return None
+
+    if wanted == ALL:
+        if position is None:
+            return _nothing("the whole board is already showing")
+        return {
+            "action": "clear",
+            "position": None,
+            "message": "showing the whole board again",
+        }
+
+    found = _positions(board).get(wanted)
+    if found is None:
+        return None
+    if found == position:
+        return _nothing(f"{found} is already the only position showing")
+    return {
+        "action": "show",
+        "position": found,
+        "message": f"showing {found} only — type \"{ALL}\" for the whole board",
+    }

--- a/src/draft/live.py
+++ b/src/draft/live.py
@@ -54,8 +54,8 @@ not revisited under a pick clock.
 
 ## This module is the edge, and the only part of `src/draft/` that is
 
-`picks`, `candidates`, `seat`, `composition` and `render` are all pure: frames and payloads in,
-frames and strings out. Everything that touches the world is here, in one file, so that "does this tool
+`picks`, `candidates`, `seat`, `composition`, `filter` and `render` are all pure: frames and
+payloads in, frames and strings out. Everything that touches the world is here, in one file, so that "does this tool
 write anything" is a question answered by reading one module rather than four.
 
 What it touches, exhaustively:
@@ -68,14 +68,17 @@ What it touches, exhaustively:
   before each returns. A draft-night process cannot corrupt what the pipeline built, and cannot
   hold the file lock against a rebuild either.
 - Whatever has been typed at **stdin**, read without blocking and resolved against the board by
-  `marks`. Nothing is written anywhere as a result: a hand-mark lives in memory until Ctrl-C.
+  `filter` and then `marks`. Nothing is written anywhere as a result: a hand-mark and a narrowed
+  board both live in memory until Ctrl-C.
 
 ## Nothing is configured by typing
 
 The league ID and season come from `src.silver.sleeper`, so the repo holds one league ID rather
-than two that can disagree. A player's name typed during the draft is the one thing that is ever
-typed at this tool, and it is resolved against the board rather than configuring anything. Everything else — seat, roster, team count, rounds, starting slots —
-is read out of the draft record. The one configured name is the Sleeper username below, which is
+than two that can disagree. A player's name and a position are the only things ever typed at this
+tool, and both are resolved against the board rather than configuring anything: one says a player
+is gone, the other says which part of the board to look at, and neither changes a number.
+Everything else — seat, roster, team count, rounds, starting slots — is read out of the draft
+record. The one configured name is the Sleeper username below, which is
 resolved to a user ID against the API and then to a seat against the draft order.
 
 ## Why it refuses to run against an old warehouse
@@ -101,6 +104,7 @@ import pandas as pd
 import requests
 
 from src.draft.composition import composition_guidance
+from src.draft.filter import ALL, read_position
 from src.draft.marks import combine, read_mark
 from src.draft.picks import ingest_picks, picks_made
 from src.draft.refresh import fingerprint, status_line
@@ -299,7 +303,8 @@ def fetch_picks(context: dict) -> list[dict]:
 
 
 def screen(
-    context: dict, picks: list[dict], limit: int = DEFAULT_LIMIT, marked=()
+    context: dict, picks: list[dict], limit: int = DEFAULT_LIMIT, marked=(),
+    position: str | None = None,
 ) -> str:
     """One picks payload against the frozen half, drawn — subtract, rank, render.
 
@@ -309,10 +314,15 @@ def screen(
     `marked` is the players the drafter has taken off the board by hand. They are unioned into the
     payload here rather than handled separately, so that everything below this line sees one list
     of who is gone and `ingest_picks` does the deduplication it was written to do.
+
+    `position` narrows the candidate list to one position. It is handed to the ranking rather than
+    applied to what the ranking returned, because cost of waiting is measured against the whole
+    board's remaining players — a narrowed screen must show the same prices as an unnarrowed one,
+    not the prices a position would have if the rest of the board had been drafted.
     """
     marked = list(marked)
     result = ingest_picks(combine(picks, marked), context["board"], context["league"])
-    ranked = rank_by_cost_of_waiting(context["board"], context["survival"], result)
+    ranked = rank_by_cost_of_waiting(context["board"], context["survival"], result, position)
 
     # The bye week is joined back on by ID rather than carried through the ranking: what the
     # ranking returns is a fixed contract, and a display column is not the ranking's business.
@@ -327,14 +337,38 @@ def screen(
     return render_board(
         candidates, result, context["league"], limit,
         degraded=ranked["degraded"], covers_to=ranked["covers_to"], marked=marked,
-        guidance=guidance,
+        guidance=guidance, position=position,
     )
 
 
-def render_once(limit: int = DEFAULT_LIMIT) -> str:
+def starting_position(typed: str | None, board: pd.DataFrame) -> str | None:
+    """A `--position` flag resolved against the board, or the whole board and a reason why.
+
+    Read through exactly the path a typed line takes, so a flag cannot recognise a position the
+    running tool would not. A flag naming nothing is a note rather than an exit: the board is
+    still worth reading, the drafter can narrow it by typing once the tool is up, and a session
+    that refused to start over a typo is a session that starts late.
+    """
+    if typed is None:
+        return None
+    outcome = read_position(typed, board)
+    if outcome is None or outcome["action"] != "show":
+        carried = ", ".join(sorted(str(value) for value in board["position"].unique()))
+        print(
+            f"\nno position on this board is called {typed!r} — showing the whole board. "
+            f"It carries {carried}.\n"
+        )
+        return None
+    return outcome["position"]
+
+
+def render_once(limit: int = DEFAULT_LIMIT, position: str | None = None) -> str:
     """Everything, once: fetch, resolve, subtract, rank, and give back the screen."""
     context = prepare()
-    return screen(context, fetch_picks(context), limit)
+    return screen(
+        context, fetch_picks(context), limit,
+        position=starting_position(position, context["board"]),
+    )
 
 
 def _write(text: str) -> None:
@@ -393,6 +427,7 @@ def watch(
     write=_write,
     keys=_typed,
     interval: float = REFRESH_SECONDS,
+    position: str | None = None,
 ) -> None:
     """Draw the board, then keep it current until interrupted.
 
@@ -403,11 +438,16 @@ def watch(
     the last check that did work, and the next tick asks again. Nothing short of Ctrl-C ends this,
     because a session that ends at pick eleven is a session nobody restarts in time.
 
-    A name typed at it is read on the next tick and marked taken by hand — see `marks` for what
-    that resolves against and what it refuses. Marks are held here, for the session, and unioned
-    into every draw from the moment they are made: the last payload a poll returned is kept, so a
-    mark still redraws the board on a tick Sleeper did not answer, which is the whole reason the
-    drafter is typing in the first place.
+    A line typed at it is read on the next tick as a position first and a name second — see
+    `filter` for why that way round, and `marks` for what a name resolves against and what it
+    refuses. Both are held here, for the session, and both take effect on the tick they are read:
+    the last payload a poll returned is kept, so a mark or a filter still redraws the board on a
+    tick Sleeper did not answer, which is the whole reason the drafter is typing in the first
+    place.
+
+    `position` is what the board starts narrowed to, for a session begun with `--position`. It is
+    a starting state and not a fixed one — the drafter can widen or narrow it at any point without
+    restarting, which is the only reason the filter is worth having.
     """
     poll = poll or (lambda: fetch_picks(context))
 
@@ -434,27 +474,40 @@ def watch(
                 if not line.strip():
                     # Enter on an empty line is how a half-typed name gets cleared.
                     continue
-                outcome = read_mark(line, context["board"], marked)
+                # A position first, a name second. `read_position` hands back None for a line
+                # that is not one of the board's positions, which is every name a drafter types.
+                outcome = read_position(line, context["board"], position)
+                if outcome is None:
+                    outcome = read_mark(line, context["board"], marked)
                 if outcome["action"] == "mark":
                     marked[outcome["player"]["player_id"]] = outcome["player"]
                 elif outcome["action"] == "unmark":
                     marked.pop(outcome["player"]["player_id"], None)
+                elif outcome["action"] in ("show", "clear"):
+                    position = outcome["position"]
                 # Every outcome, refusals included: a mark that said nothing would be read as one
-                # that worked. Ends the status line rather than being written over it.
+                # that worked, and a filter that said nothing would be a narrowed board read as a
+                # whole one. Ends the status line rather than being written over it.
                 write(f"\n{outcome['message']}\n")
                 status_width = 0
 
             combined = combine(picks, marked.values())
             made = picks_made(combined)
-            seen = fingerprint(combined)
+            # What is on screen is the picks *and* what the board is narrowed to: typing `qb`
+            # changes the screen without changing a single pick, and a fingerprint that ignored it
+            # would leave the drafter's own request undrawn until somebody else made a selection.
+            seen = (fingerprint(combined), position)
 
             # A failed poll on its own draws nothing — the board has not changed and the status
-            # line says the connection has. A mark is a change, and gets drawn whether Sleeper
-            # answered or not.
-            if (error is None or marked) and seen != drawn:
+            # line says the connection has. A mark or a filter is the drafter changing what he
+            # asked for, and gets drawn whether Sleeper answered or not.
+            if (error is None or marked or position) and seen != drawn:
                 # End whatever status line is sitting on the terminal before drawing past it.
                 lead = "\n" if drawn is None else f"\n{_rule(made, len(marked))}\n"
-                write(f"{lead}\n{screen(context, picks, limit, marked.values())}\n")
+                write(
+                    f"{lead}\n"
+                    f"{screen(context, picks, limit, marked.values(), position)}\n"
+                )
                 drawn = seen
                 status_width = 0
 
@@ -469,22 +522,23 @@ def watch(
         write(f"\n\nstopped at {made} picks made — no pick was ever submitted\n")
 
 
-def main(limit: int = DEFAULT_LIMIT, once: bool = False) -> None:
+def main(limit: int = DEFAULT_LIMIT, once: bool = False, position: str | None = None) -> None:
     built_at = warehouse_built_at()
     check_recency(built_at, datetime.now())
     built = f"board built {built_at:%Y-%m-%d %H:%M} — read-only, no pick is ever submitted"
 
     if once:
-        print(render_once(limit))
+        print(render_once(limit, position))
         print(f"\n{built}")
         return
 
     context = prepare()
     print(
-        f"{built}\nrefreshing every {REFRESH_SECONDS:.0f}s — type a name to mark him taken by "
-        "hand, -name to undo, Ctrl-C to stop"
+        f"{built}\nrefreshing every {REFRESH_SECONDS:.0f}s — type a position to show only it "
+        f'("qb", "{ALL}" for everyone), a name to mark him taken by hand, -name to undo, '
+        "Ctrl-C to stop"
     )
-    watch(context, limit)
+    watch(context, limit, position=starting_position(position, context["board"]))
 
 
 if __name__ == "__main__":
@@ -499,10 +553,14 @@ if __name__ == "__main__":
         "--once", action="store_true",
         help="draw the board once and exit, instead of refreshing until interrupted",
     )
+    parser.add_argument(
+        "--position", default=None,
+        help="show only one position (QB, RB, ...); can be changed by typing at the running tool",
+    )
     arguments = parser.parse_args()
 
     try:
-        main(arguments.limit, arguments.once)
+        main(arguments.limit, arguments.once, arguments.position)
     except KeyboardInterrupt:
         # Ctrl-C before the loop starts — during the warehouse read or the first fetch. The loop
         # has its own, which stops cleanly rather than unwinding.

--- a/src/draft/render.py
+++ b/src/draft/render.py
@@ -273,20 +273,30 @@ def _ranking(picks: dict, degraded: bool, covers_to: int | None) -> list[str]:
 
 
 def _candidates(
-    candidates: pd.DataFrame, picks: dict, limit: int, degraded: bool, covers_to: int | None
+    candidates: pd.DataFrame, picks: dict, limit: int, degraded: bool, covers_to: int | None,
+    position: str | None = None,
 ) -> list[str]:
-    """The board that is left, most expensive to pass on first, cut to what fits on a screen."""
+    """The board that is left, most expensive to pass on first, cut to what fits on a screen.
+
+    `position` is what the board has been narrowed to, and is named in the heading rather than
+    left to be inferred from the rows. A drafter who typed `qb` four picks ago and forgot is
+    otherwise reading three quarterbacks as the whole of what is left.
+    """
     shown = candidates.head(limit)
     rule, note = _ranking(picks, degraded, covers_to)
+    scope = f" ({position} only)" if position else ""
     lines = [
         "",
-        f"Best available — {len(shown)} of {len(candidates)}{rule}",
+        f"Best available{scope} — {len(shown)} of {len(candidates)}{rule}",
         note,
         f"  {'#':>3}  {'POS':<5}{'PLAYER':<{_NAME_WIDTH}}{'TM':<5}{'BYE':>3}{'PoR':>9}"
         f"{'SURV':>7}{'COST':>9}",
     ]
     if shown.empty:
-        lines.append("  nobody left on the board")
+        # Which position is empty, never just that something is. "Nobody left on the board" under
+        # a quarterback filter describes a finished draft, and reads like one.
+        empty = f"no {position} left on the board" if position else "nobody left on the board"
+        lines.append(f"  {empty}")
         return lines
 
     for rank, row in enumerate(shown.itertuples(), start=1):
@@ -308,6 +318,7 @@ def render_board(
     covers_to: int | None = None,
     marked: list[dict] | tuple = (),
     guidance: dict | None = None,
+    position: str | None = None,
 ) -> str:
     """The whole screen as one string.
 
@@ -327,6 +338,10 @@ def render_board(
     `guidance` is what `composition_guidance` returned, or None for a screen without it. It is
     printed beside the ranking and changes nothing about it: the candidate list is the same list,
     in the same order, whether it is passed or not.
+
+    `position` is the position the board has been narrowed to, or None for the whole board. It
+    names the scope of the candidate list and touches nothing above it — the roster, the warning
+    and the opening shape are claims about the draft, not about what the drafter is looking at.
     """
     marked = list(marked)
     lines = [_header(picks, league, marked)]
@@ -334,5 +349,5 @@ def render_board(
     lines += _marked(marked)
     lines += _roster(picks["roster"], league)
     lines += _guidance(guidance)
-    lines += _candidates(candidates, picks, limit, degraded, covers_to)
+    lines += _candidates(candidates, picks, limit, degraded, covers_to, position)
     return "\n".join(lines)

--- a/tests/test_draft_position_filter.py
+++ b/tests/test_draft_position_filter.py
@@ -1,0 +1,119 @@
+"""Issue #29, user story 17: "who is the best quarterback left", answered directly.
+
+The pure ranking has taken a `position` argument since cost of waiting was written, and the case
+that narrowing does not reprice anything is already covered in `test_draft_waiting`. What was
+missing is any way for a drafter to reach it. The tool refreshes until Ctrl-C, so a flag fixed at
+startup is not a filter anybody can use at pick eleven, and restarting the tool mid-draft is the
+one thing the loop exists to avoid.
+
+So the filter is typed at the running tool, down the same channel a hand-mark is typed at. That
+makes the only real decision here one of precedence: a line is read as a position first and as a
+name second. The cases below pin that down, because the two ways of getting it wrong are not
+symmetric.
+
+Reading a name as a position cannot happen — a position token is short, fixed, and has to be one
+the board actually carries. Reading a position as a name is what would happen without the
+precedence, and it costs nothing only because a one- or two-letter mark matches half the board and
+would be refused anyway.
+
+What is not harmless is a filter that changes the screen without saying so. A drafter who typed
+`qb`, got a narrowed board, and did not notice would read three quarterbacks as the whole of what
+is left. So there is no silent branch here either: every outcome carries a line to print, the same
+rule `marks` is written to.
+"""
+
+import pandas as pd
+
+from src.draft.filter import read_position
+
+# One player at each position the board carries, plus the collision the precedence rule exists
+# for: `Kyle Pitts` contains a `k`, so a bare `k` is both a substring of a name and the kicker
+# position. Nobody types one letter meaning a player, and the screen says which reading it took.
+BOARD = pd.DataFrame(
+    [
+        {"player_id": "00-0000001", "sleeper_id": "4984", "player_name": "Josh Allen",
+         "position": "QB", "team": "BUF"},
+        {"player_id": "00-0000002", "sleeper_id": "8138", "player_name": "Bijan Robinson",
+         "position": "RB", "team": "ATL"},
+        {"player_id": "00-0000003", "sleeper_id": "6794", "player_name": "Justin Jefferson",
+         "position": "WR", "team": "MIN"},
+        {"player_id": "00-0000004", "sleeper_id": "7553", "player_name": "Kyle Pitts",
+         "position": "TE", "team": "ATL"},
+        {"player_id": "00-0000005", "sleeper_id": "9224", "player_name": "Brandon Aubrey",
+         "position": "K", "team": "DAL"},
+    ]
+)
+
+
+# 1. The whole of the story: a position typed at the tool narrows the board to it.
+def test_a_typed_position_narrows_the_board_to_it():
+    outcome = read_position("QB", BOARD)
+
+    assert outcome["action"] == "show"
+    assert outcome["position"] == "QB"
+
+
+# 2. Nobody types in capitals under a pick clock, and the board's own spelling is the one that has
+# to match downstream — so the case is normalized here rather than by the drafter.
+def test_a_position_is_recognised_whatever_case_it_is_typed_in():
+    for typed in ("qb", "QB", "Qb", " qb "):
+        outcome = read_position(typed, BOARD)
+        assert outcome is not None, f"{typed!r} was not read as a position"
+        assert outcome["position"] == "QB", f"{typed!r} resolved to {outcome['position']!r}"
+
+
+# 3. A narrowed board that did not announce itself is three quarterbacks read as the whole board.
+def test_narrowing_says_on_screen_which_position_is_being_shown():
+    assert "QB" in read_position("qb", BOARD)["message"]
+
+
+# 4. The way back. Without it the only route to the full board is restarting the tool, which is
+# the thing the refresh loop exists to make unnecessary.
+def test_all_puts_the_whole_board_back():
+    outcome = read_position("all", BOARD, position="QB")
+
+    assert outcome["action"] == "clear"
+    assert outcome["position"] is None
+    assert outcome["message"]
+
+
+# 5. The precedence rule, stated as the thing it must not break: a name is still a mark. This is
+# the case that keeps the filter from eating the safety-critical channel it shares.
+def test_a_name_is_not_a_filter_command():
+    assert read_position("bijan", BOARD) is None
+    assert read_position("kyle pitts", BOARD) is None
+    assert read_position("-bijan", BOARD) is None
+
+
+# 6. The other half of precedence: a position token wins even though it is also a substring of a
+# player's name. Safe in this direction only, because a one-letter mark is ambiguous and would be
+# refused; and visible either way, because the message says which reading was taken.
+def test_a_position_wins_over_a_name_it_is_a_substring_of():
+    outcome = read_position("k", BOARD)
+
+    assert outcome is not None and outcome["position"] == "K"
+    assert "K" in outcome["message"]
+
+
+# 7. A position no player on this board plays is not a filter — it falls through to be read as a
+# name, where an unknown one is already refused by name and said out loud.
+def test_a_position_the_board_does_not_carry_is_not_a_filter_command():
+    assert read_position("p", BOARD) is None
+    assert read_position("dst", BOARD) is None
+
+
+# 8. No silent branch: clearing a board that is not narrowed still prints something, so a drafter
+# who types `all` twice is told the second one did nothing rather than left wondering.
+def test_clearing_a_board_that_is_not_narrowed_says_so():
+    outcome = read_position("all", BOARD, position=None)
+
+    assert outcome["action"] == "none"
+    assert outcome["message"]
+
+
+# 9. And the same going the other way, for the same reason.
+def test_narrowing_to_the_position_already_shown_says_so():
+    outcome = read_position("qb", BOARD, position="QB")
+
+    assert outcome["action"] == "none"
+    assert outcome["message"]

--- a/tests/test_draft_render.py
+++ b/tests/test_draft_render.py
@@ -482,3 +482,55 @@ def test_an_opening_no_plan_covers_says_so_rather_than_showing_a_band():
 def test_a_screen_with_no_guidance_says_nothing_about_the_opening():
     out = render_board(candidates(), ingested(), LEAGUE)
     assert "Opening shape" not in out
+
+
+# Issue #29, user story 17: the screen when the board has been narrowed to one position.
+#
+# The narrowing itself happens in the ranking, which was written to take a position and is tested
+# for it. What is asserted here is the half that stops a narrowed board being read as the whole
+# one: the heading has to say which position it is showing, and an empty one has to say which
+# position is empty. "nobody left on the board" under a quarterback filter is a sentence that would
+# end a draft.
+
+
+# 33. A board showing one position says so where the count is read.
+def test_a_narrowed_board_names_the_position_it_is_showing():
+    out = render_board(
+        candidates(
+            {"player_id": "00-0000001", "player_name": "A Passer", "position": "QB"},
+        ),
+        ingested(), LEAGUE, position="QB",
+    )
+    assert "QB" in line_naming(out, "Best available")
+
+
+# 34. And a board showing everything claims nothing about a position.
+def test_an_unnarrowed_board_names_no_position():
+    out = render_board(candidates(), ingested(), LEAGUE)
+    heading = line_naming(out, "Best available")
+
+    assert "only" not in heading.lower()
+
+
+# 35. The sentence that would cost a pick. Nobody left *at this position* is a reason to look
+# elsewhere; nobody left *on the board* is a finished draft, and the two must not read alike.
+def test_an_empty_narrowed_board_says_which_position_is_empty():
+    out = render_board(candidates(), ingested(), LEAGUE, position="QB")
+
+    assert "QB" in line_naming(out, "left")
+
+
+# 36. The filter narrows the list and nothing else. My roster is my roster whatever the board is
+# showing, and the opening shape is a claim about the roster rather than about the list below it.
+def test_narrowing_the_board_leaves_the_roster_and_the_opening_shape_alone():
+    rows = [
+        {"player_id": "00-0000001", "player_name": "A Passer", "position": "QB"},
+        {"player_id": "00-0000002", "player_name": "A Back", "position": "RB"},
+    ]
+    full = render_board(candidates(*rows), ingested(), LEAGUE, guidance=guidance())
+    narrowed = render_board(
+        candidates(rows[0]), ingested(), LEAGUE, guidance=guidance(), position="QB"
+    )
+
+    assert section(narrowed, "My roster") == section(full, "My roster")
+    assert section(narrowed, "Opening shape") == section(full, "Opening shape")

--- a/tests/test_draft_watch.py
+++ b/tests/test_draft_watch.py
@@ -295,3 +295,59 @@ def test_an_unmark_puts_the_player_back_on_the_board():
     assert len(drawn) == 2
     assert "Bravo Wideout" not in available(drawn[0])
     assert "Bravo Wideout" in available(drawn[1])
+
+
+# Issue #29, user story 17: the filter reaching the running tool, which is the whole point of
+# typing it rather than passing it at startup. The board is three players at three positions, so
+# a narrowed screen is unambiguous: `wr` leaves exactly one of them.
+
+
+# 25. Typed, and the board narrows on the same tick — not on the next pick, which in a quiet draft
+# room could be five minutes away.
+def test_a_typed_position_narrows_the_board_and_redraws_at_once():
+    payload = [pick(1, "4034")]
+    written = run_typed(payload, payload, typed=[[], ["wr"]])
+
+    drawn = boards(written)
+    assert len(drawn) == 2
+    assert "Charlie Ender" in available(drawn[0])
+    assert "Bravo Wideout" in available(drawn[1])
+    assert "Charlie Ender" not in available(drawn[1])
+
+
+# 26. A filter that reset itself on the next pick would be a filter nobody could read an answer
+# out of, because the next pick lands while the answer is still being read.
+def test_a_narrowed_board_stays_narrowed_as_picks_come_in():
+    written = run_typed(
+        [pick(1, "4034")], [pick(1, "4034"), pick(2, "6786")], typed=[["te"], []]
+    )
+
+    drawn = boards(written)
+    assert len(drawn) == 2
+    assert "Alpha Back" not in available(drawn[1])
+    assert "Charlie Ender" in available(drawn[1])
+
+
+# 27. The way back to the whole board, without restarting the tool mid-draft.
+def test_all_puts_the_whole_board_back():
+    payload = [pick(1, "4034")]
+    written = run_typed(payload, payload, payload, typed=[[], ["te"], ["all"]])
+
+    drawn = boards(written)
+    assert len(drawn) == 3
+    assert "Bravo Wideout" not in available(drawn[1])
+    assert "Bravo Wideout" in available(drawn[2])
+
+
+# 28. Same reasoning as the hand-mark case above it: narrowing is the drafter changing what he
+# asked for, not Sleeper reporting something new, so it is drawn whether the poll answered or not.
+def test_a_typed_position_narrows_the_board_on_a_tick_the_poll_failed():
+    written = run_typed(
+        [pick(1, "4034")], requests.ConnectionError("connection reset"),
+        typed=[[], ["wr"]],
+    )
+
+    drawn = boards(written)
+    assert len(drawn) == 2
+    assert "Charlie Ender" not in available(drawn[1])
+    assert "Bravo Wideout" in available(drawn[1])


### PR DESCRIPTION
Closes user story 17 of #29.

## Why

The pure ranking has taken a `position` argument since cost of waiting was written, and the case that narrowing does not reprice anything is already covered in `test_draft_waiting`. Nothing could reach it — `live.py` exposed `--limit` and `--once`, and stdin handled only hand-marks. "Who is the best quarterback left" was unanswerable from the running tool.

A startup flag alone would not have fixed it. That question is asked *at* a pick, about a board four picks older than the one the tool started on, and the loop runs until Ctrl-C precisely because a session that ends at pick eleven is one nobody restarts in time.

## What

- `src/draft/filter.py` — a new pure module reading one typed line as a position filter, or `None` when it is not one.
- The loop reads a line as **a position first, a name second**. That way round is safe in one direction only: a name is never one of the board's positions, while a position token *is* a substring of somebody's name (`k` is in `Kyle Pitts`) — and a one-letter mark matches half the board and would be refused as ambiguous anyway.
- Recognised positions are read off the board, not listed in code, so a rebuild cannot make the list wrong.
- No silent branch, the rule `marks` is written to. A hand-mark that silently fails leaves a player on the board who is gone; a filter that silently *works* leaves three quarterbacks read as the whole of what is left.
- The heading names the scope, and an empty narrowed board says *which position* is empty — "nobody left on the board" under a quarterback filter describes a finished draft.
- `--position` sets the starting state only; it goes through the same path a typed line does, and a flag naming nothing is a note rather than an exit.

Narrowing is handed to the ranking rather than applied to its output, so cost of waiting stays measured against the whole board's remaining players.

## Tests

17 new cases, written before the code: 9 on the reader (`tests/test_draft_position_filter.py`), 4 on the screen, 4 on the loop. Suite is 178 → 195, all passing.

Verified against the real warehouse and the live draft:

```
Best available (QB only) — 8 of 120, ranked by cost of waiting to pick #28
    1  QB   Josh Allen              BUF    7    160.5     0%     72.0
    2  QB   Lamar Jackson           BAL   13    111.9     0%     23.4
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)