### PR TITLE
feat: watch a draft by ID so the tool can rehearse on a Sleeper mock

### DIFF
--- a/src/draft/live.py
+++ b/src/draft/live.py
@@ -3,6 +3,7 @@
     python -m src.draft.live
     python -m src.draft.live --limit 50
     python -m src.draft.live --once
+    python -m src.draft.live --draft-id 1399447972411912192   # a mock, to rehearse on
 
 It resolves my seat from the draft order, reads the picks made so far, subtracts them from the
 board the warehouse built days ago, and prints what is left — then does that again every few
@@ -75,7 +76,11 @@ What it touches, exhaustively:
 ## Nothing is configured by typing
 
 The league ID and season come from `src.silver.sleeper`, so the repo holds one league ID rather
-than two that can disagree. A player's name and a position are the only things ever typed at this
+than two that can disagree. `--draft-id` is the single exception, and it is a draft to *watch*
+rather than a setting: a Sleeper mock carries `league_id: null` and appears in no league's draft
+list, so a rehearsal cannot be reached any other way. It is also the only way the draft on screen
+can be a different shape from the board it is read against, so `prepare` checks the two agree —
+see `seat.check_priced_for`. A player's name and a position are the only things ever typed at this
 tool, and both are resolved against the board rather than configuring anything: one says a player
 is gone, the other says which part of the board to look at, and neither changes a number.
 Everything else — seat, roster, team count, rounds, starting slots — is read out of the draft
@@ -112,7 +117,7 @@ from src.draft.marks import combine, read_mark
 from src.draft.picks import ingest_picks, picks_made
 from src.draft.refresh import fingerprint, status_line
 from src.draft.render import render_board
-from src.draft.seat import resolve_seat
+from src.draft.seat import check_priced_for, resolve_seat
 from src.draft.waiting import rank_by_cost_of_waiting
 from src.query import WAREHOUSE_PATH, q
 from src.silver.sleeper import LEAGUE_ID, SEASON, select_draft
@@ -284,20 +289,63 @@ def load_plans(league_key: str = LEAGUE_KEY) -> pd.DataFrame:
     return plans
 
 
-def prepare() -> dict:
+def load_priced_shape(league_key: str = LEAGUE_KEY) -> dict:
+    """The league shape this board's numbers were priced for, as the build recorded it.
+
+    Read so `check_priced_for` has something to compare a hand-given draft against. The spelling
+    is translated here, at the warehouse boundary, for the same reason `load_survival` renames its
+    column there: nothing above this line should have to know that `league_settings` writes the
+    superflex slot `superflex_slots` while a draft record writes it `slots_super_flex`.
+    """
+    settings = q(
+        """
+        SELECT team_count, qb_slots, rb_slots, wr_slots, te_slots, flex_slots,
+               superflex_slots, k_slots, p_slots, dst_slots
+        FROM league_settings
+        WHERE league_key = ?
+        """,
+        [league_key],
+    )
+    if settings.empty:
+        raise RuntimeError(
+            f"league_settings holds no row for league {league_key!r}, so there is nothing to "
+            "check a draft against. Run scripts/build_warehouse.sh."
+        )
+    row = settings.iloc[0]
+    slots = {
+        "QB": row["qb_slots"], "RB": row["rb_slots"], "WR": row["wr_slots"],
+        "TE": row["te_slots"], "FLEX": row["flex_slots"],
+        "SUPER_FLEX": row["superflex_slots"], "K": row["k_slots"],
+        "P": row["p_slots"], "DST": row["dst_slots"],
+    }
+    return {
+        "team_count": int(row["team_count"]),
+        # Absent rather than zero, matching what `seat._slots` builds from the other side.
+        "slots": {slot: int(n) for slot, n in slots.items() if int(n or 0) > 0},
+    }
+
+
+def prepare(draft_id: str | None = None) -> dict:
     """Everything that cannot change once the draft is under way, read once.
 
     The board and the survival frame were computed by a rebuild days ago; the draft record and the
     seat were settled when the order was drawn. Nothing on the night moves any of them, so the
     loop above carries this rather than re-reading it — see the module docstring on the file lock.
+
+    `draft_id` names a draft directly instead of finding this season's through the league. That is
+    the only way to reach a Sleeper mock, which carries `league_id: null` and so appears in no
+    league's draft list. It is also the only way the draft on screen can disagree with the board it
+    is read against, which is why `check_priced_for` runs below.
     """
-    draft = find_draft(LEAGUE_ID, SEASON)
+    draft = _get(f"/draft/{draft_id}") if draft_id else find_draft(LEAGUE_ID, SEASON)
+    league = resolve_seat(draft, user_id(USERNAME))
+    check_priced_for(league, load_priced_shape())
     return {
         "board": load_board(),
         "survival": load_survival(),
         "plans": load_plans(),
         "draft": draft,
-        "league": resolve_seat(draft, user_id(USERNAME)),
+        "league": league,
     }
 
 
@@ -373,9 +421,11 @@ def starting_position(typed: str | None, board: pd.DataFrame) -> str | None:
     return outcome["position"]
 
 
-def render_once(limit: int = DEFAULT_LIMIT, position: str | None = None) -> str:
+def render_once(
+    limit: int = DEFAULT_LIMIT, position: str | None = None, draft_id: str | None = None
+) -> str:
     """Everything, once: fetch, resolve, subtract, rank, and give back the screen."""
-    context = prepare()
+    context = prepare(draft_id)
     return screen(
         context, fetch_picks(context), limit,
         position=starting_position(position, context["board"]),
@@ -533,17 +583,22 @@ def watch(
         write(f"\n\nstopped at {made} picks made — no pick was ever submitted\n")
 
 
-def main(limit: int = DEFAULT_LIMIT, once: bool = False, position: str | None = None) -> None:
+def main(
+    limit: int = DEFAULT_LIMIT,
+    once: bool = False,
+    position: str | None = None,
+    draft_id: str | None = None,
+) -> None:
     built_at = warehouse_built_at()
     check_recency(built_at, datetime.now())
     built = f"board built {built_at:%Y-%m-%d %H:%M} — read-only, no pick is ever submitted"
 
     if once:
-        print(render_once(limit, position))
+        print(render_once(limit, position, draft_id))
         print(f"\n{built}")
         return
 
-    context = prepare()
+    context = prepare(draft_id)
     print(
         f"{built}\nrefreshing every {REFRESH_SECONDS:.0f}s — type a position to show only it "
         f'("qb", "{ALL}" for everyone), a name to mark him taken by hand, -name to undo, '
@@ -568,10 +623,15 @@ if __name__ == "__main__":
         "--position", default=None,
         help="show only one position (QB, RB, ...); can be changed by typing at the running tool",
     )
+    parser.add_argument(
+        "--draft-id",
+        help="watch this draft instead of the league's — the only way to reach a Sleeper mock, "
+             "which belongs to no league. Refused unless its settings match the board's league.",
+    )
     arguments = parser.parse_args()
 
     try:
-        main(arguments.limit, arguments.once, arguments.position)
+        main(arguments.limit, arguments.once, arguments.position, arguments.draft_id)
     except KeyboardInterrupt:
         # Ctrl-C before the loop starts — during the warehouse read or the first fetch. The loop
         # has its own, which stops cleanly rather than unwinding.

--- a/src/draft/seat.py
+++ b/src/draft/seat.py
@@ -25,6 +25,9 @@ A draft that is not a snake, and a draft whose order has not been drawn yet. Bot
 rather than defaults because the alternative is a pick number that is wrong without looking wrong
 — `next_pick_number` reverses every even round, so against a linear draft it is right in round one
 and wrong from round two onwards, which is the worst shape an error can have on a draft night.
+
+`check_priced_for` refuses a third thing for the same reason, one step later: a draft whose teams
+and starting slots are not the ones the board on screen was priced for.
 """
 
 # Sleeper's own settings keys, mapped onto the slot names `picks.SLOT_ELIGIBILITY` uses. `slots_bn`
@@ -102,3 +105,47 @@ def resolve_seat(draft: dict, user_id: str) -> dict:
         "rounds": int(settings["rounds"]),
         "slots": _slots(settings),
     }
+
+
+def check_priced_for(league: dict, priced: dict) -> None:
+    """Refuse a draft whose shape is not the one the board on screen was priced for.
+
+    Pure. `league` is what `resolve_seat` read out of the draft record; `priced` is the shape the
+    warehouse priced this `league_key` for, as `league_settings` records it.
+
+    Watching a draft found *through* the league made this impossible — the draft and the board
+    came from the same place. A draft ID typed by hand does not: a Sleeper mock is a draft record
+    with `league_id: null` and whatever settings the lobby chose. Read a 12-team 1QB mock against
+    a 14-team superflex board and every number still renders, correctly formatted, priced against
+    a replacement level for a league nobody is drafting in.
+
+    Only what pricing depends on is compared. Team count and starting slots set replacement level;
+    rounds set how deep the draft goes and leave what a player is worth alone, so a ten-round mock
+    off a fifteen-round board is fine and is not mentioned here.
+    """
+    mismatches = []
+
+    if int(league["team_count"]) != int(priced["team_count"]):
+        mismatches.append(
+            f"{league['team_count']} teams, but the board is priced for {priced['team_count']}"
+        )
+
+    theirs, ours = league["slots"], priced["slots"]
+    for slot in sorted(set(theirs) | set(ours)):
+        if int(theirs.get(slot, 0)) != int(ours.get(slot, 0)):
+            mismatches.append(
+                f"{slot}: this draft starts {theirs.get(slot, 0)}, "
+                f"the board is priced for {ours.get(slot, 0)}"
+            )
+
+    if not mismatches:
+        return None
+
+    listed = "\n  ".join(mismatches)
+    raise ValueError(
+        "This draft is not the league the board was priced for:\n  "
+        f"{listed}\n"
+        "Every value on screen comes from a warehouse build for the other shape, and would "
+        "render correctly while being priced against the wrong replacement level. Draft in a "
+        "lobby matching the league, or rebuild the board for this one."
+    )

--- a/tests/test_draft_priced_for.py
+++ b/tests/test_draft_priced_for.py
@@ -1,0 +1,69 @@
+"""Refuse to draft off a board priced for a different league than the one on screen.
+
+The live tool reads `draft_board`, `draft_availability` and `draft_plans` filtered to one
+`league_key` — a board priced for 14-team superflex. Until now the draft it watched was found
+*through* that league, so the two could not disagree. Pointing the tool at a draft ID by hand
+breaks that guarantee: a Sleeper mock is a draft record with no league behind it, and its
+settings are whatever the person who opened the lobby chose.
+
+A 12-team 1QB mock read against a 14-team superflex board is wrong in the way that matters most
+here — every number still renders, nothing looks broken, and the replacement level under all of
+them is for a league nobody is drafting in. That is the same shape of silent error `resolve_seat`
+already refuses for when it will not guess a seat, so it gets the same treatment.
+
+What is compared is what the *pricing* depends on: how many teams there are and what each of them
+starts. Those two set replacement level. Rounds do not — see the last case.
+"""
+
+import pytest
+
+from src.draft.seat import check_priced_for
+
+# The shape the warehouse priced the `sleeper` board for, as `league_settings` records it.
+PRICED = {
+    "team_count": 14,
+    "slots": {"QB": 1, "RB": 2, "WR": 2, "TE": 1, "FLEX": 1, "SUPER_FLEX": 1, "K": 1, "DST": 1},
+}
+
+
+def league(**overrides) -> dict:
+    """What `resolve_seat` returns for a draft record — the mock's own shape."""
+    resolved = {
+        "seat": 1,
+        "roster_id": 1,
+        "team_count": 14,
+        "rounds": 15,
+        "slots": dict(PRICED["slots"]),
+    }
+    return {**resolved, **overrides}
+
+
+# 1. A draft whose shape matches the board it will be read against is allowed through.
+def test_a_matching_draft_passes():
+    assert check_priced_for(league(), PRICED) is None
+
+
+# 2. A different team count is refused, and the message names both numbers so the drafter can
+#    see which side is wrong without opening the lobby settings.
+def test_a_different_team_count_is_refused():
+    with pytest.raises(ValueError) as raised:
+        check_priced_for(league(team_count=12), PRICED)
+    message = str(raised.value)
+    assert "12" in message and "14" in message
+
+
+# 3. A 1QB mock read against a superflex board is refused, naming the slot that differs. This is
+#    the case the guard exists for: superflex is what makes this league draft differently, and a
+#    board priced with it is wrong from the first pick in a league without it.
+def test_a_different_starting_lineup_is_refused():
+    without_superflex = {slot: n for slot, n in PRICED["slots"].items() if slot != "SUPER_FLEX"}
+    with pytest.raises(ValueError) as raised:
+        check_priced_for(league(slots=without_superflex), PRICED)
+    assert "SUPER_FLEX" in str(raised.value)
+
+
+# 4. A shallower or deeper draft is *not* refused. Rounds set how far the draft goes, not what a
+#    player is worth: replacement level falls out of team count and starting slots, both of which
+#    still match. A 10-round mock off a 15-round board prices every player correctly.
+def test_a_different_round_count_is_allowed():
+    assert check_priced_for(league(rounds=10), PRICED) is None


### PR DESCRIPTION
`python -m src.draft.live --draft-id 1399447972411912192` watches a named draft instead of finding this season's through the league.

## Why a flag at all

Everything else about this tool is read rather than typed — seat, roster, team count, rounds, starting slots all come out of the draft record, and the league ID comes from `src.silver.sleeper` so the repo holds one rather than two that can disagree. `--draft-id` is the single exception, and it is a draft to *watch* rather than a setting: a Sleeper mock carries `league_id: null` and so appears in no league's draft list, which is the one place `find_draft` can look. Naming the draft directly is the only way to reach one, and rehearsing on a mock is the only way to find out what the board is like to read under a pick clock before it counts.

## What it breaks, and the guard

Finding the draft *through* the league gave one guarantee for free: the draft on screen and the board it is read against were the same league. A draft ID typed by hand does not. A 12-team 1QB mock read against this league's 14-team superflex board renders every number correctly, nothing looks broken, and every one of them is priced against a replacement level for a league nobody is drafting in — the worst shape an error can have on a draft night.

So `seat.check_priced_for` compares the two shapes and refuses when they differ, naming what differs on both sides so the drafter can see which side is wrong without opening the lobby settings. It compares only what pricing depends on — team count and starting slots, which set replacement level. Rounds are allowed to differ: they set how deep the draft goes, not what a player is worth, so a 10-round mock off a 15-round board is fine and is not mentioned. `live.load_priced_shape` reads the board's side out of `league_settings`, translating the spelling at the warehouse boundary (`superflex_slots` there, `slots_super_flex` in a draft record) so nothing above that line has to know about the difference.

This is the same treatment `resolve_seat` already gives a non-snake draft and an undrawn order: refuse rather than default.

## Tests

`tests/test_draft_priced_for.py`, four cases written against `check_priced_for`, which is pure: a matching draft passes; a different team count is refused with both numbers in the message; a 1QB mock against a superflex board is refused naming `SUPER_FLEX`; a different round count is allowed. Suite is green (182 passed).

## Verified live

Run against a real Sleeper mock: seat 1, roster 1, next pick #1, cost of waiting measured to #28.

That rehearsal is what produced issues #57, #59 and #60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)