### PR TITLE
fix: attribute a mock's picks by seat when they carry no roster

### DIFF
--- a/src/draft/picks.py
+++ b/src/draft/picks.py
@@ -29,6 +29,32 @@ The second is exactly the failure the whole feature exists to prevent, and it co
 unmatched pick is never dropped, never guessed at, and is returned named so the renderer can put
 it on screen. `sleeper_ids.report_unmapped` is the same instinct applied days earlier.
 
+## Whose pick it is, and why that takes two fields
+
+A pick carries `roster_id`, which is the roster it lands on, and `draft_slot`, which is the seat
+that held it. In this league those are not the same number, and `roster_id` is the one that stays
+right under a **traded pick**: the seat is whoever originally held the pick, the roster is whoever
+actually made it.
+
+So `roster_id` decides it — except that a Sleeper **mock** has no league behind it, so there are no
+rosters, and every pick comes back with `roster_id: null`. All 210 of them, in the mock this was
+found in. The draft record still carries a `slot_to_roster_id` (an identity map), so `resolve_seat`
+returns a roster ID quite happily and nothing refuses; it is simply a number no pick will ever
+match. My roster then stays empty for a whole draft, and `composition`, which reads `mine`,
+believes no opening picks have been made and keeps recommending the opening band at pick 197.
+
+Hence: `roster_id` when the pick carries one, `draft_slot == seat` when it does not. That order
+matters and is not interchangeable. Reading the seat first would attribute a traded pick to the
+manager who used to hold it, silently, which is the same shape of failure `seat.py`'s docstring
+warns about for `draft_order` and `slot_to_roster_id`.
+
+The fallback cannot do everything the primary does: in a mock with pick trading on, a pick traded
+between seats is attributed to the seat that held it, because a mock carries nothing that says
+otherwise. That is the limit of what a league-less draft can support, not a decision taken here.
+
+A hand-marked player carries neither field, and so is never mine — which is exactly what `marks`
+promises. A mark says a player is gone, never whose he is.
+
 ## Snake arithmetic
 
 Rounds alternate direction, so a seat's pick number depends on the round's parity:
@@ -108,6 +134,20 @@ def _picked_name(entry: dict) -> str | None:
     metadata = entry.get("metadata") or {}
     parts = [metadata.get("first_name"), metadata.get("last_name")]
     return " ".join(part for part in parts if part) or None
+
+
+def _is_mine(entry: dict, league: dict) -> bool:
+    """Whether one pick belongs to the drafter — by roster where there is one, else by seat.
+
+    See the module docstring for why the order is this way round and not the other: `roster_id` is
+    what survives a traded pick, and `draft_slot` is all a mock has.
+    """
+    roster_id = entry.get("roster_id")
+    if roster_id is not None:
+        return roster_id == league["roster_id"]
+
+    draft_slot = entry.get("draft_slot")
+    return draft_slot is not None and draft_slot == league["seat"]
 
 
 def picks_made(picks: list[dict]) -> int:
@@ -234,7 +274,7 @@ def ingest_picks(picks: list[dict], board: pd.DataFrame, league: dict) -> dict:
             continue
 
         taken.add(row["player_id"])
-        if entry.get("roster_id") == league["roster_id"]:
+        if _is_mine(entry, league):
             mine.append(row)
 
     made = picks_made(ordered)

--- a/tests/test_draft_picks.py
+++ b/tests/test_draft_picks.py
@@ -354,3 +354,122 @@ def test_my_own_picks_are_reported_in_draft_order_with_their_positions():
         "My Receiver", "My Quarterback"
     ]
     assert [player["position"] for player in result["mine"]] == ["WR", "QB"]
+
+
+# Issue #59: through a whole 210-pick mock the roster panel stayed empty, because every pick in a
+# mock carries `roster_id: null`. There is no league behind a mock, so there are no rosters for
+# picks to land on — but `slot_to_roster_id` is still populated (an identity map), so `resolve_seat`
+# returns a roster ID that nothing will ever match. `draft_slot` is populated on every mock pick
+# and identifies the seat, so it is the fallback.
+#
+# It is emphatically the fallback and not the primary. `roster_id` is what survives a **traded
+# pick**: when a pick has been traded, `draft_slot` is the seat that originally held it and
+# `roster_id` is the manager who actually made it. Reading `draft_slot` first would hand a traded
+# pick to the wrong manager, quietly. Case D below is the one that pins the precedence down.
+
+
+def mock_pick(sleeper_id: str, pick_no: int, draft_slot: int, **metadata) -> dict:
+    """One pick as a Sleeper *mock* hands it back: no roster at all, the seat in `draft_slot`.
+
+    Verified against every one of the 210 picks of mock draft 1399447972411912192, where
+    `roster_id` is null throughout and the fifteen picks at `draft_slot` 1 are exactly seat 1's
+    snake sequence — 1, 28, 29, 56, 57 and so on.
+    """
+    return {**pick(sleeper_id, pick_no, roster_id=None, **metadata), "draft_slot": draft_slot}
+
+
+MY_SEAT = 1
+ANOTHER_SEAT = 7
+
+
+# C1. A pick carrying my roster ID is mine, whatever seat it came from. Unchanged behaviour,
+#     restated here because the fallback must not disturb it.
+def test_a_pick_carrying_my_roster_id_is_still_mine():
+    result = ingest_picks(
+        [pick("4034", pick_no=1, roster_id=MY_ROSTER)],
+        board(ONE_BACK),
+        league(seat=MY_SEAT, roster_id=MY_ROSTER),
+    )
+
+    assert [player["player_name"] for player in result["mine"]] == ["My Back"]
+    assert players_in(result["roster"], "RB") == ["My Back"]
+
+
+# C2. A pick with no roster ID at all, made from my seat, is mine.
+#
+#     This is the mock, and the whole symptom: fifteen picks made from seat 1 and a roster panel
+#     that stayed empty for all 210. `mine` is asserted as well as the roster frame because it is
+#     what `composition_guidance` reads — an empty `mine` is what had it recommending the opening
+#     band at pick 197.
+def test_a_pick_with_no_roster_id_from_my_seat_is_mine():
+    result = ingest_picks(
+        [
+            mock_pick("4034", pick_no=1, draft_slot=MY_SEAT),
+            mock_pick("5849", pick_no=2, draft_slot=ANOTHER_SEAT, position="WR"),
+            mock_pick("7564", pick_no=28, draft_slot=MY_SEAT, position="TE"),
+        ],
+        board(
+            ONE_BACK,
+            {"player_id": "00-0000002", "sleeper_id": "5849", "player_name": "Their Receiver",
+             "position": "WR"},
+            {"player_id": "00-0000003", "sleeper_id": "7564", "player_name": "My End",
+             "position": "TE"},
+        ),
+        league(seat=MY_SEAT, roster_id=MY_ROSTER),
+    )
+
+    assert [player["player_name"] for player in result["mine"]] == ["My Back", "My End"]
+    assert players_in(result["roster"], "RB") == ["My Back"]
+    assert players_in(result["roster"], "TE") == ["My End"]
+    # Everyone drafted is still off the board, mine and theirs alike — the fallback decides
+    # whose a pick is, never whether it happened.
+    assert result["taken"] == {"00-0000001", "00-0000002", "00-0000003"}
+
+
+# C3. A pick with no roster ID, made from somebody else's seat, is not mine.
+def test_a_pick_with_no_roster_id_from_another_seat_is_not_mine():
+    result = ingest_picks(
+        [mock_pick("4034", pick_no=1, draft_slot=ANOTHER_SEAT)],
+        board(ONE_BACK),
+        league(seat=MY_SEAT, roster_id=MY_ROSTER),
+    )
+
+    assert result["mine"] == []
+    assert players_in(result["roster"], "RB") == []
+    assert result["taken"] == {"00-0000001"}
+
+
+# C4. A pick carrying somebody else's roster ID but *my* draft slot is not mine.
+#
+#     The traded pick, and the case that proves the precedence is the right way round: I once held
+#     this slot, another manager holds the pick now and made it. Read `draft_slot` first and his
+#     player lands on my roster while the board looks entirely plausible — which is the failure
+#     `seat.py`'s docstring warns about for `draft_order` and `slot_to_roster_id`.
+def test_a_traded_pick_belongs_to_the_roster_that_made_it_not_to_the_seat():
+    result = ingest_picks(
+        [{**pick("4034", pick_no=1, roster_id=ANOTHER_ROSTER), "draft_slot": MY_SEAT}],
+        board(ONE_BACK),
+        league(seat=MY_SEAT, roster_id=MY_ROSTER),
+    )
+
+    assert result["mine"] == []
+    assert players_in(result["roster"], "RB") == []
+    assert result["taken"] == {"00-0000001"}
+
+
+# C5. A hand-marked player is gone, and is never mine.
+#
+#     `marks.as_picks` gives an entry no roster and no pick number, and it has never carried a
+#     draft slot: a mark says a player is *gone*, never whose he is. With the fallback in place
+#     that has to stay true — an entry with neither identifier must not fall through to my seat.
+UNCLAIMED_HAND_MARK = {"player_id": "4034", "roster_id": None, "pick_no": None, "metadata": {}}
+
+
+def test_a_hand_marked_player_is_gone_but_never_mine():
+    result = ingest_picks(
+        [UNCLAIMED_HAND_MARK], board(ONE_BACK), league(seat=MY_SEAT, roster_id=MY_ROSTER)
+    )
+
+    assert result["taken"] == {"00-0000001"}
+    assert result["mine"] == []
+    assert players_in(result["roster"], "RB") == []


### PR DESCRIPTION
Closes #59.

## What was wrong

Every pick in a Sleeper mock carries `roster_id: null` — there is no league behind a mock, so there are no rosters for picks to land on. Confirmed against all 210 picks of draft `1399447972411912192`:

```
picks: 210   roster_id: Counter({'None': 210})
draft_slot counts: [(1, 15), (2, 15), ... (14, 15)]
```

The record's `slot_to_roster_id` is still populated (an identity map), so `resolve_seat` returns `roster_id: 1` and nothing refuses. It is just a number no pick will ever match. My roster stayed empty for the whole draft, and `composition_guidance` — which reads `mine` — believed no opening picks had been made and kept recommending the opening band at pick 197.

## The fix

`roster_id` when the pick carries one, `draft_slot == seat` when it does not.

That order is the point. `roster_id` is what survives a **traded pick**: `draft_slot` is the seat that originally held the pick, `roster_id` is the manager who actually made it. This mock has `mock_traded_picks: on`, and the real league can trade picks too — reading the seat first would hand a traded pick to the wrong manager, quietly. The same fallback also covers a real draft where a pick arrives before Sleeper has assigned a roster.

## Not `picked_by`

The ticket's own analysis found my picks via `picked_by`, so it is worth saying why it is not the fallback: in this mock it is the empty string on 195 of the 210 picks, every one made by a bot.

```
picked_by: [('', 195), ('1154199555601219584', 15)]
```

`draft_slot` is populated on all 210.

## Tests

The ticket's five cases, committed before the fix. Only case 2 was red; the other four are the guards the fix must not trip — case 4, another manager's roster on my old draft slot, is what makes this more than a one-line swap.

## Verified

`python -m src.draft.live --draft-id 1399447972411912192 --once` against the real mock:

```
seat 1 of 14  ·  210 picks made  ·  draft complete

My roster — roster 1
  QB          1/1  Josh Allen
  RB          2/2  Chase Brown, Travis Etienne
  WR          2/2  Parker Washington, Michael Pittman
  TE          1/1  Jake Ferguson
  FLEX        1/1  Bucky Irving
  SUPER_FLEX  1/1  Bo Nix
  K           1/1  Will Reichard
  DST         1/1  DET
  BENCH         5  Jaylen Warren, Khalil Shakir, ...

Opening shape — withdrawn
  the plan table covers the first 5 rounds and says nothing about the picks that follow
```

All fifteen of seat 1's picks, and the opening shape correctly withdrawn rather than stuck at `0 of 5`. Full suite: 244 passed.

## On the ticket's "also worth checking"

Left alone deliberately, with reasoning in the issue thread: an identity `slot_to_roster_id` is a false-positive-prone tell, since a real league can legitimately have seat N on roster N. The unambiguous signature of a league-less draft is top-level `league_id: null`, which `live.py` and `check_priced_for` already document — and with the fallback in place there is no longer a failure for a warning to guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
