### PR TITLE
Show how many are left at each position before the next drop

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -126,3 +126,12 @@ would be left at his position, so a deep position is cheap to wait on even when 
 player is likely to go, and a cliff is expensive even when he will probably last. Zero at the
 turn, where the two picks are adjacent and there is no gap to survive.
 _Avoid_: urgency, opportunity cost, need (that is a roster question, not a supply one)
+
+**Cliff**:
+The largest drop in points over replacement between two consecutive players still available at a
+position, looked for among the next few rather than the whole remaining tail. How many sit above
+it is what says a position is thin or deep — a fact about the position, where **cost of waiting**
+is a fact about a player. Below the last player at a position the drop is his own points over
+replacement, because replacement level is zero by construction.
+_Avoid_: tier (already spent on an offensive line's grade), run (that is what a room does, not
+what a board looks like)

--- a/src/draft/cliff.py
+++ b/src/draft/cliff.py
@@ -1,0 +1,108 @@
+"""How many are left at each position before the next real drop.
+
+Pure, like everything in this package bar `live`: one frame in, one frame out, nothing handed in
+modified. No network, no warehouse connection, no printing.
+
+## The question the ranking cannot answer
+
+Cost of waiting already prices the drop behind one player — that is half of what it multiplies,
+and the reason a cliff position is expensive to pass on even when the player will probably last.
+But it hands back one number per player, and a drafter reading the top of that list sees whichever
+positions happen to rank highest across the whole board at once. "Are there six more backs like
+this one, or is this the last of them" is a question nothing on the screen answers.
+
+That question is about a position rather than a player, so it needs its own answer rather than
+another column on a row.
+
+## What counts as a cliff
+
+The largest drop in points over replacement between two consecutive players still available at the
+position. How many sit above it is the answer: three left before it gets materially worse, or
+eleven. Both numbers go on screen, because either alone is unreadable — three left is comfortable
+behind a four-point step and an emergency behind a forty-point one.
+
+This is arithmetic over frozen inputs, in exactly the sense `waiting` is. Every value comes back
+from the board as the rebuild priced it; nothing here refits, rescales or reprices anything.
+
+## Two consequences worth stating, because they look like special cases and are not
+
+**Below the last player at a position is replacement level.** Points over replacement is measured
+against a freely available player, so the drop below the last quarterback on the board is his own
+points over replacement and nothing has to be invented to say so. `waiting._cost_within_position`
+floors its expectation at zero for the same reason. It makes the last startable player at a
+position the biggest cliff on the board, which is correct and is exactly when a drafter most needs
+telling.
+
+**A cliff is only looked for among the next few.** The largest drop in the whole remaining tail of
+a position is usually somewhere in the forties, and reporting it would say "39 left" — true, and
+an answer to nothing being decided now. So the search stops at `LOOKAHEAD`, and the cliff reported
+is the next one rather than the biggest one. Equal drops report the nearer, for the same reason.
+
+## What this is not
+
+Not a recommendation, and not part of the ranking. It sits beside the candidate list the way the
+opening guidance does, and reorders nothing — the repo's standing preference for keeping a
+metric's inputs visible rather than folding them into a single score, and the same reason a
+drafter can overrule what he is shown.
+
+Not roster-conditional either. How thin quarterback is has nothing to do with how many the drafter
+already has; what a position is *worth* to a partly-filled roster is a different question and is
+deliberately out of scope for this feature.
+"""
+
+import numpy as np
+import pandas as pd
+
+# How far down a position the next cliff is looked for. Roughly a round's worth of one position in
+# a fourteen-team league: far enough that a real shelf two or three players away is found, near
+# enough that the answer is about the pick being made. A drop past this is a fact about the fourth
+# round, and the count above it would be a number nobody can act on.
+LOOKAHEAD = 10
+
+# What a cliff row carries: the position, how many are above the drop, how big the drop is, and
+# how many are left at the position at all — "3 of 4" and "3 of 40" are different boards.
+CLIFF_COLUMNS = ["position", "above", "drop", "remaining"]
+
+
+def _cliff(values: list[float], lookahead: int) -> tuple[int, float]:
+    """How many are above the next cliff at one position, and how far it drops.
+
+    `values` is that position's remaining players in value order. The walk looks at the steps
+    between the first `lookahead` of them and whoever is immediately behind — or replacement level,
+    zero, when nobody is, which is what makes the last player at a position a cliff without a
+    special case.
+    """
+    window = values[:lookahead]
+    behind = values[lookahead:lookahead + 1] or [0.0]
+    steps = window + behind
+
+    drops = [steps[index] - steps[index + 1] for index in range(len(steps) - 1)]
+    # `index` of the max takes the first, which is the nearer cliff when two drops are equal: the
+    # near one is the one being decided, and the far one will still be there to report next tick.
+    deepest = drops.index(max(drops))
+    return deepest + 1, drops[deepest]
+
+
+def position_cliffs(candidates: pd.DataFrame, lookahead: int = LOOKAHEAD) -> pd.DataFrame:
+    """The next cliff at every position still on the board.
+
+    `candidates` is who is left, carrying `position` and `points_over_replacement` — the frame
+    `rank_candidates` hands over, in any order. It is sorted here rather than assumed, because the
+    ranking above this is sorted by cost of waiting and a cliff is a fact about value order.
+
+    Returns one row per position with `CLIFF_COLUMNS`, sorted by position so the result is
+    deterministic; a caller wanting the league's own reading order applies it. A position nobody is
+    left at gets no row — a zero in a column of counts reads as a count.
+    """
+    rows = []
+    for position, group in candidates.groupby("position", sort=True):
+        values = list(
+            group["points_over_replacement"].sort_values(ascending=False).astype(float)
+        )
+        if not values or np.isnan(values[0]):
+            continue
+        above, drop = _cliff(values, lookahead)
+        rows.append(
+            {"position": position, "above": above, "drop": drop, "remaining": len(values)}
+        )
+    return pd.DataFrame(rows, columns=CLIFF_COLUMNS)

--- a/src/draft/live.py
+++ b/src/draft/live.py
@@ -54,9 +54,10 @@ not revisited under a pick clock.
 
 ## This module is the edge, and the only part of `src/draft/` that is
 
-`picks`, `candidates`, `seat`, `composition`, `filter` and `render` are all pure: frames and
-payloads in, frames and strings out. Everything that touches the world is here, in one file, so that "does this tool
-write anything" is a question answered by reading one module rather than four.
+`picks`, `candidates`, `seat`, `composition`, `cliff`, `filter` and `render` are all pure: frames
+and payloads in, frames and strings out. Everything that touches the world is here, in one file,
+so that "does this tool write anything" is a question answered by reading one module rather than
+four.
 
 What it touches, exhaustively:
 
@@ -103,6 +104,8 @@ from datetime import datetime, timedelta
 import pandas as pd
 import requests
 
+from src.draft.candidates import rank_candidates
+from src.draft.cliff import position_cliffs
 from src.draft.composition import composition_guidance
 from src.draft.filter import ALL, read_position
 from src.draft.marks import combine, read_mark
@@ -334,10 +337,17 @@ def screen(
     # Beside the ranking, never in it: the guidance is read from the plan table and says what a
     # position keeps open or closes off, and the order below it is the same order either way.
     guidance = composition_guidance(context["plans"], result, context["league"])
+
+    # Depth is computed from the unnarrowed board on purpose, which is why it is ranked again here
+    # rather than read off `ranked`. It is the reason to look away from the position being shown,
+    # so a screen filtered to quarterbacks that reported only quarterback depth could never answer
+    # the question it is read for. The second pass is a sort over a few hundred rows.
+    cliffs = position_cliffs(rank_candidates(context["board"], result["taken"]))
+
     return render_board(
         candidates, result, context["league"], limit,
         degraded=ranked["degraded"], covers_to=ranked["covers_to"], marked=marked,
-        guidance=guidance, position=position,
+        guidance=guidance, position=position, cliffs=cliffs,
     )
 
 

--- a/src/draft/render.py
+++ b/src/draft/render.py
@@ -11,6 +11,7 @@ something that has to be eyeballed on a draft night to know whether it is right.
     marked by hand                     short, and only when there is one
     my roster                          short, and answers "what do I still need"
     opening shape                      short, and answers "what am I still on track for"
+    depth to the next cliff            short, and answers "is this position thin or deep"
     best available                     the long list, last
 
 The order is the only real decision here, and it is decided by what a wrong screen costs. An
@@ -29,6 +30,10 @@ the roster rather than about a player, so it belongs with the roster; and it mus
 ranking rather than inside it, because the ranking is the recommendation and this is the thing a
 drafter overrules it with. A column of it on a candidate row would fold the two together and leave
 neither auditable — which is the same reason the repo keeps a blended metric's inputs visible.
+
+The depth block sits directly above the board for the same two reasons pointing the other way: it
+is a claim about the board rather than about the roster, and it is read *while* reading the list,
+as the thing that says a position is thinner than the rows at the top of the screen suggest.
 
 ## Missing values print as gaps, never as values
 
@@ -246,6 +251,33 @@ def _guidance(guidance: dict | None) -> list[str]:
     return lines
 
 
+def _cliffs(cliffs: pd.DataFrame | None, league: dict) -> list[str]:
+    """How many are left at each position before the next drop, or nothing at all.
+
+    Both numbers per position, because either alone is unreadable: three left is comfortable
+    behind a four-point step and an emergency behind a forty-point one.
+
+    Ordered by the slots the league starts, which is the order the roster block above already
+    reads in — a block whose rows moved between ticks would be re-read from the top every time,
+    which is the opposite of at a glance. Anything the league does not start goes last, in the
+    order `position_cliffs` returned it.
+    """
+    if cliffs is None or cliffs.empty:
+        return []
+
+    slots = list(league["slots"])
+    order = cliffs["position"].map(
+        lambda position: slots.index(position) if position in slots else len(slots)
+    )
+    lines = ["", "Depth to the next cliff"]
+    for row in cliffs.assign(_order=order).sort_values("_order", kind="stable").itertuples():
+        lines.append(
+            f"  {row.position:<6}{row.above:>3} above a {row.drop:>6.1f} drop"
+            f"  ·  {row.remaining:>3} left"
+        )
+    return lines
+
+
 def _ranking(picks: dict, degraded: bool, covers_to: int | None) -> list[str]:
     """How the list below was ordered, and — when it is not the good rule — why not.
 
@@ -319,6 +351,7 @@ def render_board(
     marked: list[dict] | tuple = (),
     guidance: dict | None = None,
     position: str | None = None,
+    cliffs: pd.DataFrame | None = None,
 ) -> str:
     """The whole screen as one string.
 
@@ -342,6 +375,12 @@ def render_board(
     `position` is the position the board has been narrowed to, or None for the whole board. It
     names the scope of the candidate list and touches nothing above it — the roster, the warning
     and the opening shape are claims about the draft, not about what the drafter is looking at.
+
+    `cliffs` is what `position_cliffs` returned, or None for a screen without it. Like the opening
+    shape it sits beside the ranking and reorders nothing, and like the ranking it covers every
+    position whatever the board is narrowed to: depth is the reason to look away from the position
+    being shown, so a narrowed screen reporting only that position's depth could never answer the
+    question it is read for.
     """
     marked = list(marked)
     lines = [_header(picks, league, marked)]
@@ -349,5 +388,6 @@ def render_board(
     lines += _marked(marked)
     lines += _roster(picks["roster"], league)
     lines += _guidance(guidance)
+    lines += _cliffs(cliffs, league)
     lines += _candidates(candidates, picks, limit, degraded, covers_to, position)
     return "\n".join(lines)

--- a/tests/test_draft_cliffs.py
+++ b/tests/test_draft_cliffs.py
@@ -1,0 +1,162 @@
+"""Issue #29, user story 18: telling a thin position from a deep one, at a glance.
+
+Cost of waiting already prices the drop behind *one player* — that is half of what it multiplies.
+What it cannot show is the shape of a whole position, because it hands back one number per player
+and the drafter reading the top of the list sees only the players who happen to rank highest
+across every position at once. "Are there six more backs like this one, or is this the last of
+them" is a question the ranking answers nowhere.
+
+## What a cliff is here, since the ticket did not say
+
+The largest drop in points over replacement between two consecutive players still available at a
+position, looked for among the next few rather than the whole tail. The count above it is the
+answer: three left before it gets materially worse, or eleven.
+
+Two decisions inside that are worth stating, because they are the ones these cases pin down.
+
+**The drop below the last player at a position is his own points over replacement.** Not a special
+case bolted on — points over replacement is measured against a freely available player, so a
+fallback below the last player at a position is replacement level, which is zero by construction.
+`waiting._cost_within_position` already floors its expectation at zero for exactly this reason.
+It makes the last startable quarterback the biggest cliff on the board, which is correct.
+
+**A cliff is only looked for among the next few.** A twenty-point step between the fortieth and
+forty-first receiver is not a fact about this pick, and reporting the largest drop in the whole
+remaining tail would find it and say "39 left" — a true number that answers nothing. The lookahead
+is a parameter here so these cases can state the boundary rather than assume it.
+"""
+
+import pandas as pd
+
+from src.draft.cliff import position_cliffs
+
+
+def remaining(*rows: tuple) -> pd.DataFrame:
+    """Who is left, as the ranking hands them over: a position and a price, in value order."""
+    return pd.DataFrame(
+        [
+            {
+                "player_id": f"00-000000{index}",
+                "player_name": f"Player {index}",
+                "position": position,
+                "team": "SF",
+                "points_over_replacement": value,
+            }
+            for index, (position, value) in enumerate(rows, start=1)
+        ],
+        columns=["player_id", "player_name", "position", "team", "points_over_replacement"],
+    )
+
+
+def row_for(cliffs: pd.DataFrame, position: str) -> dict:
+    """The one row about one position, so a claim is about that position alone."""
+    matches = cliffs.loc[cliffs["position"] == position]
+    assert len(matches) == 1, f"expected one row for {position}, got {len(matches)}"
+    return matches.iloc[0].to_dict()
+
+
+# 1. The whole of the story: how many are left before the drop, and how big the drop is.
+def test_the_cliff_is_the_largest_drop_and_the_count_is_who_is_above_it():
+    cliffs = position_cliffs(
+        remaining(("RB", 100.0), ("RB", 95.0), ("RB", 90.0), ("RB", 40.0), ("RB", 38.0)),
+        lookahead=5,
+    )
+    back = row_for(cliffs, "RB")
+
+    assert back["above"] == 3
+    assert back["drop"] == 50.0
+
+
+# 2. The reading the block exists for. Same count above the cliff, opposite meaning: one position
+# falls off a shelf and the other slopes, and only the size of the drop says which.
+def test_a_deep_position_and_a_thin_one_are_told_apart_by_the_size_of_the_drop():
+    cliffs = position_cliffs(
+        remaining(
+            ("RB", 100.0), ("RB", 99.0), ("RB", 98.0), ("RB", 90.0), ("RB", 89.0),
+            ("WR", 100.0), ("WR", 99.0), ("WR", 98.0), ("WR", 40.0), ("WR", 39.0),
+        ),
+        lookahead=4,
+    )
+
+    assert row_for(cliffs, "RB")["above"] == row_for(cliffs, "WR")["above"] == 3
+    assert row_for(cliffs, "WR")["drop"] > row_for(cliffs, "RB")["drop"]
+
+
+# 3. The last one at a position is the biggest cliff there is, and falls out of the same rule
+# rather than a special case: below him is replacement level, which is zero by construction.
+def test_the_last_player_at_a_position_is_a_cliff_to_replacement_level():
+    cliffs = position_cliffs(remaining(("TE", 41.0)), lookahead=5)
+    end = row_for(cliffs, "TE")
+
+    assert end["above"] == 1
+    assert end["drop"] == 41.0
+
+
+# 4. The boundary the lookahead exists for. The largest drop in the whole tail is at the far end;
+# reporting it would say "4 left" about a position whose next real step down is two players away.
+def test_a_cliff_past_the_lookahead_is_not_the_one_reported():
+    cliffs = position_cliffs(
+        remaining(("WR", 100.0), ("WR", 80.0), ("WR", 78.0), ("WR", 76.0), ("WR", 10.0)),
+        lookahead=3,
+    )
+    wideout = row_for(cliffs, "WR")
+
+    assert wideout["above"] == 1
+    assert wideout["drop"] == 20.0
+
+
+# 5. Two equal drops is a real board, not a contrived one — the near one is the one being decided.
+def test_equal_drops_report_the_nearer_cliff():
+    cliffs = position_cliffs(
+        remaining(("RB", 100.0), ("RB", 80.0), ("RB", 60.0), ("RB", 55.0), ("RB", 50.0)),
+        lookahead=2,
+    )
+
+    assert row_for(cliffs, "RB")["above"] == 1
+
+
+# 6. Depth is a fact about who is left, so a drafted player is not part of it. Driven through the
+# frame the ranking actually hands over rather than asserted about a set.
+def test_a_player_already_taken_is_not_part_of_his_position_s_depth():
+    board = remaining(("QB", 150.0), ("QB", 60.0), ("QB", 55.0))
+    without_the_best = position_cliffs(board.iloc[1:], lookahead=5)
+
+    assert row_for(without_the_best, "QB")["above"] == 2
+    assert row_for(without_the_best, "QB")["drop"] == 55.0
+
+
+# 7. Every position, not only the interesting ones: "how deep is tight end" is a question asked by
+# a drafter who has not been shown a reason to ask it.
+def test_every_position_still_on_the_board_gets_a_row():
+    cliffs = position_cliffs(
+        remaining(("QB", 90.0), ("RB", 80.0), ("WR", 70.0), ("TE", 60.0)), lookahead=5
+    )
+
+    assert set(cliffs["position"]) == {"QB", "RB", "WR", "TE"}
+
+
+# 8. A position nobody is left at is not depth information, and a zero in a column of counts reads
+# as one. It is absent, and the screen says nothing about it.
+def test_a_position_with_nobody_left_is_not_reported():
+    assert position_cliffs(remaining(), lookahead=5).empty
+
+
+# 9. How many are left at all, beside how many are above the cliff — "3 of 4" and "3 of 40" are
+# different boards, and the count above the cliff is the same in both.
+def test_the_number_left_at_the_position_is_reported_beside_the_count():
+    cliffs = position_cliffs(
+        remaining(("RB", 100.0), ("RB", 40.0), ("RB", 38.0), ("RB", 36.0)), lookahead=5
+    )
+
+    assert row_for(cliffs, "RB")["remaining"] == 4
+
+
+# 10. Read by every other surface on the screen: sorting or cutting it here would silently change
+# what the ranking, the roster and the guidance are computed from.
+def test_the_frame_handed_in_is_not_modified():
+    frame = remaining(("RB", 100.0), ("RB", 40.0), ("WR", 90.0))
+    before = frame.copy()
+
+    position_cliffs(frame, lookahead=5)
+
+    pd.testing.assert_frame_equal(frame, before)

--- a/tests/test_draft_render.py
+++ b/tests/test_draft_render.py
@@ -534,3 +534,83 @@ def test_narrowing_the_board_leaves_the_roster_and_the_opening_shape_alone():
 
     assert section(narrowed, "My roster") == section(full, "My roster")
     assert section(narrowed, "Opening shape") == section(full, "Opening shape")
+
+
+def cliffs(*rows: tuple) -> pd.DataFrame:
+    """What `position_cliffs` hands over: one row per position still on the board."""
+    return pd.DataFrame(
+        [
+            {"position": position, "above": above, "drop": drop, "remaining": left}
+            for position, above, drop, left in rows
+        ],
+        columns=["position", "above", "drop", "remaining"],
+    )
+
+
+# Issue #29, user story 18: how many are left before the next real drop, position by position.
+#
+# The block answers a question the ranking cannot, because the ranking hands back one number per
+# player and the eye reading the top of it sees whichever positions happen to rank highest. So
+# what is asserted here is that the two numbers a drafter compares — the count above the cliff and
+# the size of the drop — are both on the line, and that the block reads in the order the rest of
+# the screen already uses.
+
+
+# 37. Both numbers, because either alone is unreadable: three left is fine behind a four-point
+# step and an emergency behind a forty-point one.
+def test_each_position_shows_how_many_are_left_above_the_drop_and_how_big_it_is():
+    out = render_board(
+        candidates(), ingested(), LEAGUE,
+        cliffs=cliffs(("QB", 3, 80.4, 12), ("RB", 6, 8.2, 41)),
+    )
+    passer = line_naming(out, "QB ")
+
+    assert "3" in passer and "80.4" in passer
+
+
+# 38. The count of who is left at all, beside the count above the cliff. "3 of 4" and "3 of 40"
+# are different boards, and the first number is the same in both.
+def test_a_position_shows_how_many_are_left_at_it_in_total():
+    out = render_board(
+        candidates(), ingested(), LEAGUE, cliffs=cliffs(("QB", 3, 80.4, 12))
+    )
+    assert "12" in line_naming(out, "QB ")
+
+
+# 39. The same order the roster block reads in. A block whose rows moved between ticks would be
+# re-read from the top every time, which is the opposite of at a glance.
+def test_the_positions_read_in_the_order_the_league_starts_them():
+    out = render_board(
+        candidates(), ingested(), LEAGUE,
+        cliffs=cliffs(("DST", 1, 5.0, 20), ("RB", 6, 8.2, 41), ("QB", 3, 80.4, 12)),
+    )
+    rows = section(out, "Depth")
+
+    assert [row.split()[0] for row in rows] == ["QB", "RB", "DST"]
+
+
+# 40. A screen with nothing to say about depth says nothing, rather than an empty heading.
+def test_a_screen_with_no_cliffs_says_nothing_about_depth():
+    assert "Depth" not in render_board(candidates(), ingested(), LEAGUE)
+    assert "Depth" not in render_board(candidates(), ingested(), LEAGUE, cliffs=cliffs())
+
+
+# 41. Beside the ranking, above it, and changing nothing about it — the same rule the opening
+# shape follows, for the same reason: a drafter has to be able to overrule what he is shown.
+def test_depth_sits_above_the_candidate_list_and_does_not_reorder_it():
+    rows = [
+        {"player_id": "00-0000001", "player_name": "A Passer", "position": "QB"},
+        {"player_id": "00-0000002", "player_name": "A Back", "position": "RB"},
+    ]
+    plain = render_board(candidates(*rows), ingested(), LEAGUE)
+    with_depth = render_board(
+        candidates(*rows), ingested(), LEAGUE, cliffs=cliffs(("QB", 3, 80.4, 12))
+    )
+
+    assert with_depth.index("Depth") < with_depth.index("Best available")
+    assert available(with_depth) == available(plain)
+
+
+def available(out: str) -> str:
+    """The candidate list out of one screen — the part the depth block must not touch."""
+    return out.split("Best available")[-1]

--- a/tests/test_draft_render.py
+++ b/tests/test_draft_render.py
@@ -556,6 +556,17 @@ def cliffs(*rows: tuple) -> pd.DataFrame:
 # the screen already uses.
 
 
+def depth_row(out: str, position: str) -> str:
+    """The one depth line about one position.
+
+    Found inside the depth section rather than anywhere on screen: the roster block above names
+    positions too, so `QB` alone matches two lines that mean entirely different things.
+    """
+    rows = [row for row in section(out, "Depth") if row.split()[0] == position]
+    assert len(rows) == 1, f"expected one depth row for {position}, got {rows}"
+    return rows[0]
+
+
 # 37. Both numbers, because either alone is unreadable: three left is fine behind a four-point
 # step and an emergency behind a forty-point one.
 def test_each_position_shows_how_many_are_left_above_the_drop_and_how_big_it_is():
@@ -563,7 +574,7 @@ def test_each_position_shows_how_many_are_left_above_the_drop_and_how_big_it_is(
         candidates(), ingested(), LEAGUE,
         cliffs=cliffs(("QB", 3, 80.4, 12), ("RB", 6, 8.2, 41)),
     )
-    passer = line_naming(out, "QB ")
+    passer = depth_row(out, "QB")
 
     assert "3" in passer and "80.4" in passer
 
@@ -574,7 +585,7 @@ def test_a_position_shows_how_many_are_left_at_it_in_total():
     out = render_board(
         candidates(), ingested(), LEAGUE, cliffs=cliffs(("QB", 3, 80.4, 12))
     )
-    assert "12" in line_naming(out, "QB ")
+    assert "12" in depth_row(out, "QB")
 
 
 # 39. The same order the roster block reads in. A block whose rows moved between ticks would be

--- a/tests/test_draft_watch.py
+++ b/tests/test_draft_watch.py
@@ -351,3 +351,18 @@ def test_a_typed_position_narrows_the_board_on_a_tick_the_poll_failed():
     assert len(drawn) == 2
     assert "Charlie Ender" not in available(drawn[1])
     assert "Bravo Wideout" in available(drawn[1])
+
+
+# 29. Issue #29, user stories 17 and 18 meeting. Depth is the reason to look away from the
+# position being shown, so narrowing the board must not narrow it: a screen showing quarterbacks
+# that reported only quarterback depth could never answer "should I be taking a back instead".
+def test_depth_covers_every_position_even_when_the_board_is_narrowed_to_one():
+    payload = [pick(1, "4034")]
+    written = run_typed(payload, payload, typed=[[], ["wr"]])
+
+    narrowed = boards(written)[1]
+    assert "Depth" in narrowed, "the narrowed board reported no depth at all"
+    depth = narrowed.split("Depth")[1].split("Best available")[0]
+
+    assert "Charlie Ender" not in available(narrowed)
+    assert "WR" in depth and "TE" in depth


### PR DESCRIPTION
Closes user story 18 of #29 — the one story the original test enumeration missed, which is how it came to be built nowhere. The enumerated cases jump from the position filter (27) to the roster slots (28).

**Stacked on #54.** Base is `feat/draft-position-filter`; GitHub will retarget this to `main` when that merges. Both touch `render_board`, so stacking avoids a conflict.

## Why

Cost of waiting already prices the drop behind *one player* — that is half of what it multiplies. But it hands back one number per player, and a drafter reading the top of that list sees whichever positions happen to rank highest across the whole board at once. "Are there six more backs like this one, or is this the last of them" is a question about a position rather than a player, and nothing on the screen answered it.

## What a cliff is

The ticket never said, so this defines it: the largest drop in points over replacement between two consecutive players still available at a position, looked for among the next few rather than the whole tail. The count above it is the answer, and both numbers go on screen — three left is comfortable behind a four-point step and an emergency behind a forty-point one.

Two consequences fall out of the definition rather than being special-cased:

- **Below the last player at a position is replacement level**, which is zero by construction, so the drop below the last quarterback is his own points over replacement. `waiting._cost_within_position` floors its expectation at zero for the same reason. That makes the last startable player at a position the biggest cliff on the board, which is correct and is when a drafter most needs telling.
- **A cliff past the lookahead is not reported.** The largest drop in a position's whole remaining tail is usually somewhere in the forties; reporting it would say "39 left" — true, and an answer to nothing being decided now. Equal drops report the nearer, for the same reason.

## What it is not

Not part of the ranking. It sits above the candidate list and reorders nothing, the way the opening shape does. And it covers **every position even when the board is narrowed to one** — depth is the reason to look away from the position being shown, so a screen filtered to quarterbacks that reported only quarterback depth could never answer the question it is read for.

## Tests

16 new cases written before the code: 10 on `position_cliffs`, 5 on the screen, 1 on the loop for the interaction with #54. Suite is 195 → 211, all passing.

One committed test had a broken *locator* — `line_naming(out, "QB ")` matched the roster block's `QB` row as well as the depth row. The assertion is unchanged; a `depth_row` helper now scopes the search to the depth section.

Also adds a **Cliff** entry to `CONTEXT.md`, since the word is now on a screen and the glossary already warns off `tier`.

Verified against the real warehouse and the live draft:

```
Depth to the next cliff
  QB      1 above a   48.7 drop  ·  120 left
  RB      2 above a   48.8 drop  ·  136 left
  WR      4 above a   24.3 drop  ·  200 left
  TE      2 above a   23.0 drop  ·  123 left
  K       4 above a    7.1 drop  ·   44 left
  DST     4 above a    8.3 drop  ·   32 left
```

Josh Allen at 160.5 with the next quarterback at 111.9 is the 48.7; Bijan and Gibbs at 178 with the third back at 129.3 is the 48.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)