### PR TITLE
feat: sort a missing cost of waiting as no urgency, not as no value

### DIFF
--- a/src/draft/waiting.py
+++ b/src/draft/waiting.py
@@ -248,15 +248,22 @@ def rank_by_cost_of_waiting(
         candidates = candidates.loc[candidates["position"] == position]
 
     # Cost of waiting first, then value, then name. The second key is not only a tiebreak: it is
-    # what ranks a player whose cost cannot be computed, and pandas puts those missing values last
-    # whichever way the first key is sorted, which is exactly where a number nobody has belongs.
-    ranked = candidates[WAITING_COLUMNS].sort_values(
-        ["cost_of_waiting", "points_over_replacement", "player_name"],
+    # what ranks a player whose cost cannot be computed at all.
+    #
+    # A missing cost sorts as *no urgency*, alongside the players whose cost is a computed zero,
+    # rather than below every player who has a number. Nobody's ADP lists him, so nothing in the
+    # market is about to take him, and "he will keep" is the honest reading of that silence;
+    # `na_position="last"` read it instead as "worth less than everyone", which is a claim about
+    # value that nothing supports. The key is derived and thrown away — the column he carries
+    # stays NaN, because this places him and does not price him.
+    ranked = candidates.assign(
+        _urgency=candidates["cost_of_waiting"].fillna(0.0)
+    ).sort_values(
+        ["_urgency", "points_over_replacement", "player_name"],
         ascending=[False, False, True],
-        na_position="last",
     )
     return {
-        "candidates": ranked.reset_index(drop=True),
+        "candidates": ranked[WAITING_COLUMNS].reset_index(drop=True),
         "degraded": degraded,
         "covers_to": covers_to,
     }

--- a/tests/test_draft_render.py
+++ b/tests/test_draft_render.py
@@ -316,6 +316,32 @@ def test_a_candidate_with_no_survival_data_shows_gaps_rather_than_numbers():
     assert "Unpriced Rookie" in row
 
 
+def test_a_candidate_with_no_survival_data_reads_as_a_gap_where_it_now_sits():
+    """#71 places him among the priced rows, so the gap has to be legible where he lands.
+
+    Below the bottom of the list he was a footnote nobody reached. Between two rows that carry
+    numbers he is a row a drafter could read as a zero, and a zero cost of waiting is a different
+    pick from an unknown one.
+    """
+    out = render_board(
+        candidates(
+            {"player_id": "00-0000001", "player_name": "Urgent Back", "cost_of_waiting": 30.0},
+            {"player_id": "00-0000002", "player_name": "Unpriced Rookie", "p_survives": None,
+             "cost_of_waiting": None, "survival_known": False},
+            {"player_id": "00-0000003", "player_name": "Cheap Back", "p_survives": 1.0,
+             "cost_of_waiting": 0.0},
+        ),
+        ingested(),
+        LEAGUE,
+    )
+
+    # Both of his numbers are absent, and neither is spelled as one.
+    assert line_naming(out, "Unpriced Rookie").split()[-2:] == ["-", "-"]
+    # The rows either side of him do carry numbers, including a genuine zero he must not look like.
+    assert line_naming(out, "Urgent Back").split()[-2:] == ["35%", "30.0"]
+    assert line_naming(out, "Cheap Back").split()[-2:] == ["100%", "0.0"]
+
+
 def test_a_degraded_result_says_it_has_fallen_back_to_value_ranking():
     out = render_board(
         candidates({"player_name": "Best Left", "p_survives": None, "cost_of_waiting": None,

--- a/tests/test_draft_waiting.py
+++ b/tests/test_draft_waiting.py
@@ -239,8 +239,12 @@ def test_a_player_with_no_survival_data_is_ranked_by_value_and_flagged():
     assert rookie["survival_known"] == False  # noqa: E712 — the flag itself is the claim
     assert pd.isna(rookie["p_survives"])
     assert pd.isna(rookie["cost_of_waiting"])
-    # Ranked by value: after everyone who has a cost of waiting, and among themselves by value.
-    assert names(result)[-2:] == ["Unpriced Rookie", "Unpriced Camp Body"]
+    # Ranked by value, among everyone whose waiting costs nothing rather than beneath the lot of
+    # them: the rookie outvalues the mid back, who is certain to last and therefore also free to
+    # wait on, so he sorts above him. Only the priced back, who costs something, is ahead of both.
+    assert names(result) == [
+        "Priced Back", "Unpriced Rookie", "Mid Back", "Unpriced Camp Body",
+    ]
 
     # The strong form of "never treated as a number": a missing probability is not silently a 0 or
     # a 1, so the players who *do* have one price identically whether or not he is on the board.
@@ -479,6 +483,85 @@ def test_at_the_turn_even_a_player_the_model_never_covered_is_certain_to_last():
     # rather than buried under the one player the table happens to price.
     assert names(result) == ["Long Faller", "Priced Back", "Unpriced Rookie"]
     assert result["degraded"] is False
+
+
+# 71. A missing cost of waiting is an unknown urgency, not a known lack of value. The board carries
+#     728 players with no ADP at all, and `na_position="last"` sorted every one of them below every
+#     player the survival model happens to price.
+def test_a_player_with_no_cost_sorts_by_value_rather_than_below_everyone():
+    """No ADP source lists him, so nothing in the market is about to take him.
+
+    That silence is a statement about *urgency* — wait on him, he will keep — and not a statement
+    about worth. Sorting it as "less than everybody" quietly turned the one into the other.
+    """
+    result = rank_by_cost_of_waiting(
+        board(
+            player("00-0000001", "Priced Back", 90.0),
+            player("00-0000002", "Unpriced Rookie", 200.0, position="WR"),
+        ),
+        survival(
+            *at(GAP_STARTS, ("00-0000001", 1.0)),
+            *at(WAIT_TO, ("00-0000001", 1.0)),
+        ),
+        picks(),
+    )
+
+    # Both are free to wait on. Between two players who cost nothing, value decides.
+    assert names(result) == ["Unpriced Rookie", "Priced Back"]
+
+    # Placed, not priced: the row still says it has no number, because it has none.
+    rookie = row_for(result, "Unpriced Rookie")
+    assert rookie["survival_known"] == False  # noqa: E712 — the flag itself is the claim
+    assert pd.isna(rookie["p_survives"])
+    assert pd.isna(rookie["cost_of_waiting"])
+
+
+def test_an_unknown_urgency_never_outranks_a_known_one():
+    """The boundary that keeps this from swallowing the faller fix.
+
+    A player who costs something to pass on is ahead of a player who costs nothing, however much
+    more valuable the second one is. Otherwise a board with no ADP coverage would bury exactly the
+    players cost of waiting exists to surface.
+    """
+    result = rank_by_cost_of_waiting(
+        board(
+            player("00-0000001", "Urgent Back", 40.0),
+            player("00-0000002", "Cheap Back", 10.0),
+            player("00-0000003", "Unpriced Star", 200.0, position="WR"),
+        ),
+        survival(
+            *at(GAP_STARTS, ("00-0000001", 1.0), ("00-0000002", 1.0)),
+            *at(WAIT_TO, ("00-0000001", 0.0), ("00-0000002", 1.0)),
+        ),
+        picks(),
+    )
+
+    # The urgent back costs 40 - 10 to pass on; the star costs nothing anybody can name.
+    assert names(result) == ["Urgent Back", "Unpriced Star", "Cheap Back"]
+    assert row_for(result, "Urgent Back")["cost_of_waiting"] == pytest.approx(30.0)
+
+
+def test_players_without_survival_data_are_ordered_by_value_then_name():
+    """Among themselves, the same two keys as everybody else, in the same order."""
+    result = rank_by_cost_of_waiting(
+        board(
+            player("00-0000001", "Anchor Back", 70.0),
+            player("00-0000002", "Unpriced Top", 100.0, position="TE"),
+            player("00-0000003", "Unpriced Zeta", 50.0, position="WR"),
+            player("00-0000004", "Unpriced Alpha", 50.0, position="WR"),
+        ),
+        survival(
+            *at(GAP_STARTS, ("00-0000001", 1.0)),
+            *at(WAIT_TO, ("00-0000001", 1.0)),
+        ),
+        picks(),
+    )
+
+    # Everything costs nothing, so this is value order throughout, with the two equal receivers
+    # broken alphabetically the way every other tie on this board is.
+    assert names(result) == [
+        "Unpriced Top", "Anchor Back", "Unpriced Alpha", "Unpriced Zeta",
+    ]
 
 
 def test_a_finished_draft_degrades_rather_than_raising():


### PR DESCRIPTION
Closes #71 · stacked on #73

728 of the 972 players on the sleeper board carry no `consensus_adp`, so none of them can be given a survival probability. `na_position="last"` on the primary sort key put every one of them below every player the model does price — 730 of 947 available at pick 28, in a block the 15-row screen never reaches — which reads an unknown urgency as a known lack of worth.

Nobody's ADP listing him is itself a statement: nothing in the market is about to take him, so waiting costs nothing and he belongs among the players whose cost is a computed zero, where the value tiebreak can place him. The sort key is derived and thrown away; the row still carries NaN and `render` still prints a gap.

## Measured

No ADP-less player displaces anyone in the top 15 at any of seat 1's turns today, so this is a safety net rather than a visible change — the same structural fault as #70 with a less dramatic population.

## One existing assertion changes

`test_a_player_with_no_survival_data_is_ranked_by_value_and_flagged` asserted both unpriced players sit at the very bottom. The fixture's `Mid Back` is certain to last, so his cost is 0.0, he ties with them and loses the value tiebreak to the 200-PoR rookie. Expected order becomes `Priced Back, Unpriced Rookie, Mid Back, Unpriced Camp Body`.

The test's name stays true — still ranked by value, still flagged — and its second half, which pins that a missing probability never enters anyone else's fallback arithmetic, is untouched.