### PR TITLE
feat: cut the default board to fifteen rows so it fits one screen

### DIFF
--- a/src/draft/live.py
+++ b/src/draft/live.py
@@ -124,9 +124,10 @@ USERNAME = "commonfox"
 # last of the preseason news in it — the window in which starters are named and seasons end.
 MAX_WAREHOUSE_AGE = timedelta(hours=24)
 
-# About a screenful. The count above the table always names the total, so a cut list never reads
-# as a short one, and `--limit` is there for looking deeper.
-DEFAULT_LIMIT = 30
+# About a screenful. A board that has to be scrolled is a board that gets skimmed, and the
+# scrolling is what the first mock rehearsal turned up. The count above the table always names
+# the total, so a cut list never reads as a short one, and `--limit` is there for looking deeper.
+DEFAULT_LIMIT = 15
 
 # A draft night has a pick clock. A request that hangs is worse than one that fails, because a
 # failure is reported and retried on the next tick and a hang is a screen that has stopped.


### PR DESCRIPTION
`DEFAULT_LIMIT` in `src/draft/live.py` drops from 30 to 15.

The first live mock rehearsal (draft `1399447972411912192`) read the board under a pick clock and had to scroll it — a table that gets scrolled is a table that gets skimmed. Fifteen rows is what fits.

Nothing is lost: the count line above the table still names the total ("Best available — 12 of 651"), so a shorter list reads as a cut of a larger board rather than as a short board, and `--limit` is still there for looking deeper. The `--limit` help string interpolates the constant, so it followed automatically (`default 15`).

The comment above the constant now records the rehearsal that prompted the cut.

No test asserted on 30, and none was added: this is a tuning constant, and `render_board`'s row-count behaviour is already covered by `test_only_the_asked_for_number_of_candidates_are_shown`, which passes `limit` explicitly. Suite is green (178 passed).

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)