### PR TITLE
fix: read a dropped survival row as gone, not as unknown

### DIFF
--- a/src/draft/waiting.py
+++ b/src/draft/waiting.py
@@ -69,10 +69,11 @@ The denominator starts one past the turn being decided because that turn is *min
 one passing: my own pick cannot be part of the hazard a player has to survive, or the tool charges
 me for the chance that I take him myself.
 
-At the turn the two picks are adjacent, numerator and denominator are the same pick, and the ratio
-is one: nothing costs anything to wait for, because there is no gap. Read off the raw column
-instead, De'Von Achane shows a 9% survival probability at pick 29 and a large cost of waiting from
-a seat that is about to pick twice in a row.
+At the turn the two picks are adjacent and there is no gap at all: nothing costs anything to wait
+for, and that holds for every player on the board rather than only the ones the ratio can be taken
+for. Zero picks by other people is certainty, whether or not the table has ever priced him. Read
+off the raw column instead, De'Von Achane shows a 9% survival probability at pick 29 and a large
+cost of waiting from a seat that is about to pick twice in a row.
 
 ## Three kinds of missing, and only one of them is missing
 
@@ -83,16 +84,23 @@ certain. The three cases:
 
 - **No row at the pick I am waiting to, but rows elsewhere.** He is gone. `p_survives` is 0, and
   waiting costs the full drop to whoever is behind him.
-- **No row at the pick the gap opens on.** The table already had him gone, and yet here he sits.
-  The conditional's denominator is zero, the model has been overtaken by events, and there is no
-  honest number to put in its place.
+- **No row at the pick the gap opens on.** The table had him gone *before* the gap even opened,
+  and yet here he sits. Same answer, and for the same reason: the warehouse computed a zero and
+  then discarded the row for being too small, so the absence *is* that zero rather than a hole
+  where one should be. `p_survives` is 0 and passing on him costs the full drop.
 - **No row anywhere.** No ADP, so no distribution, so nothing to say — the rookies and camp bodies
-  the board carries on its depth arm rather than its market arm.
+  the board carries on its depth arm rather than its market arm. This case alone stays missing:
+  `survival_known` is False, nothing is guessed, and he is ranked by value.
 
-The last two are the same answer: `survival_known` is False, both numbers are missing rather than
-guessed, and he is ranked by value at the end of the list. A missing probability is never defaulted
-to a number, and never enters anyone else's fallback expectation either — a player who cannot be
-weighted cannot be counted on.
+Reading the second case as ignorance is the bug in #70. A NaN in the primary sort key lands below
+every player who has a number, so the value tiebreak is never reached — which put Jalen Hurts
+219th of 947 at a live 2.14 while he sat there with the second-highest value on the board. The
+players it hid were precisely the fallers, which is the one thing a live board exists to catch.
+
+A missing probability is still never defaulted to a number, and never enters anyone else's
+fallback expectation either — a player who cannot be weighted cannot be counted on. A zero is not
+that: it is a weight, and it says a player certain to be gone is nobody's fallback, which the walk
+handles by leaving the expectation past him where it was.
 
 ## Vocabulary
 
@@ -130,23 +138,33 @@ def _survival_probabilities(
     """P(still there at `wait_to` | still there when the gap opens), or NaN where it cannot be said.
 
     `gap_starts` is one past the turn being decided: the first pick somebody else makes, and so the
-    first one that can take the player away.
+    first one that can take the player away. When it is `wait_to` itself the seat picks twice in a
+    row, nobody selects in between, and survival is certain for every player on the board —
+    including the ones the table has never had an opinion about, whose certainty here is
+    arithmetic rather than a probability anybody modelled.
     """
+    if wait_to == gap_starts:
+        return pd.Series(1.0, index=player_ids.index, dtype="float64")
+
     covered = set(survival["player_id"])
     at_next = _at_pick(survival, wait_to)
     at_now = _at_pick(survival, gap_starts)
 
     probabilities = []
     for player_id in player_ids:
-        denominator = at_now.get(player_id)
-        if player_id not in covered or not denominator:
-            # Either the model never covered him, or it had him gone before the gap even opens and
-            # has been overtaken by the fact that he is still sitting on the board.
+        if player_id not in covered:
+            # No ADP anywhere, so no distribution and nothing to say. The one genuinely missing
+            # number of the three, and the only one that stays missing.
             probabilities.append(np.nan)
             continue
-        # An absent numerator is a probability under the table's floor or past his observed range.
-        # Both mean gone, which is a number, not a gap.
-        probabilities.append(min(at_next.get(player_id, 0.0) / denominator, 1.0))
+        # An absent probability is one under the table's floor or past his observed range, and it
+        # means the same thing at whichever end of the ratio it goes missing: gone. A dropped
+        # denominator says the market had him taken before the gap even opened, and a player the
+        # market says is already gone does not last another gap of picks.
+        denominator = at_now.get(player_id)
+        probabilities.append(
+            0.0 if not denominator else min(at_next.get(player_id, 0.0) / denominator, 1.0)
+        )
     return pd.Series(probabilities, index=player_ids.index, dtype="float64")
 
 

--- a/tests/test_draft_waiting.py
+++ b/tests/test_draft_waiting.py
@@ -353,30 +353,131 @@ def test_a_player_the_table_drops_at_my_pick_is_gone_rather_than_unknown():
     assert faller["cost_of_waiting"] == pytest.approx(60.0)
 
 
-def test_a_player_the_table_already_had_gone_gets_no_probability_at_all():
-    """The other side of that: the model has been overtaken by events, so it has nothing to say.
+def test_a_player_the_table_already_had_gone_is_gone_rather_than_unknown():
+    """The deep end of the rule above: the table wrote him off before the gap even opened.
 
-    A player with no row at the pick about to be made is one the table says is *already* gone —
-    yet here he sits on the board. The conditional has a zero denominator, and there is no honest
-    number to put in its place, so he is flagged like anyone else the model does not cover.
+    A player with no row at the pick the gap opens on is one the table had gone *already* — and
+    yet here he sits on the board. The conditional's denominator is missing, which reads at first
+    like nothing to divide by. It is not. The warehouse computed a zero for him and then dropped
+    the row for falling under its own floor, which is the same thing it does on the numerator side
+    and means the same thing here: gone.
+
+    Reading that absence as a gap is what put Jalen Hurts 219th of 947 in a live mock while he sat
+    available at 2.14 with the second-highest value on the board (#70). So the answer is the one
+    the numerator already gives, and waiting on him costs the whole drop to whoever is behind him.
     """
     result = rank_by_cost_of_waiting(
         board(
             player("00-0000001", "Long Faller", 100.0),
-            player("00-0000002", "Priced Back", 40.0),
+            player("00-0000002", "Next Back", 40.0),
         ),
         survival(
+            # One row far back at pick 1 and nothing after it: the shape the warehouse leaves for
+            # a player whose whole distribution sits ahead of the picks being decided.
             ("00-0000001", 1, 1.0),
             *at(GAP_STARTS, ("00-0000002", 1.0)),
-            *at(WAIT_TO, ("00-0000002", 0.5)),
+            *at(WAIT_TO, ("00-0000002", 1.0)),
         ),
         picks(),
     )
 
     faller = row_for(result, "Long Faller")
-    assert faller["survival_known"] == False  # noqa: E712 — the flag itself is the claim
-    assert pd.isna(faller["p_survives"])
-    assert pd.isna(faller["cost_of_waiting"])
+    assert faller["survival_known"] == True  # noqa: E712 — the flag itself is the claim
+    assert faller["p_survives"] == 0.0
+    # Certain to be gone, so waiting costs the whole drop to the next back: 100 - 40.
+    assert faller["cost_of_waiting"] == pytest.approx(60.0)
+    assert result["degraded"] is False
+
+
+def test_the_most_valuable_faller_leads_the_one_list():
+    """The regression for #70, stated the way a drafter would have seen it go wrong.
+
+    There is one list, and the best pick on the board is at the top of it. A faller ranked behind
+    every player the model happens to cover is a faller nobody reads, because the screen is cut to
+    fifteen rows and he was 218th.
+    """
+    result = rank_by_cost_of_waiting(
+        board(
+            player("00-0000001", "Long Faller", 100.0),
+            player("00-0000002", "Next Back", 40.0),
+            player("00-0000003", "Priced Receiver", 90.0, position="WR"),
+            player("00-0000004", "Backup Receiver", 30.0, position="WR"),
+        ),
+        survival(
+            ("00-0000001", 1, 1.0),
+            *at(
+                GAP_STARTS,
+                ("00-0000002", 1.0), ("00-0000003", 1.0), ("00-0000004", 1.0),
+            ),
+            *at(
+                WAIT_TO,
+                ("00-0000002", 1.0), ("00-0000003", 0.5), ("00-0000004", 1.0),
+            ),
+        ),
+        picks(),
+    )
+
+    # The faller costs the full 100 - 40; the receiver, half likely to last, costs 90 - 60.
+    assert names(result)[0] == "Long Faller"
+    assert row_for(result, "Long Faller")["cost_of_waiting"] == pytest.approx(60.0)
+    assert row_for(result, "Priced Receiver")["cost_of_waiting"] == pytest.approx(30.0)
+
+
+def test_a_faller_certain_to_be_gone_is_nobody_elses_fallback():
+    """Zero means gone, and a man who is gone is not the man you fall back to.
+
+    Three backs in value order with the faller in the middle, so the claim is about the player
+    *above* him: he must be priced against the third back, because falling back onto somebody who
+    is certainly gone is not falling back at all. This is the half of the semantics a flag on its
+    own cannot state — `p_survives` of 0 has to flow through the expectation, not just the column.
+    """
+    result = rank_by_cost_of_waiting(
+        board(
+            player("00-0000001", "Top Back", 100.0),
+            player("00-0000002", "Long Faller", 80.0),
+            player("00-0000003", "Third Back", 20.0),
+        ),
+        survival(
+            ("00-0000002", 1, 1.0),
+            *at(GAP_STARTS, ("00-0000001", 1.0), ("00-0000003", 1.0)),
+            *at(WAIT_TO, ("00-0000001", 0.0), ("00-0000003", 1.0)),
+        ),
+        picks(),
+    )
+
+    # Expected best available walks up from the bottom: the third back is certain at 20, the
+    # faller is gone so the expectation past him is still 20, and the top back — gone himself —
+    # is priced against that 20 rather than against the faller's 80.
+    assert row_for(result, "Third Back")["cost_of_waiting"] == pytest.approx(0.0)
+    assert row_for(result, "Long Faller")["cost_of_waiting"] == pytest.approx(60.0)
+    assert row_for(result, "Top Back")["cost_of_waiting"] == pytest.approx(80.0)
+
+
+def test_at_the_turn_even_a_player_the_model_never_covered_is_certain_to_last():
+    """An empty gap is certainty for everybody, and that is arithmetic rather than a model.
+
+    Deciding pick 28 and picking again at 29, nobody else selects in between, so there is no
+    hazard for anyone to survive — whether the table has an opinion about him or not. Case 20
+    already pins this for players the frame covers; the two it does not cover are the ones that
+    used to come back `NaN` and sink to the bottom of a list where nothing costs anything.
+    """
+    result = rank_by_cost_of_waiting(
+        board(
+            player("00-0000001", "Priced Back", 90.0),
+            player("00-0000002", "Long Faller", 120.0),
+            player("00-0000003", "Unpriced Rookie", 60.0, position="WR"),
+        ),
+        # Only the first of the three is in the frame at all.
+        survival(*at(29, ("00-0000001", 0.086))),
+        picks(next_pick=28, pick_after_next=29, picks_made=27),
+    )
+
+    assert list(result["candidates"]["p_survives"]) == [1.0, 1.0, 1.0]
+    assert list(result["candidates"]["cost_of_waiting"]) == [0.0, 0.0, 0.0]
+    assert list(result["candidates"]["survival_known"]) == [True, True, True]
+    # Nothing costs anything, so the list falls through to value — with the faller leading it
+    # rather than buried under the one player the table happens to price.
+    assert names(result) == ["Long Faller", "Priced Back", "Unpriced Rookie"]
     assert result["degraded"] is False
 
 


### PR DESCRIPTION
Closes #70

A player with no row at the pick the gap opens on was flagged unpriceable and sorted below every player the model does cover. The warehouse computed a zero for him and then discarded the row for falling under its own 1% floor, so the absence *is* that zero — the same reading the numerator side already takes ("Both mean gone, which is a number, not a gap").

The players it hid were the fallers. Found in a live mock: Jalen Hurts sat available at 2.14 with the second-highest value on the board and ranked **219th of 947**; Brock Purdy at 4.14, 219th. Jahmyr Gibbs, the most valuable player on the board, would have ranked **218th**.

Also makes an empty gap certain for everyone rather than only for players the ratio can be taken for. At the turn the seat picks twice in a row and nobody selects in between, so survival is arithmetic.

## Measured, on the real sleeper board

```
       before                       after
2.14   Gibbs 218, Hurts 219         Gibbs 1, Hurts 3, Purdy 8
3.01   Gibbs 217, Hurts 218         Gibbs 1, Hurts 2, Purdy 3
4.14   Gibbs 218, Hurts 219         Gibbs 1, Hurts 2, Purdy 3
6.14   Gibbs 218, Hurts 219         Gibbs 1, Hurts 2, Purdy 3
```

At 3.01, where the gap to 4.14 is 26 real picks, Gibbs' cost of waiting is 112.9 against 25.8 for the next player. At 2.14 the gap is empty, every cost is 0.00, and the list correctly falls through to value order — which is why Hurts is 3rd there and not 1st.

## One existing test was asserting the bug

`test_a_player_the_table_already_had_gone_gets_no_probability_at_all` asserted this case comes back NaN. Replaced rather than edited, with the reasoning on #70 rather than buried in a commit — it sat directly below `test_a_player_the_table_drops_at_my_pick_is_gone_rather_than_unknown`, which tests the numerator side and warns in its own docstring that reading absence as no-data "would flag the most certain players on the board as the least certain." The suite documented both readings.

Four new cases in its place, and the module docstring's "Three kinds of missing" section corrected to match.